### PR TITLE
Low: postfix: issue an error if multiple data directories are set

### DIFF
--- a/heartbeat/postfix
+++ b/heartbeat/postfix
@@ -96,8 +96,8 @@ END
 }
 
 postfix_running() {
-    local loglevel 
-    loglevel=${1:-err} 
+    local loglevel
+    loglevel=${1:-err}
 
     # run Postfix status if available
     if ocf_is_true $status_support; then
@@ -209,10 +209,10 @@ postfix_monitor()
 {
     local status_loglevel="err"
 
-    # Set loglevel to info during probe 
-    if ocf_is_probe; then 
-        status_loglevel="info" 
-    fi 
+    # Set loglevel to info during probe
+    if ocf_is_probe; then
+        status_loglevel="info"
+    fi
 
     if postfix_running $status_loglevel; then
         return $OCF_SUCCESS


### PR DESCRIPTION
Low: postfix: issue an error if multiple data directories are set
Low: postfix: cleanup trailing whitespaces
