### PR TITLE
I have to make this folder to have apache running in pacemaker with SSL....

### DIFF
--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -173,6 +173,8 @@ start_apache() {
     return $OCF_SUCCESS
   fi
   validate_default_config || return $OCF_ERR_CONFIGURED
+  # https://bugs.launchpad.net/ubuntu/+source/apache2/+bug/603211
+  [ -d /var/run/apache2 ] || mkdir /var/run/apache2
   ocf_run $HTTPD $HTTPDOPTS $OPTIONS -f $CONFIGFILE
   tries=0
   while :  # wait until the user set timeout


### PR DESCRIPTION
...

Ubuntu proposes to use apache2ctl instead of apache2 executable.
