### PR TITLE
Added allowed_initiators configuration parameter to iSCSILogicalUnit in lio mode.

### DIFF
--- a/heartbeat/iSCSILogicalUnit
+++ b/heartbeat/iSCSILogicalUnit
@@ -423,9 +423,10 @@ iSCSILogicalUnit_validate() {
 	iet)
 	    # IET does not support setting the vendor and product ID
 	    # (it always uses "IET" and "VIRTUAL-DISK")
-	    unsupported_params="vendor_id product_id"
+	    unsupported_params="vendor_id product_id allowed_initiators"
 	    ;;
 	tgt)
+		unsupported_params="allowed_initiators"
 	    ;;
 	lio)
 	    unsupported_params="scsi_id vendor_id product_id"


### PR DESCRIPTION
When using iSCSITarget with LIO and allowed_initiator option, you have to create a nodeACL
for every initiator and logical unit.

I added also an allowed_initiator configuration parameter to iSCSILogicalUnit, to be able to define
initiators, allowed to connect to this LUN.

Otherwise initiators cannot connect to any LUN, if iSCSITarget does not run in demo mode/permissive mode.
