### PR TITLE
IPaddr2: add support for same ip/netmask on different interfaces

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -400,17 +400,23 @@ ip_init() {
 }
 
 #
-#	Find out which interface serves the given IP address
-#	The argument is an IP address, and its output
-#	is an interface name (e.g., "eth0").
+#	Find out which interfaces serve the given IP address and netmask.
+#	The arguments are an IP address and a netmask.
+#	Its output are interface names devided by spaces (e.g., "eth0 eth1").
 #
 find_interface() {
+	local ipaddr="$1"
+	local netmask="$2"
+
 	#
 	# List interfaces but exclude FreeS/WAN ipsecN virtual interfaces
 	#
-	local iface=`$IP2UTIL -o -f inet addr show | grep "\ $OCF_RESKEY_ip/$NETMASK" \
-		| cut -d ' ' -f2 | grep -v '^ipsec[0-9][0-9]*$'`
-	echo $iface
+	local iface="`$IP2UTIL -o -f inet addr show \
+		| grep "\ $ipaddr/$netmask" \
+		| cut -d ' ' -f2 \
+		| grep -v '^ipsec[0-9][0-9]*$'`"
+
+	echo "$iface"
 	return 0
 }
 
@@ -560,7 +566,7 @@ run_send_ib_arp() {
 	fi
 }
 
-# Do we already serve this IP address?
+# Do we already serve this IP address on the given $NIC?
 #
 # returns:
 # ok = served (for CIP: + hash bucket)
@@ -574,7 +580,7 @@ ip_served() {
 		return 0
 	fi
 
-	cur_nic="`find_interface $OCF_RESKEY_ip`"
+	cur_nic="`find_interface $OCF_RESKEY_ip $NETMASK`"
 
 	if [ -z "$cur_nic" ]; then
 		echo "no"
@@ -584,7 +590,8 @@ ip_served() {
 	if [ -z "$IP_CIP" ]; then
 		for i in $cur_nic; do
 			case $i in
-			lo*)	if ocf_is_true ${OCF_RESKEY_lvs_support}; then
+			lo*)
+				if ocf_is_true ${OCF_RESKEY_lvs_support}; then
 					echo "no"
 					return 0
 				fi
@@ -641,7 +648,7 @@ ip_start() {
 	fi
 
 	#
-	#	Do we already service this IP address?
+	#	Do we already service this IP address on $NIC?
 	#
 	local ip_status=`ip_served`
 
@@ -669,7 +676,7 @@ ip_start() {
 	
 	if [ "$ip_status" = "no" ]; then
 		if ocf_is_true ${OCF_RESKEY_lvs_support}; then
-			for i in `find_interface $OCF_RESKEY_ip`; do
+			for i in `find_interface $OCF_RESKEY_ip $NETMASK`; do
 				case $i in
 				lo*)
 					remove_conflicting_loopback $OCF_RESKEY_ip 32 255.255.255.255 lo


### PR DESCRIPTION
there are some (rare) use cases where you need to attach the same IP address on different interfaces ... later on that could be handled by policy routing

at the moment find_interface() finds all interfaces with the same IP/netmask,
the second IPaddr2 resource would not attach its IP since ip_served() is already "ok" ... afterwards when using ip_stop(), it cannot delete it (error)

there was an ugly but possible workaround by changing the netmask on each resource having the same IP (/32, /31, /30), but that leads into problems on the main routing table ...

with this patch ip_served() would say "ok" only if the specified or found nic serves the wanted IP

however the unique constraint on "ip" was NOT removed ... it is just a warning and might be still ok to check for false configuration since this use case is a rare exception?
