### PR TITLE
The correction that bind_dn is not usable

### DIFF
--- a/heartbeat/slapd
+++ b/heartbeat/slapd
@@ -431,7 +431,7 @@ slapd_monitor()
   options="-LLL -s base -x"
 
   if [ -n "$bind_dn" ]; then
-    options="$options -D '$bind_dn' -w '$password'"
+    options="$options -D $bind_dn -w $password"
   fi
 
   [ -z "$1" ] && err_option=""


### PR DESCRIPTION
As a result of having confirmed it in jeroen, I tested it, and I carried out this correction.
The answers from jeroen are as follows.

---

I don't use the bind_dn directive, so I haven't tested this in an actual pacemaker environment.
I probably put the quotes there in case somebody uses a dn, or password containing spaces.
That might lead to problems?
You could test if the same problem arises when using double quotes, the ldapsearch man pages contains an example that uses double quotes 
http://www.openldap.org/software/man.cgi?query=ldapsearch&apropos=0&sektion=0&manpath=OpenLDAP+2.0-Release&format=html.

Perhaps an environment variable exists with which you can specify the binddn and the password?

---

I confirmed that I worked without a problem when a password contained space and $.
