### PR TITLE
remove a status file only when OCF_CHECK_LEVEL is set as 20 to prevent the unexpected timeout

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -755,7 +755,7 @@ Filesystem_stop()
 	else
 		# Wipe the status file, but continue with a warning if
 		# removal fails -- the file system might be read only
-		if [ -f "$STATUSFILE" ]; then
+		if [ $OCF_CHECK_LEVEL -eq 20 ]; then
 			rm -f ${STATUSFILE}
 			if [ $? -ne 0 ]; then
 				ocf_log warn "Failed to remove status file ${STATUSFILE}."


### PR DESCRIPTION
http://lists.linux-ha.org/pipermail/linux-ha-dev/2012-May/019386.html
