### PR TITLE
Bug fix

### DIFF
--- a/rgmanager/src/resources/nfsclient.sh
+++ b/rgmanager/src/resources/nfsclient.sh
@@ -271,6 +271,8 @@ verify_path()
 		return $OCF_ERR_ARGS
 	fi
 
+	OCF_RESKEY_path="${OCF_RESKEY_path%/}"
+
 	[ -d "$OCF_RESKEY_path" ] && return 0
 
 	ocf_log err "$OCF_RESKEY_path is not a directory"


### PR DESCRIPTION
The exportfs command and/or rpc.mountd trim the trailing slashes
when reporting things in /var/lib/nfs/etab, causing mismatch problems
for the nfsclient resource agent.

Resolves: rhbz#592624

Signed-off-by: Lon Hohberger lhh@redhat.com
