### PR TITLE
slapd resource agent

### DIFF
--- a/heartbeat/slapd
+++ b/heartbeat/slapd
@@ -492,6 +492,13 @@ slapd_validate_all()
     return $OCF_ERR_INSTALLED
   fi
 
+  pid_dir=`dirname "$pid_file"`
+  if [ ! -d "$pid_dir" ]; then
+    mkdir -p "$pid_dir"
+    chown -R "$user" "$pid_dir"
+    chgrp -R "$group" "$pid_dir"
+  fi
+
   return $OCF_SUCCESS
 }
 


### PR DESCRIPTION
Added check for pid file directory and create if missing.
In Ubuntu 10.04 /var/run/slapd doesn't exist.  The slapd init script checks for and creates if missing this directory.  This RA does not do this check so slapd fails to start due to missing directory
