### PR TITLE
Fix: DATADIR was being fix value in ocf-tester.in file.

### DIFF
--- a/tools/ocf-tester.in
+++ b/tools/ocf-tester.in
@@ -27,6 +27,7 @@
 
 LRMD=@libdir@/heartbeat/lrmd
 LRMADMIN=@sbindir@/lrmadmin
+DATADIR=@datadir@
 METADATA_LINT="xmllint --noout --valid -"
 
 # set some common meta attributes, which are expected to be
@@ -211,7 +212,7 @@ test_metadata() {
     if [ $verbose -ne 0 ]; then
     	echo $msg
     fi
-    bash $agent $action | (cd /usr/share/resource-agents && $METADATA_LINT)
+    bash $agent $action | (cd $DATADIR/resource-agents && $METADATA_LINT)
     rc=$?
     #echo rc: $rc
     return $rc


### PR DESCRIPTION
When prefix was changed and compiled, the ocf-tester command became an error.
This problem is the fixed value of '/usr/share/resource-agents' was used.
Please fix it.
