### PR TITLE
Medium: ldirectord: precedence error with perl v5.8.8 in IPv6 code

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -2458,7 +2458,7 @@ sub get_real_service_str
 	my ($v) = (@_);
 
 	if ($v->{"protocol"} eq "fwm") {
-		return &get_virtual($v) . " "  . $v->{protocol} . ($v->{addressfamily} == AF_INET6 ? "6" : "");
+		return &get_virtual($v) . " "  . $v->{protocol} . (($v->{addressfamily} == AF_INET6) ? "6" : "");
 	}
 	else {
 		return &get_virtual($v) . " "  . $v->{protocol};
@@ -4825,7 +4825,7 @@ sub get_virtual_id_str
 	my ($v) = (@_);
 
 	if ($v->{"protocol"} eq "fwm") {
-		return $v->{"protocol"} . ($v->{addressfamily} == AF_INET6?"6":"") . ":" .  &get_virtual($v);
+		return $v->{"protocol"} . (($v->{addressfamily} == AF_INET6)?"6":"") . ":" .  &get_virtual($v);
 	}
 	else {
 		return $v->{"protocol"} . ":" .  &get_virtual($v);


### PR DESCRIPTION
ldirectord in v3.9.2 does not work on CentOS 5 / RHEL5 with a numerous number of syntax errors:

```
[root@node1 ~]# /usr/sbin/ldirectord status 
Possible unintended interpolation of @real_checked in string at /usr/sbin/ldirectord line 2461.
Possible unintended interpolation of @real_checked in string at /usr/sbin/ldirectord line 2461.
(snip)
/usr/sbin/ldirectord has too many errors.
```

See below for details of the cause of this issue:
https://github.com/ClusterLabs/resource-agents/commit/829aed7b962e1e90f4f5e43b03373e9aa93d4032

This patch will fix a similar code which was introduced after the fix above:
https://github.com/ClusterLabs/resource-agents/commit/d8f6c5d8cab26df8cbc99830c62e8f97ec653a1c

v3.9.1 or later should be affected.

Thanks to yosuke takadate for reporting this issue.
