### PR TITLE
SAPDatabase: changed default of monitoring for one database

### DIFF
--- a/heartbeat/sapdb.sh
+++ b/heartbeat/sapdb.sh
@@ -327,7 +327,7 @@ then
     DB6) db2sid="db2`echo $SID | tr '[:upper:]' '[:lower:]'`"
          export OCF_RESKEY_MONITOR_SERVICES="${SID}|${db2sid}"
          ;;
-    SYB) export OCF_RESKEY_MONITOR_SERVICES="Server|Database"
+    SYB) export OCF_RESKEY_MONITOR_SERVICES="Server"
          ;;
     HDB) export OCF_RESKEY_MONITOR_SERVICES="hdbindexserver"
          ;;


### PR DESCRIPTION
After discussion with developers at SAP:
Change default component for monitoring of sybase ASE via sapdbctrl from "Sserver|Database" to "Server".

Please merge to upstream.
Regards
Alex
