### PR TITLE
Xen HVM ACPI shutdown

### DIFF
--- a/heartbeat/Xen
+++ b/heartbeat/Xen
@@ -41,6 +41,7 @@ usage() {
 
 
 : ${OCF_RESKEY_xmfile=/etc/xen/vm/MyDomU}
+: ${OCF_RESKEY_shutdown_acpi=0}
 : ${OCF_RESKEY_allow_mem_management=0}
 : ${OCF_RESKEY_reserved_Dom0_memory=512}
 
@@ -106,6 +107,14 @@ Setting this value to 0 forces an immediate destroy.
 </longdesc>
 <shortdesc lang="en">Shutdown escalation timeout</shortdesc>
 <content type="string" default="" />
+</parameter>
+<parameter name="shutdown_acpi" unique="0" required="0">
+<longdesc lang="en">
+In HVM without PV driver installed it is possible to handle a graceful
+shutdow by simulate a power button event.
+</longdesc>
+<shortdesc lang="en">Simulate power button event on shutdown</shortdesc>
+<content type="boolean" default="0" />
 </parameter>
 <parameter name="allow_mem_management" unique="0" required="0">
 <longdesc lang="en">
@@ -303,7 +312,11 @@ xen_domain_stop() {
 
     if [ "$timeout" -gt 0 ]; then
       ocf_log info "Xen domain $dom will be stopped (timeout: ${timeout}s)"
-      xm shutdown $dom
+      if ocf_is_true "${OCF_RESKEY_shutdown_acpi}"; then
+        xm trigger $dom power
+      else
+        xm shutdown $dom
+      fi
           
       while Xen_Status $dom && [ "$timeout" -gt 0 ]; do
         ocf_log debug "$dom still not stopped. Waiting..."


### PR DESCRIPTION
Hi there,

It's long time that Xen support the graceful shutdown for HVM even without PV drivers. It use ACPI features and the Guest should be configured to manage it (http://old-list-archives.xen.org/archives/html/xen-devel/2009-04/msg00065.html).

This simple patch allow you to choose the ACPI method instead of the standard "shutdown".
The standard shutdown command without PV drivers cause a brutal power off with potential filesystem corruptions.

Regards,
Ettore Simone
