### PR TITLE
Medium: slapd: Gracefully handle config check during probe

### DIFF
--- a/heartbeat/slapd
+++ b/heartbeat/slapd
@@ -424,8 +424,12 @@ slapd_monitor()
     done
 
   else
-    ocf_log err "slapd configuration '$config' does not exist."
-    return $OCF_ERR_INSTALLED
+    if ocf_is_probe; then
+      ocf_log info "slapd configuration '$config' does not exist during probe."
+    else
+      ocf_log err "slapd configuration '$config' does not exist."
+      return $OCF_ERR_INSTALLED
+    fi
   fi
 
   options="-LLL -s base -x"
@@ -473,8 +477,12 @@ slapd_validate_all()
 		's/^pidfile[[:space:]]\+\(.\+\)/\1/p' \
 		"$config" 2>/dev/null`
     else
-      ocf_log err "slapd configuration '$config' does not exist."
-      return $OCF_ERR_INSTALLED
+      if ocf_is_probe; then
+        ocf_log info "slapd configuration '$config' does not exist during probe."
+      else
+        ocf_log err "slapd configuration '$config' does not exist."
+        return $OCF_ERR_INSTALLED
+      fi
     fi
   fi
 


### PR DESCRIPTION
Do not exit with OCF_ERR_INSTALLED if the slapd configuration
file or directory, which may lie on a shared storage,
does not exist during probe
