### PR TITLE
mysql RA improvements

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -551,7 +551,7 @@ check_slave() {
         if ocf_is_true $OCF_RESKEY_evict_outdated_slaves; then
             # We're supposed to bail out if we lag too far
             # behind. Let's check our lag.
-            if [ $secs_behind = NULL ] || [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
+            if [ "$secs_behind" = "NULL" ] || [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
                 ocf_log err "MySQL Slave is $secs_behind seconds behind master (allowed maximum: $OCF_RESKEY_max_slave_lag)."
                 ocf_log err "See $tmpfile for details"
 
@@ -574,7 +574,7 @@ check_slave() {
         fi
 
         # is the slave ok to have a VIP on it
-        if [ $secs_behind = NULL ] || [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
+        if [ "$secs_behind" = "NULL" ] || [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
             set_reader_attr 0
         else
             set_reader_attr 1


### PR DESCRIPTION
This patch
- fixes an error that comes up when replication is not working: `$secs_behind` is `NULL`, which causes an error in numerical comparisons and leads `if` to choose the wrong branch (thus leaving the `reader` attribute on)
- <del>adds a `writable` attribute for the master</del>
- fixes a line indent in `check_slave` (sorry, I just _had_ to do it :-/)
