### PR TITLE
Conntrackd: Please accept the following two fixes

### DIFF
--- a/heartbeat/conntrackd
+++ b/heartbeat/conntrackd
@@ -208,7 +208,6 @@ conntrackd_validate_all() {
         meta_expect master-node-max = 1
         meta_expect master-max = 1
         meta_expect clone-node-max = 1
-        meta_expect clone-max = 2
 	
 	return $OCF_SUCCESS
 }


### PR DESCRIPTION
Hi,

I fixed the usage of the "conntrackd" parameter, there was a a parameter named "binary" used internally so a user-defined value for the propagated "conntrackd" parameter was always ignored and a predefined default value was used.

Second fix removes the check for a maximum of two allowed instances, conntrackd can runs fine with more than one slave instances connected.

Cheers,
Andreas
