### PR TITLE
Bug in exportfs (variable not expanded)

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -217,7 +217,7 @@ exportfs_start ()
 	fi
 	if [ `echo ${OPTIONS} | grep fsid` ]; then
 		#replace fsid provided in options list with one provided in fsid param.
-		OPTIONS=`echo ${OPTIONS} | sed 's/fsid=[0-9]\+/fsid=${OCF_RESKEY_fsid}/g'`
+		OPTIONS=`echo ${OPTIONS} | sed "s/fsid=[0-9]\+/fsid=${OCF_RESKEY_fsid}/g"`
 	else
 		#tack the fsid option onto our options list.
 		OPTIONS="${OPTIONS}${OPTPREFIX}fsid=${OCF_RESKEY_fsid}"


### PR DESCRIPTION
Hi,
I think i stumbled upon a small bug in the exportfs RA today. I think the line that makes sure fsid is assigned the value from the CRM config even if the "options" line also contains fsid should use double instead of single quotes. Current version fails to export file system in this case, because the ${OCF_RESKEY_fsid} is not expanded.
Best regards,
Joerg
