### PR TITLE
Med: named: fix bashism - do not rely on $EUID to exist

### DIFF
--- a/heartbeat/named
+++ b/heartbeat/named
@@ -424,7 +424,7 @@ then
     esac
 fi
 
-if [ "$EUID" != "0" ]; then 
+if [ `id -u` -ne 0 ]; then
     ocf_log err "$0 must be run as root"
     exit $OCF_ERR_GENERIC
 fi


### PR DESCRIPTION
$EUID is a bashism. It's not available on Debian/Ubuntu where the
default /bin/sh links to /bin/dash.
