### PR TITLE
Fix use of non-existant $OCF_RUNNING return code; alternatively we could introduce that as legal alias, as in OCF_RUNNING=$OCF_SUCCESS

### DIFF
--- a/heartbeat/AoEtarget
+++ b/heartbeat/AoEtarget
@@ -166,7 +166,7 @@ AoEtarget_monitor() {
 	# stale pid file, assume something went wrong
 	return $OCF_ERR_GENERIC
     fi
-    return $OCF_RUNNING
+    return $OCF_SUCCESS
 }
 
 AoEtarget_validate() {

--- a/heartbeat/SphinxSearchDaemon
+++ b/heartbeat/SphinxSearchDaemon
@@ -169,7 +169,7 @@ searchd_monitor() {
     fi 
     if searchd_status ; then 
 	if searchd_check ; then
-	    return $OCF_RUNNING
+	    return $OCF_SUCCESS
 	else	    
 	    return $OCF_ERR_GENERIC
 	fi

--- a/heartbeat/anything
+++ b/heartbeat/anything
@@ -59,7 +59,7 @@ anything_status() {
 	then
 		if pid=`getpid $pidfile` && [ "$pid" ] && kill -s 0 $pid
 		then
-			return $OCF_RUNNING
+			return $OCF_SUCCESS
 		else
 			# pidfile w/o process means the process died
 			return $OCF_ERR_GENERIC

--- a/rgmanager/src/resources/drbd.sh
+++ b/rgmanager/src/resources/drbd.sh
@@ -68,7 +68,7 @@ drbd_status() {
     role=$(drbdadm role $OCF_RESKEY_resource)
     case $role in
 	Primary/*)
-	    return $OCF_RUNNING
+	    return $OCF_SUCCESS
 	    ;;
 	Secondary/*)
 	    return $OCF_NOT_RUNNING


### PR DESCRIPTION
There is no OCF_RUNNING.
return $OCF_RUNNING looks good, and will be hard to spot when reviewing
resource agents, but will typically expand to "return" (because
OCF_RUNNING is undefined), and thus return the exit code of the previous
command.

This may or may not be the indented value 0.
