### PR TITLE
fix for Bugz. 2600

### DIFF
--- a/tools/ocft/ocft.in
+++ b/tools/ocft/ocft.in
@@ -75,8 +75,8 @@ explode()
       if (i%2 == 0)
         print $i;
       else {
-        split($i, str, /[[:blank:]]+/);
-        for (j=0; j<length(str); j++) {
+        len = split($i, str, /[ \t]+/);
+        for (j=1; j<=len; j++) {
           sb = sub(/#.*/, "", str[j]);
           if (str[j] != "")
             print str[j];


### PR DESCRIPTION
Actually that explode expression only worked by accident anways.

Awk arrays are 1 based, so the for loop should have read
for (j=1; j<=length(str);j++) ...
It worked with (j=0; j<length(str); j++) only because
referencing the previously non-existing [0] index instantiates it,
increasing length(str) by one.

length(array) is not supported in all incarnations of awk.
Neither is [[:blank:]].
Fortunately split() returns the number of elements it created.
And [[:blank:]] can be open coded easily enough, too.
