### PR TITLE
Tomcat: Proposal patch of new Tomcat-RA.

### DIFF
--- a/heartbeat/tomcat
+++ b/heartbeat/tomcat
@@ -471,20 +471,6 @@ validate_all_tomcat()
 		misconfigured=1
 	fi
 
-	if [ "$RESOURCE_TOMCAT_USER" != RUNASIS ]; then
-		su - -s /bin/sh $RESOURCE_TOMCAT_USER -c "touch $CATALINA_PID"
-		if [ $? -ne 0 ]; then
-			ocf_log err "$RESOURCE_TOMCAT_USER cannot write to $CATALINA_PID. Check directory permissions."
-			wrongpermissions=1
-		fi
-	else
-		touch $CATALINA_PID
-		if [ $? -ne 0 ]; then
-			ocf_log err "$USER cannot write to $CATALINA_PID. Check directory permissions."
-			wrongpermissions=1
-		fi
-	fi
-
 	if [[ "$RESOURCE_STATUSURL" =~ :[0-9][0-9]* ]]; then
 		port=${RESOURCE_STATUSURL##*:}
 		port=${port%%/*}


### PR DESCRIPTION
This is a proposal enhancement from Tomcat-RA which Tony suggested.

The suggestion versions of Tony are as follows.
https://github.com/ClusterLabs/resource-agents/pull/79
The patch is splendid.
However, to take existing thing and compatibility,
I rewrote improvement contents same as a Tony version as a patch for Tomcat RA of the conventional version.

I would appreciate your comments and suggestions for merging this into the upstream.

---
- Bug fixes:
  - High: tomcat: Correction of the time-out level of the stop processing. 
  - Medium: tomcat: Correction of the process alive monitoring.
- Enhancements:
  - Medium: tomcat: add the parameter check in validate-all.
  - Low: tomcat: add the catalina_out parameter.
  - Low: Improvement of the convenience by adding a parameter to customize setting of Tomcat.
  - Low: tomcat: appropriate return code in the monitor_tomcat.
- Clean up:
  - Low: tomcat: Delete of deprecated parameter.
  - Low: tomcat: unification of tomcat command.
  - Low: tomcat: set retries to number of wget explicitly.
