### PR TITLE
Low: doc: recover an accidentally missing file

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -22,4 +22,6 @@ SUBDIRS			= man
 
 MAINTAINERCLEANFILES    = Makefile.in
 
+EXTRA_DIST 		= $(doc_DATA)
+
 doc_DATA		= README.webapps


### PR DESCRIPTION
doc/README.webapps has been missing for the dist target
since the commit 361fec2ba8da328b8181945e654f27a3b6a453b1
which would cause a RPM build error.
