### PR TITLE
Medium: lxc: fix LXC_status to work with lxc-0.7.5 or later

### DIFF
--- a/heartbeat/lxc
+++ b/heartbeat/lxc
@@ -239,7 +239,10 @@ LXC_stop() {
 }
 
 LXC_status() {
-	S=`lxc-info -n ${OCF_RESKEY_container}`
+	# run lxc-info with -s option for LXC-0.7.5 or later
+	local lxc_info_opt="-s"
+	ocf_version_cmp "`lxc-version | cut -d' ' -f 3`" 0.7.5 && lxc_info_opt=""
+	S=`lxc-info $lxc_info_opt -n ${OCF_RESKEY_container}`
 	ocf_log debug "State of ${OCF_RESKEY_container}: $S"
 	if [[ "${S##* }" = "RUNNING" ]] ; then 
 		return $OCF_SUCCESS


### PR DESCRIPTION
This patch is a revised patch for lxc ra, accepting fghaas's comment.

This patch fixes lxc-status function to work with lxc-0.7.5.  lxc-status uses lxc-info command to get container status, but output of lxc-info has changed from lxc-0.7.5.  This patch makes lxc-status work with not only lxc-0.7.5 but also the previous version of lxc.
