### PR TITLE
Med: VirtualDomain: honor virsh "in shutdown" state

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -227,11 +227,12 @@ VirtualDomain_Status() {
 		ocf_log debug "Virtual domain $DOMAIN_NAME is currently $status."
 	        rc=$OCF_NOT_RUNNING
 	        ;;
-	    running|paused|idle|blocked)
+	    running|paused|idle|blocked|"in shutdown")
 		# running: domain is currently actively consuming cycles
 		# paused: domain is paused (suspended)
 		# idle: domain is running but idle
 		# blocked: synonym for idle used by legacy Xen versions
+		# in shutdown: the domain is in process of shutting down, but has not completely shutdown or crashed.
 		ocf_log debug "Virtual domain $DOMAIN_NAME is currently $status."
 	        rc=$OCF_SUCCESS
 	        ;;


### PR DESCRIPTION
Using libvirt 0.9.8 / qemu 1.0 / kvm from kernel 3.2.0,
"virsh list" briefly shows the virtual maschine in a
"in shutdown" state during a regular "virsh shutdown"
operation:
##  Id Name                 State

  5 testvm1              running
  6 testvm2              running

  ...
  5 testvm1              running
  5 testvm1              running
  ...
  5 testvm1              in shutdown
  5 testvm1              in shutdown
  ...
- testvm1              shut off
  - testvm1              shut off
      ...

The VirtualDomain resource agent does not recognize this
state and thus issues a "virsh destroy" command.

This patch correctly handles "in shutdown" as a "this virtual
machine is still running" state.

See also: libvirt's tools/virsh.c:
static const char \* vshDomainStateToString(int state)

PS: in the virsh manpage, there is a reference to a "dying" state looks like the "in shutdown" state. most probably there is something messed up :)

http://libvirt.org/git/?p=libvirt.git;a=blob;f=tools/virsh.c;h=dd9292a1f08391146e4a8588042056cd55453e69;hb=HEAD#l19109 vs. 
http://libvirt.org/git/?p=libvirt.git;a=blob;f=tools/virsh.pod;h=ef7171702a49cce94999fbe7753047bb5eca40af;hb=HEAD#l371 vs.
http://docs.oracle.com/cd/E19082-01/819-2240/virsh-1m/index.html (as an example from a well known distribution)
