### PR TITLE
Medium: lxc: fix to work with lxc-0.7.5

### DIFF
--- a/heartbeat/lxc
+++ b/heartbeat/lxc
@@ -239,7 +239,8 @@ LXC_stop() {
 }
 
 LXC_status() {
-	S=`lxc-info -n ${OCF_RESKEY_container}`
+	# run lxc-info with -s option for LXC-0.7.5 or later, otherwise not
+	S=`lxc-info -s -n ${OCF_RESKEY_container} 2>/dev/null || lxc-info -n ${OCF_RESKEY_container} 2>/dev/null`
 	ocf_log debug "State of ${OCF_RESKEY_container}: $S"
 	if [[ "${S##* }" = "RUNNING" ]] ; then 
 		return $OCF_SUCCESS


### PR DESCRIPTION
Fix lxc-status function to work with lxc-0.7.5.  lxc-status uses lxc-info command to get container status ,  but  output of lxc-info has changed at the version lxc-0.7.5.  This patch makes lxc-status work with not only lxc-0.7.5 but also the previous version of lxc package.
