### PR TITLE
Addition to rotate of console log.

### DIFF
--- a/heartbeat/jboss
+++ b/heartbeat/jboss
@@ -135,7 +135,7 @@ start_jboss()
 		if [ $? = 0 ]; then
 			ocf_log debug "Rotate console log succeeded."
 		else
-			ocf_log warn "Rotate console log failed. Starting tomcat without console log rotation."
+			ocf_log warn "Rotate console log failed. Starting jboss without console log rotation."
 		fi
 	fi
 


### PR DESCRIPTION
This patch enables a rotation of the console log.

For example, a result is output by console log when I acquire GC log.
Therefore I want to enable rotate because log is easy to be enlarged.
