### PR TITLE
New RA: sshtunnel

### DIFF
--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -82,6 +82,7 @@ man_MANS	       = ocf_heartbeat_AoEtarget.7 \
                           ocf_heartbeat_ServeRAID.7 \
                           ocf_heartbeat_SphinxSearchDaemon.7 \
                           ocf_heartbeat_Squid.7 \
+			  ocf_heartbeat_sstunnel.7 \
                           ocf_heartbeat_Stateful.7 \
                           ocf_heartbeat_SysInfo.7 \
                           ocf_heartbeat_VIPArip.7 \

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -82,7 +82,7 @@ man_MANS	       = ocf_heartbeat_AoEtarget.7 \
                           ocf_heartbeat_ServeRAID.7 \
                           ocf_heartbeat_SphinxSearchDaemon.7 \
                           ocf_heartbeat_Squid.7 \
-			  ocf_heartbeat_sstunnel.7 \
+			  ocf_heartbeat_sshtunnel.7 \
                           ocf_heartbeat_Stateful.7 \
                           ocf_heartbeat_SysInfo.7 \
                           ocf_heartbeat_VIPArip.7 \

--- a/heartbeat/Makefile.am
+++ b/heartbeat/Makefile.am
@@ -100,6 +100,7 @@ ocf_SCRIPTS	     =  ClusterMon		\
 			slapd			\
 			SphinxSearchDaemon	\
 			Squid			\
+			sshtunnel		\
 			Stateful		\
 			SysInfo			\
 			scsi2reservation	\

--- a/heartbeat/sshtunnel
+++ b/heartbeat/sshtunnel
@@ -88,7 +88,7 @@ sshtunnel_monitor()
 
 	# If no server configured (empty list), nothing is running
 	server_list=$( get_server_list )
-	if [[ $server_list =~ ^[[:space:]]$ ]]
+	if [[ $server_list =~ ^[[:space:]]*$ ]]
 	then
 		flag_not_running=1
 	else
@@ -289,7 +289,7 @@ kill_all()
 			# And remove the pid file of the connection we just stoped
 			rm -f $pid_file 2>/dev/null || ocf_log warn "Unable to delete pid file \"$pid_file\"..."
 		else
-			ocf_log info "Not killing connection to [${node}] because it seems that doesn't exist (no readable/writable PID file)..."
+			ocf_log warn "Not killing connection to [${node}] because it seems that doesn't exist (no readable/writable PID file)..."
 		fi
 	done
 

--- a/heartbeat/sshtunnel
+++ b/heartbeat/sshtunnel
@@ -18,9 +18,10 @@
 #########################################
 #########################################
 ## Default parameters
-OCF_RESKEY_crm_node_binary_default="/usr/sbin/crm_node"
-OCF_RESKEY_ssh_binary_default="/usr/bin/ssh"
+OCF_RESKEY_crm_node_binary_default="crm_node"
+OCF_RESKEY_ssh_binary_default="ssh"
 OCF_RESKEY_ssh_port_default="22"
+OCF_RESKEY_ssh_parameters_default="-n -N -M"
 OCF_RESKEY_tunnel_cluster_nodes_default="yes"
 OCF_RESKEY_tunnel_server_list_default=""
 OCF_RESKEY_pid_dir_default="/var/run/resource-agents"
@@ -29,6 +30,7 @@ OCF_RESKEY_tunnel_stop_timeout="5"
 [ -z "$OCF_RESKEY_crm_mode_binary" ] && OCF_RESKEY_crm_node_binary=$OCF_RESKEY_crm_node_binary_default
 [ -z "$OCF_RESKEY_ssh_binary" ] && OCF_RESKEY_ssh_binary=$OCF_RESKEY_ssh_binary_default
 [ -z "$OCF_RESKEY_ssh_port" ] && OCF_RESKEY_ssh_port=$OCF_RESKEY_ssh_port_default
+[ -z "$OCF_RESKEY_ssh_parameters" ] && OCF_RESKEY_ssh_parameters=$OCF_RESKEY_ssh_parameters_default
 [ -z "$OCF_RESKEY_tunnel_cluster_nodes" ] && OCF_RESKEY_tunnel_cluster_nodes=$OCF_RESKEY_tunnel_cluster_nodes_default
 [ -z "$OCF_RESKEY_tunnel_server_list" ] && OCF_RESKEY_tunnel_server_list=$OCF_RESKEY_tunnel_server_list_default
 [ -z "$OCF_RESKEY_tunnel_pid_dir" ] && OCF_RESKEY_pid_dir=$OCF_RESKEY_pid_dir_default
@@ -54,18 +56,24 @@ sshtunnel_start()
 			# do nothing if local node
 			[ "$node" == "`uname -n`" ] && continue
 			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
+
 			# do nothing if already started
-			[ -e "$pid_file" ] && is_running `cat $pid_file` && ocf_log info "Tunnel to [${node}] already started." && continue
+			[ -e "$pid_file" ] && is_running `cat $pid_file` \
+				&& ocf_log info "Tunnel to [${node}] already started." && continue
+
 			# start the tunnel otherwise
-			$OCF_RESKEY_ssh_binary -n -N -M -p $OCF_RESKEY_ssh_port ${OCF_RESKEY_default_user}@${node} >/dev/null 2>/dev/null &
+			$OCF_RESKEY_ssh_binary ${OCF_RESKEY_ssh_parametes} -p $OCF_RESKEY_ssh_port ${OCF_RESKEY_default_user}@${node} >/dev/null 2>/dev/null &
 			local pid=$!
 			echo $pid > $pid_file \
 				|| { ocf_log err "Unable to store the tunnel PID to host [${node}] in \"$pid_file\"." ; exit $OCF_ERR_GENERIC ; }
+
+			# try if the start proccess was fine
 			if is_running $pid
 			then
 				ocf_log info "Tunnel to [${node}] created."
 			else
-				ocf_log err "Unable to create the tunnel to [${node}]." ; exit $OCF_ERR_GENERIC
+				ocf_log err "Unable to create the tunnel to [${node}]."
+				exit $OCF_ERR_GENERIC
 			fi
 		done
 		IFS=$oldIFS
@@ -77,20 +85,29 @@ sshtunnel_start()
 		IFS=$' \t\n'
 		for node in $OCF_RESKEY_tunnel_server_list
 		do
-			is_ipv4_valid $node || is_ipv6_valid $node || is_fqdn_valid $node || { ocf_log warn "Detected invalid address in \"tunnel_server_list\" : [${node}]." ; continue ; }
+			# validating IPv4, IPv6 and FQDN
+			is_ipv4_valid $node || is_ipv6_valid $node \
+				|| is_fqdn_valid $node \
+				|| { ocf_log warn "Detected invalid address in \"tunnel_server_list\" : [${node}]." ; continue ; }
+
 			# do nothing if already started
 			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
-			[ -e "$pid_file" ] && is_running `cat $pid_file` && ocf_log info "Tunnel to [$node] already started." && continue
+			[ -e "$pid_file" ] && is_running `cat $pid_file` \
+				&& ocf_log info "Tunnel to [$node] already started." && continue
+
 			# start the tunnel otherwise
-			$OCF_RESKEY_ssh_binary -n -N -M -p $OCF_RESKEY_ssh_port ${OCF_RESKEY_default_user}@${node} >/dev/null 2>/dev/null &
+			$OCF_RESKEY_ssh_binary ${OCF_RESKEY_ssh_parameters} -p $OCF_RESKEY_ssh_port ${OCF_RESKEY_default_user}@${node} >/dev/null 2>/dev/null &
 			local pid=$!
 			echo $pid > $pid_file \
 				|| { ocf_log err "Unable to store the tunnel PID to host [${node}] in \"$pid_file\"." ; exit $OCF_ERR_GENERIC ; }
+
+			# check if the start operation was fine
 			if is_running $pid
 			then
 				ocf_log info "Tunnel to [${node}] created."
 			else
-				ocf_log err "Unable to create the tunnel to [${node}]." ; exit $OCF_ERR_GENERIC
+				ocf_log err "Unable to create the tunnel to [${node}]."
+				exit $OCF_ERR_GENERIC
 			fi
 		done
 		IFS=$oldIFS
@@ -113,16 +130,22 @@ sshtunnel_monitor()
 		for node in $( obtain_nodes )
 		do
 			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
+
 			# check nothing if local node
 			[ $node == "`uname -n`" ] && continue
-			: checking if $pid_file is running
-			[ -r $pid_file ] && is_running `cat $pid_file` && continue
+
+			# checking if $pid_file is running
+			[ -r $pid_file ] \
+				&& is_running `cat $pid_file` && continue
+
 			# if this point is reached, the node desn't have a tunnel
 			ocf_log warn "Tunnel to [${node}] found not running. Possible ssh or network problem."
-			flag_not_running=1 ; break
+			flag_not_running=1
+			break
 		done
 		IFS=$oldIFS
 	fi
+
 	# is our tunnel build also between a server in server_list?
 	if [ ! -z "$OCF_RESKEY_tunnel_server_list" ]
 	then
@@ -130,13 +153,20 @@ sshtunnel_monitor()
 		IFS=$' \t\n'
 		for node in $OCF_RESKEY_tunnel_server_list
 		do
+			# validating IPv4, IPv6 and FQDN
 			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
-			is_ipv4_valid $node || is_ipv6_valid $node || is_fqdn_valid $node || { ocf_log warn "Detected invalid address in \"tunnel_server_list\" : [${node}]." ; continue ; }
-			: checking if $pid_file is running
-			[ -r $pid_file ] && is_running `cat $pid_file` && continue
+			is_ipv4_valid $node || is_ipv6_valid $node \
+				|| is_fqdn_valid $node \
+				|| { ocf_log warn "Detected invalid address in \"tunnel_server_list\" : [${node}]." ; continue ; }
+
+			# checking if $pid_file is running
+			[ -r $pid_file ] \
+				&& is_running `cat $pid_file` && continue
+
 			# if this point is reached, the remote server desn't have a tunnel
 			ocf_log warn "Tunnel to [${node}] found not running. Possible ssh or network problem."
-			flag_not_running=1 ; break
+			flag_not_running=1
+			break
 		done
 		IFS=$oldIFS
 	fi
@@ -148,8 +178,11 @@ sshtunnel_stop()
 {
 	# exit immediately if configuration is not valid
 	sshtunnel_validate_all || exit $?
-	#sshtunnel_monitor || exit $?
+
+	# kill all tunnels
 	kill_all || exit $OCF_ERR_GENERIC
+
+	# log and exit
 	ocf_log info "All tunnels where stopped successfully."
 	return $OCF_SUCCESS
 }
@@ -180,25 +213,31 @@ cat <<EOF
 	<longdesc lang="en">
 		Sshtunnel is a Resource Agent capable of creating ssh tunnels (constant connections) between all nodes of the cluster.
 By using this RA, and configuring correctly implied ssh servers and clients you will benefit from some ssh capabilities, such as transparent ssh, connection multiplexing, and so on.
-There are two working modes, that can be used both at same time: creating ssh tunnels between al configured nodes in the Pacemaker cluster, or creating ssh tunnels to other external ssh servers.
+There are two working modes that can be used both at same time: creating ssh tunnels between al configured nodes in the Pacemaker cluster, or creating ssh tunnels to other external ssh servers.
 Full IPv6 support is expected.
 	</longdesc>
 	<shortdesc lang="en">sshtunel resource agent</shortdesc>
 	<parameters>
 		<parameter name="crm_node_binary" unique="0" required="0">
 			<longdesc lang="en">
-				Absolute path to crm_node binary on the system. This Resource Agent uses "crm_node" to get all names of nodes within the Pacemaker cluster.
+				The crm_node binary on the system. This Resource Agent uses "crm_node" to get all names of nodes within the Pacemaker cluster.
 			</longdesc>
 			<shortdesc lang="en">Path to crm_node binary.</shortdesc>
-			<content type="string" default="/usr/sbin/crm_node" />
+			<content type="string" default="crm_node" />
 		</parameter>
 		<parameter name="ssh_binary" unique="0" required="0">
 			<longdesc lang="en">
-				Absolute path to the main ssh (client) binary on the system. Used for building the tunnels.
+				The main ssh (client) binary on the system. Used for building the tunnels (ssh connections).
 			</longdesc>
 			<shortdesc lang="en">Path to ssh binary.</shortdesc>
-			<content type="string" default="/usr/bin/ssh" />
+			<content type="string" default="ssh" />
 		</parameter>
+		<parameter name="ssh_parameters" unique="0" required="0">
+			<longdesc lang="en">
+				Here you can define all ssh client options for use in the connection. Default is recommended.
+			</longdesc>
+			<shortdesc lang="en">ssh client options.</shortdesc>
+			<content type="string" default="-n -N -M" />
 		<parameter name="ssh_port" unique="0" required="0">
 			<longdesc lang="en">
 				TCP port for using in connections with all other nodes.
@@ -208,7 +247,7 @@ Full IPv6 support is expected.
 		</parameter>
 		<parameter name="tunnel_cluster_nodes" unique="0" required="0">
 			<longdesc lang="en">
-				If sshtunel RA should create tunnel between all nodes of the cluster except each local node.
+				If sshtunel RA should create tunnels (ssh connections) between all nodes of the Pacemaker cluster except each local node.
 At this point, this RA use the "uname -n" name of each node (i.e node1, node2), so be sure to make it reachable just by that name (maybe declaring in /etc/hosts file)
 			</longdesc>
 			<shortdesc lang="en">Enable tunnel creating between nodes.</shortdesc>
@@ -278,30 +317,34 @@ kill_all()
 
 	local flag_all_tunnel_killed=0
 
-	# First, kill all nodes used by the cluster
+	# First, kill all nodes used by the cluster (pacemaker nodes)
 	oldIFS=$IFS ; IFS=$' \t\n'
-	for node in $( obtain_nodes )
+	for node in $( get_server_list )
 	do
-		[ -z "$node" ] && { ocf_log warn "No cluster tunnel nodes to kill." ; break ; }
-		[ "$node" == "`uname -n`" ] && continue # local node, doing nothing
-		local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
-		[ -r $pid_file ] && local pid=`cat $pid_file`
-		[ -z "$pid" ] && rm -r $pid_file && continue # we found an empty pid file
-		kill_tunnel $pid || { ocf_log warn "Unable to kill tunnel to [$node]..." ; flag_all_tunnel_killed=1 ; }
-		rm -f $pid_file 2>/dev/null || ocf_log warn "Unable to delete pid file \"$pid_file\"..."
-	done
-	IFS=$oldIFS
+		# check if any server is obtained from get_server_list(). Break if no.
+		[ -z "$node" ] && break
 
-	# Then, kill all nodes in server_list
-	oldIFS=$IFS ; IFS=$' \t\n'
-	for node in $OCF_RESKEY_tunnel_server_list
-	do
-		[ -z "$node" ] && { ocf_log warn "No server tunnel to kill." ; break ; }
+		# continuing (doing nothing) if local node
+		[ "$node" == "`uname -n`" ] && continue
+
+		# preparing to kill the ssh connection pid
 		local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
-		[ -r $pid_file ] && local pid=`cat $pid_file`
-		[ -z "$pid" ] && rm -r $pid_file && continue # we found an empty pid file
-		kill_tunnel $pid || { ocf_log warn "Unable to kill tunnel to [$node]..." ; flag_all_tunnel_killed=1 ; }
-		rm -f $pid_file 2> /dev/null || ocf_log warn "Unable to delete pid file \"$pid_file\"..."
+		if [ -w $pid_file ]
+		then
+			local pid=`cat $pid_file`
+			# if an empty pid file was found, remove it (We know it belongs to this RA because the name)
+			[ -z "$pid" ] \
+				&& rm -r $pid_file && continue
+
+			# Actually shut down the connection. Finally...
+			kill_tunnel $pid \
+				|| { ocf_log warn "Unable to kill tunnel to [$node]..." ; flag_all_tunnel_killed=1 ; }
+
+			# And remove the pid file of the connection we just stoped
+			rm -f $pid_file 2>/dev/null || ocf_log warn "Unable to delete pid file \"$pid_file\"..."
+		else
+			ocf_log info "Not killing connection to [${node}] because it seems that doesn't exist (no readable/writable PID file)..."
+		fi
 	done
 	IFS=$oldIFS
 
@@ -309,13 +352,28 @@ kill_all()
 	oldIFS=$IFS ; IFS=$' \t\n'
 	for pid_file in $( ls $OCF_RESKEY_pid_dir/ | grep sshtunnel )
 	do
-		[ -r $pid_file ] && local pid=`cat $pid_file`
-		[ -z "$pid" ] && rm -r $pid_file && continue # we found an empty pid file
-		if is_running $pid
+		# check the pid file obtained from the dir
+		if [ -w $pid_file ]
 		then
-			kill_tunnel $pid || ocf_log warn "Detected dirty pid file in \"$pid_file\", with pid \"$pid\", that appears to be running but this RA is unable to kill..."
-		else
-			rm -f $pid_file 2> /dev/null || ocf_log war "Unable to delete remaining pid file [$pid_file]."
+			local pid=`cat $pid_file`
+
+			# remove the file if empty and continue
+			[ -z "$pid" ] && rm -r $pid_file && continue
+
+			# if the pid is running, stop the connection
+			if is_running $pid
+			then
+				if kill_tunnel $pid
+				then
+					# delete pid file if the connection was killed
+					rm -f $pid_file 2> /dev/null || ocf_log war "Unable to delete remaining pid file [$pid_file]."
+				else
+					ocf_log warn "Detected dirty pid file in \"$pid_file\", with pid \"$pid\", that appears to be running but this RA is unable to kill..."
+				fi
+			else
+				# already stopped, delete pid file
+				rm -f $pid_file 2> /dev/null || ocf_log war "Unable to delete remaining pid file [$pid_file]."
+			fi
 		fi
 	done
 	IFS=$oldIFS
@@ -324,22 +382,43 @@ kill_all()
 }
 
 # int kill_tunnel(pid)
-# used to kill one node
+# used to kill one PID
 kill_tunnel()
 {
 	[ -z "$1" ] && return 1 #error
 
-	kill -9 $1 2> /dev/null &
+	# trying to kill with SIGTERM
+	kill $1 2> /dev/null &
 	local cont=0
 	while is_running $1
 	do
-		[ $cont -ge $OCF_RESKEY_tunnel_stop_timeout ] && return 1 # kill timeout
+		# check for timeout
+		if [ $cont -ge $OCF_RESKEY_tunnel_stop_timeout ]
+		then
+			# timeout!
+			kill -9 $1 2> /dev/null
+
+			# return 1 if no way to stop the connection
+			is_running $1 && return 1
+
+			# return 0 oterwise
+			return 0
+		fi
 		sleep 1
 		((cont++))
 	done
 	return 0
 }
 
+
+# string get_server_list()
+# used to get all pacemaker nodes and other server list
+# in just one space separated list
+get_server_list()
+{
+	echo "$( obtain_nodes ) ${OCF_RESKEY_tunnel_server_list}" || return 1
+	return 0
+}
 
 
 # string obtain_nodes()
@@ -352,7 +431,7 @@ obtain_nodes()
 	return 0
 }
 # int is_running(int pid)
-# used to know if a given PID is running
+# used to know if a given PID is running (and if it is a ssh tunnel)
 is_running() #int pid
 {
 	if [ -z "$1" ]
@@ -360,7 +439,7 @@ is_running() #int pid
 		ocf_log warn "The function  \"is_running()\" was called without arguments. Possible RA bug."
 		return 1
 	else
-		ps aux | grep $1 | grep -v grep | grep "$OCF_RESKEY_ssh_binary -n -N -M -p $OCF_RESKEY_ssh_port ${OCF_RESKEY_default_user}" >/dev/null
+		ps aux | grep $1 | grep -v grep | grep "${OCF_RESKEY_ssh_binary} ${OCF_RESKEY_ssh_parameters} -p ${OCF_RESKEY_ssh_port} ${OCF_RESKEY_default_user}" >/dev/null
 		[ $? -eq 0 ] && return 0
 	fi
 	return 1

--- a/heartbeat/sshtunnel
+++ b/heartbeat/sshtunnel
@@ -1,0 +1,459 @@
+#!/bin/bash
+
+#
+#   Resource Agent for managing ssh tunnels
+#
+#   License:      GNU General Public License (GPL)
+#   (c) 2012 Arturo Borrero <aborrero@cica.es>
+#
+
+#########################################
+#########################################
+## Initialization:
+: ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
+. ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs || exit 1
+# Debug
+#. /usr/lib/ocf/lib/heartbeat/ocf-shellfuncs
+
+#########################################
+#########################################
+## Default parameters
+OCF_RESKEY_crm_node_binary_default="/usr/sbin/crm_node"
+OCF_RESKEY_ssh_binary_default="/usr/bin/ssh"
+OCF_RESKEY_ssh_port_default="22"
+OCF_RESKEY_tunnel_cluster_nodes_default="yes"
+OCF_RESKEY_tunnel_server_list_default=""
+OCF_RESKEY_pid_dir_default="/var/run/resource-agents"
+OCF_RESKEY_default_user_default="root"
+OCF_RESKEY_tunnel_stop_timeout="5"
+[ -z "$OCF_RESKEY_crm_mode_binary" ] && OCF_RESKEY_crm_node_binary=$OCF_RESKEY_crm_node_binary_default
+[ -z "$OCF_RESKEY_ssh_binary" ] && OCF_RESKEY_ssh_binary=$OCF_RESKEY_ssh_binary_default
+[ -z "$OCF_RESKEY_ssh_port" ] && OCF_RESKEY_ssh_port=$OCF_RESKEY_ssh_port_default
+[ -z "$OCF_RESKEY_tunnel_cluster_nodes" ] && OCF_RESKEY_tunnel_cluster_nodes=$OCF_RESKEY_tunnel_cluster_nodes_default
+[ -z "$OCF_RESKEY_tunnel_server_list" ] && OCF_RESKEY_tunnel_server_list=$OCF_RESKEY_tunnel_server_list_default
+[ -z "$OCF_RESKEY_tunnel_pid_dir" ] && OCF_RESKEY_pid_dir=$OCF_RESKEY_pid_dir_default
+[ -z "$OCF_RESKEY_default_user" ] && OCF_RESKEY_default_user=$OCF_RESKEY_default_user_default
+[ -z "$OCF_RESKEY_tunnel_stop_timeout" ] && OCF_RESKEY_stop_timeout=$OCF_RESKEY_stop_timeout
+
+#########################################
+#########################################
+## Actions
+
+sshtunnel_start()
+{
+	# exit immediately if configuration is not valid
+	sshtunnel_validate_all || exit $?
+
+	# is our tunnel between all nodes in the cluster?
+	if ocf_is_true $OCF_RESKEY_tunnel_cluster_nodes
+	then
+		oldIFS=$IFS
+		IFS=$' \t\n'
+		for node in $( obtain_nodes )
+		do
+			# do nothing if local node
+			[ "$node" == "`uname -n`" ] && continue
+			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
+			# do nothing if already started
+			[ -e "$pid_file" ] && is_running `cat $pid_file` && ocf_log info "Tunnel to [${node}] already started." && continue
+			# start the tunnel otherwise
+			$OCF_RESKEY_ssh_binary -n -N -M -p $OCF_RESKEY_ssh_port ${OCF_RESKEY_default_user}@${node} >/dev/null 2>/dev/null &
+			local pid=$!
+			echo $pid > $pid_file \
+				|| { ocf_log err "Unable to store the tunnel PID to host [${node}] in \"$pid_file\"." ; exit $OCF_ERR_GENERIC ; }
+			if is_running $pid
+			then
+				ocf_log info "Tunnel to [${node}] created."
+			else
+				ocf_log err "Unable to create the tunnel to [${node}]." ; exit $OCF_ERR_GENERIC
+			fi
+		done
+		IFS=$oldIFS
+	fi
+	# is our tunnel between a server in server_list ?
+	if [ ! -z "$OCF_RESKEY_tunnel_server_list" ]
+	then
+		oldIFS=$IFS
+		IFS=$' \t\n'
+		for node in $OCF_RESKEY_tunnel_server_list
+		do
+			is_ipv4_valid $node || is_ipv6_valid $node || is_fqdn_valid $node || { ocf_log warn "Detected invalid address in \"tunnel_server_list\" : [${node}]." ; continue ; }
+			# do nothing if already started
+			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
+			[ -e "$pid_file" ] && is_running `cat $pid_file` && ocf_log info "Tunnel to [$node] already started." && continue
+			# start the tunnel otherwise
+			$OCF_RESKEY_ssh_binary -n -N -M -p $OCF_RESKEY_ssh_port ${OCF_RESKEY_default_user}@${node} >/dev/null 2>/dev/null &
+			local pid=$!
+			echo $pid > $pid_file \
+				|| { ocf_log err "Unable to store the tunnel PID to host [${node}] in \"$pid_file\"." ; exit $OCF_ERR_GENERIC ; }
+			if is_running $pid
+			then
+				ocf_log info "Tunnel to [${node}] created."
+			else
+				ocf_log err "Unable to create the tunnel to [${node}]." ; exit $OCF_ERR_GENERIC
+			fi
+		done
+		IFS=$oldIFS
+	fi
+	return $OCF_SUCCESS
+}
+
+sshtunnel_monitor()
+{
+	# exit immediately if configuration is not valid
+	sshtunnel_validate_all || exit $?
+
+	local flag_not_running=0
+
+	# is our tunnel build between all nodes in the cluster?
+	if ocf_is_true $OCF_RESKEY_tunnel_cluster_nodes
+	then
+		oldIFS=$IFS
+		IFS=$' \t\n'
+		for node in $( obtain_nodes )
+		do
+			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
+			# check nothing if local node
+			[ $node == "`uname -n`" ] && continue
+			: checking if $pid_file is running
+			[ -r $pid_file ] && is_running `cat $pid_file` && continue
+			# if this point is reached, the node desn't have a tunnel
+			ocf_log warn "Tunnel to [${node}] found not running. Possible ssh or network problem."
+			flag_not_running=1 ; break
+		done
+		IFS=$oldIFS
+	fi
+	# is our tunnel build also between a server in server_list?
+	if [ ! -z "$OCF_RESKEY_tunnel_server_list" ]
+	then
+		oldIFS=$IFS
+		IFS=$' \t\n'
+		for node in $OCF_RESKEY_tunnel_server_list
+		do
+			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
+			is_ipv4_valid $node || is_ipv6_valid $node || is_fqdn_valid $node || { ocf_log warn "Detected invalid address in \"tunnel_server_list\" : [${node}]." ; continue ; }
+			: checking if $pid_file is running
+			[ -r $pid_file ] && is_running `cat $pid_file` && continue
+			# if this point is reached, the remote server desn't have a tunnel
+			ocf_log warn "Tunnel to [${node}] found not running. Possible ssh or network problem."
+			flag_not_running=1 ; break
+		done
+		IFS=$oldIFS
+	fi
+	ocf_is_true $flag_not_running && return $OCF_NOT_RUNNING
+	return $OCF_SUCCESS
+}
+
+sshtunnel_stop()
+{
+	# exit immediately if configuration is not valid
+	sshtunnel_validate_all || exit $?
+	#sshtunnel_monitor || exit $?
+	kill_all || exit $OCF_ERR_GENERIC
+	ocf_log info "All tunnels where stopped successfully."
+	return $OCF_SUCCESS
+}
+
+sshtunnel_validate_all()
+{
+	have_binary $OCF_RESKEY_crm_node_binary || { ocf_log err "\"crm_node_binary\" binary not found at [${OCF_RESKEY_crm_node_binary}]." ; return $OCF_ERR_INSTALLED ; }
+	have_binary $OCF_RESKEY_ssh_binary || { ocf_log err "\"ssh_binary\" binary not found at [${OCF_RESKEY_ssh_binary}]." ; return $OCF_ERR_INSTALLED ; }
+	have_binary uname || { ocf_log err "The binary \"uname\" was not found." ; return $OCF_ERR_INSTALLED ; }
+	have_binary dig || { ocf_log err "The binary \"dig\" was not found." ; return $OCF_ERR_INSTALLED ; }
+	[ -z "$OCF_RESKEY_ssh_port" ] && { ocf_log err "The parameter \"ssh_port\" is not set." ; return $OCF_ERR_CONFIGURED ; }
+	[[ $OCF_RESKEY_ssh_port =~ ^[0-9]*$ ]] || { ocf_log err "The parameter \"ssh_port\" is not an integer. Expected a possitive integer between 1-35536" ; return $OCF_ERR_CONFIGURED ; }
+	[ "$OCF_RESKEY_ssh_port" -ge 1 ] || { ocf_log err "The parameter \"ssh_port\" is out of range. Needed >= 1." ; return $OCF_ERR_CONFIGURED ; }
+	[ "$OCF_RESKEY_ssh_port" -le 65536 ] || { ocf_log err "The parameter \"ssh_port\" is out of range. Needed <= 65536" ; return $OCF_ERR_CONFIGURED ; }
+	[ -d "$OCF_RESKEY_pid_dir" ] || { ocf_log err "The parameter \"pid_dir\" is invalid. Unable to use directory." ; return $OCF_ERR_CONFIGURED ; }
+	[ -z "$OCF_RESKEY_default_user" ] && { ocf_log err "No parameter \"default_user\" was set." ; return $OCF_ERR_CONFIGURED ; }
+	[[ $OCF_RESKEY_tunnel_stop_timeout =~ ^[0-9]*$ ]] || { ocf_log err "The parameter \"tunnel_stop_timeout\" is not a valid integer. Expected a possitive integer." ; return $OCF_ERR_CONFIGURED ; }
+	return $OCF_SUCCESS
+}
+
+sshtunnel_meta_data()
+{
+cat <<EOF
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="sshtunnel" version="0.1">
+	<version>0.1</version>
+	<longdesc lang="en">
+		Sshtunnel is a Resource Agent capable of creating ssh tunnels (constant connections) between all nodes of the cluster.
+By using this RA, and configuring correctly implied ssh servers and clients you will benefit from some ssh capabilities, such as transparent ssh, connection multiplexing, and so on.
+There are two working modes, that can be used both at same time: creating ssh tunnels between al configured nodes in the Pacemaker cluster, or creating ssh tunnels to other external ssh servers.
+Full IPv6 support is expected.
+	</longdesc>
+	<shortdesc lang="en">sshtunel resource agent</shortdesc>
+	<parameters>
+		<parameter name="crm_node_binary" unique="0" required="0">
+			<longdesc lang="en">
+				Absolute path to crm_node binary on the system. This Resource Agent uses "crm_node" to get all names of nodes within the Pacemaker cluster.
+			</longdesc>
+			<shortdesc lang="en">Path to crm_node binary.</shortdesc>
+			<content type="string" default="/usr/sbin/crm_node" />
+		</parameter>
+		<parameter name="ssh_binary" unique="0" required="0">
+			<longdesc lang="en">
+				Absolute path to the main ssh (client) binary on the system. Used for building the tunnels.
+			</longdesc>
+			<shortdesc lang="en">Path to ssh binary.</shortdesc>
+			<content type="string" default="/usr/bin/ssh" />
+		</parameter>
+		<parameter name="ssh_port" unique="0" required="0">
+			<longdesc lang="en">
+				TCP port for using in connections with all other nodes.
+			</longdesc>
+			<shortdesc lang="en">TCP port for using in connections.</shortdesc>
+			<content type="integer" default="22" />
+		</parameter>
+		<parameter name="tunnel_cluster_nodes" unique="0" required="0">
+			<longdesc lang="en">
+				If sshtunel RA should create tunnel between all nodes of the cluster except each local node.
+At this point, this RA use the "uname -n" name of each node (i.e node1, node2), so be sure to make it reachable just by that name (maybe declaring in /etc/hosts file)
+			</longdesc>
+			<shortdesc lang="en">Enable tunnel creating between nodes.</shortdesc>
+			<content type="boolean" default="yes" />
+		</parameter>
+		<parameter name="tunnel_server_list" unique="1" required="0">
+			<longdesc lang="en">
+				A space separated list of IPv4, IPv6 or FQDNs of end points of tunnels (ssh servers).
+Use this if "tunnel_cluster_nodes"=no. Otherwise, this RA will do nothing.
+			</longdesc>
+			<shortdesc lang="en">List of ssh servers.</shortdesc>
+			<content type="string" default="" />
+		</parameter>
+		<parameter name="pid_dir" unique="0" required="0">
+			<longdesc lang="en">
+				A directory where to put all PIDs regarding tunnels. Absolute path, with no trailing slash.
+			</longdesc>
+			<shortdesc lang="en">Directory where to put all PIDs.</shortdesc>
+			<content type="string" default="/var/run/resource-agents" />
+		</parameter>
+		<parameter name="default_user" unique="0" required="0">
+			<longdesc lang="en">
+				The default user used in ssh connections to all other ssh servers.
+Note that this RA will not test the user other than launch the connection. Maybe you want to set transparent-ssh between client and server.
+			</longdesc>
+			<shortdesc lang="en">User to connect other ssh servers.</shortdesc>
+			<content type="string" default="root" />
+		</parameter>
+		<parameter name="tunnel_stop_timeout" unique="0" required="0">
+			<longdesc lang="en">
+				The time this RA should wait when stopping each node tunnel.
+If a connection get freezed due to a network problem, this time is crucial.
+			</longdesc>
+			<shortdesc lang="en">Tunel stop timeout.</shortdesc>
+			<content type="integer" default="5" />
+		</parameter>
+	</parameters>
+	<actions>
+		<action name="start"        timeout="20" />
+		<action name="stop"         timeout="20" />
+		<action name="monitor"      timeout="20" interval="10" depth="0" />
+		<action name="reload"       timeout="20" />
+		<action name="meta-data"    timeout="5" />
+		<action name="validate-all"   timeout="20" />
+		</actions>
+</resource-agent>
+EOF
+return 0
+}
+
+sshtunnel_usage()
+{
+	echo "Usage: {start|stop|status|monitor|reload|meta-data|validate-all}"
+	return 0
+}
+
+#########################################
+#########################################
+# Other functions
+
+# int kill_all()
+# used to kill all tunnels and remove pid files
+kill_all()
+{
+
+	ocf_log info "Killing all tunnels..."
+
+	local flag_all_tunnel_killed=0
+
+	# First, kill all nodes used by the cluster
+	oldIFS=$IFS ; IFS=$' \t\n'
+	for node in $( obtain_nodes )
+	do
+		[ -z "$node" ] && { ocf_log warn "No cluster tunnel nodes to kill." ; break ; }
+		[ "$node" == "`uname -n`" ] && continue # local node, doing nothing
+		local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
+		[ -r $pid_file ] && local pid=`cat $pid_file`
+		[ -z "$pid" ] && rm -r $pid_file && continue # we found an empty pid file
+		kill_tunnel $pid || { ocf_log warn "Unable to kill tunnel to [$node]..." ; flag_all_tunnel_killed=1 ; }
+		rm -f $pid_file 2>/dev/null || ocf_log warn "Unable to delete pid file \"$pid_file\"..."
+	done
+	IFS=$oldIFS
+
+	# Then, kill all nodes in server_list
+	oldIFS=$IFS ; IFS=$' \t\n'
+	for node in $OCF_RESKEY_tunnel_server_list
+	do
+		[ -z "$node" ] && { ocf_log warn "No server tunnel to kill." ; break ; }
+		local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
+		[ -r $pid_file ] && local pid=`cat $pid_file`
+		[ -z "$pid" ] && rm -r $pid_file && continue # we found an empty pid file
+		kill_tunnel $pid || { ocf_log warn "Unable to kill tunnel to [$node]..." ; flag_all_tunnel_killed=1 ; }
+		rm -f $pid_file 2> /dev/null || ocf_log warn "Unable to delete pid file \"$pid_file\"..."
+	done
+	IFS=$oldIFS
+
+	# Finally, remove all remaining data belonging to us
+	oldIFS=$IFS ; IFS=$' \t\n'
+	for pid_file in $( ls $OCF_RESKEY_pid_dir/ | grep sshtunnel )
+	do
+		[ -r $pid_file ] && local pid=`cat $pid_file`
+		[ -z "$pid" ] && rm -r $pid_file && continue # we found an empty pid file
+		if is_running $pid
+		then
+			kill_tunnel $pid || ocf_log warn "Detected dirty pid file in \"$pid_file\", with pid \"$pid\", that appears to be running but this RA is unable to kill..."
+		else
+			rm -f $pid_file 2> /dev/null || ocf_log war "Unable to delete remaining pid file [$pid_file]."
+		fi
+	done
+	IFS=$oldIFS
+
+	return $flag_all_tunnel_killed
+}
+
+# int kill_tunnel(pid)
+# used to kill one node
+kill_tunnel()
+{
+	[ -z "$1" ] && return 1 #error
+
+	kill -9 $1 2> /dev/null &
+	local cont=0
+	while is_running $1
+	do
+		[ $cont -ge $OCF_RESKEY_tunnel_stop_timeout ] && return 1 # kill timeout
+		sleep 1
+		((cont++))
+	done
+	return 0
+}
+
+
+
+# string obtain_nodes()
+# used to get all nodes configured in the cluster
+obtain_nodes()
+{
+	nodes=$( eval $OCF_RESKEY_crm_node_binary -p )
+	[ -z "$nodes" ] && return 1
+	echo $nodes
+	return 0
+}
+# int is_running(int pid)
+# used to know if a given PID is running
+is_running() #int pid
+{
+	if [ -z "$1" ]
+	then
+		ocf_log warn "The function  \"is_running()\" was called without arguments. Possible RA bug."
+		return 1
+	else
+		ps aux | grep $1 | grep -v grep | grep "$OCF_RESKEY_ssh_binary -n -N -M -p $OCF_RESKEY_ssh_port ${OCF_RESKEY_default_user}" >/dev/null
+		[ $? -eq 0 ] && return 0
+	fi
+	return 1
+}
+
+# int is_ipv4_valid(string ip)
+# used to know if a given IP is a valid IPv4
+is_ipv4_valid()
+{
+        local retval=1
+        if [ ! -z $1 ]
+        then
+                egrep '^(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[0-9]{1,2})){3}$' <<< $1 > /dev/null
+                if [ $? -eq 0 ]
+                then
+                        retval=0
+                fi
+        fi
+        return $retval
+}
+
+# int is_ipv6_valid(string ip)
+# used to know if a given IP is a valid IPv6
+is_ipv6_valid()
+{
+        local retval=1
+        if [ ! -z $1 ]
+        then
+		egrep -E '^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:)))(%.+)?\s*$' <<< $1 > /dev/null
+                if [ $? -eq 0 ]
+                then
+                        retval=0
+                fi
+        fi
+        return $retval
+}
+
+# int is_fqdn_valid(string fqdn)
+# used to know if a given FQDN is valid (we can get the corresponding ip)
+is_fqdn_valid()
+{
+        local retval=1
+        if [ ! -z $1 ]
+        then
+                if [ `dig +short $1 | wc -l` -ne 0 ] > /dev/null
+                then
+                        retval=0
+                fi
+        fi
+        return $retval
+}
+
+
+#########################################
+#########################################
+# Execution block
+
+
+case $__OCF_ACTION in
+meta-data)      sshtunnel_meta_data
+                exit $OCF_SUCCESS
+                ;;
+usage|help)     sshtunnel_usage
+                exit $OCF_SUCCESS
+                ;;
+esac
+
+# Anything other than meta-data and usage must pass validation
+sshtunnel_validate_all || exit $?
+
+# Translate each action into the appropriate function call
+case $__OCF_ACTION in
+	start)          sshtunnel_start
+			;;
+	stop)           sshtunnel_stop
+			;;
+	status|monitor) sshtunnel_monitor
+			;;
+	promote)        exit $OCF_ERR_UNIMPLEMENTED
+			;;
+	demote)         exit $OCF_ERR_UNIMPLEMENTED
+			;;
+	reload)         ocf_log info "Reloading..."
+        	        sshtunnel_start
+                	;;
+	validate-all)   ;;
+
+	*)              sshtunnel_usage
+        	        exit $OCF_ERR_UNIMPLEMENTED
+	                ;;
+esac
+rc=$?
+
+# The resource agent may optionally log a debug message
+ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION returned $rc"
+exit $rc

--- a/heartbeat/sshtunnel
+++ b/heartbeat/sshtunnel
@@ -26,7 +26,7 @@ OCF_RESKEY_tunnel_cluster_nodes_default="yes"
 OCF_RESKEY_tunnel_server_list_default=""
 OCF_RESKEY_pid_dir_default="/var/run/resource-agents"
 OCF_RESKEY_default_user_default="root"
-OCF_RESKEY_tunnel_stop_timeout="5"
+OCF_RESKEY_tunnel_stop_timeout_default="5"
 [ -z "$OCF_RESKEY_crm_mode_binary" ] && OCF_RESKEY_crm_node_binary=$OCF_RESKEY_crm_node_binary_default
 [ -z "$OCF_RESKEY_ssh_binary" ] && OCF_RESKEY_ssh_binary=$OCF_RESKEY_ssh_binary_default
 [ -z "$OCF_RESKEY_ssh_port" ] && OCF_RESKEY_ssh_port=$OCF_RESKEY_ssh_port_default
@@ -35,7 +35,7 @@ OCF_RESKEY_tunnel_stop_timeout="5"
 [ -z "$OCF_RESKEY_tunnel_server_list" ] && OCF_RESKEY_tunnel_server_list=$OCF_RESKEY_tunnel_server_list_default
 [ -z "$OCF_RESKEY_tunnel_pid_dir" ] && OCF_RESKEY_pid_dir=$OCF_RESKEY_pid_dir_default
 [ -z "$OCF_RESKEY_default_user" ] && OCF_RESKEY_default_user=$OCF_RESKEY_default_user_default
-[ -z "$OCF_RESKEY_tunnel_stop_timeout" ] && OCF_RESKEY_stop_timeout=$OCF_RESKEY_stop_timeout
+[ -z "$OCF_RESKEY_tunnel_stop_timeout" ] && OCF_RESKEY_stop_timeout=$OCF_RESKEY_stop_timeout_default
 
 #########################################
 #########################################
@@ -46,72 +46,36 @@ sshtunnel_start()
 	# exit immediately if configuration is not valid
 	sshtunnel_validate_all || exit $?
 
-	# is our tunnel between all nodes in the cluster?
-	if ocf_is_true $OCF_RESKEY_tunnel_cluster_nodes
-	then
-		oldIFS=$IFS
-		IFS=$' \t\n'
-		for node in $( obtain_nodes )
-		do
-			# do nothing if local node
-			[ "$node" == "`uname -n`" ] && continue
-			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
+	oldIFS=$IFS
+	IFS=$' \t\n' # we need to set this to get the for loop working fine
+	for node in $( get_server_list )
+	do
+		# do nothing if local node
+		[ "$node" == "`uname -n`" ] && continue
 
-			# do nothing if already started
-			[ -e "$pid_file" ] && is_running `cat $pid_file` \
-				&& ocf_log info "Tunnel to [${node}] already started." && continue
+		# do nothing if already started
+		local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
+		[ -e "$pid_file" ] && [ ! -z "`cat $pid_file`" ] \
+			&& is_running `cat $pid_file` \
+			&& { ocf_log info "Tunnel to [${node}] already started." ; continue ; }
 
-			# start the tunnel otherwise
-			$OCF_RESKEY_ssh_binary ${OCF_RESKEY_ssh_parametes} -p $OCF_RESKEY_ssh_port ${OCF_RESKEY_default_user}@${node} >/dev/null 2>/dev/null &
-			local pid=$!
-			echo $pid > $pid_file \
-				|| { ocf_log err "Unable to store the tunnel PID to host [${node}] in \"$pid_file\"." ; exit $OCF_ERR_GENERIC ; }
+		# start the tunnel otherwise
+		$OCF_RESKEY_ssh_binary ${OCF_RESKEY_ssh_parameters} -p $OCF_RESKEY_ssh_port ${OCF_RESKEY_default_user}@${node} >/dev/null 2>/dev/null &
+		local pid=$!
+		echo $pid > $pid_file \
+			|| { ocf_log err "Unable to store the tunnel PID to host [${node}] in \"$pid_file\"." ; exit $OCF_ERR_GENERIC ; }
 
-			# try if the start proccess was fine
-			if is_running $pid
-			then
-				ocf_log info "Tunnel to [${node}] created."
-			else
-				ocf_log err "Unable to create the tunnel to [${node}]."
-				exit $OCF_ERR_GENERIC
-			fi
-		done
-		IFS=$oldIFS
-	fi
-	# is our tunnel between a server in server_list ?
-	if [ ! -z "$OCF_RESKEY_tunnel_server_list" ]
-	then
-		oldIFS=$IFS
-		IFS=$' \t\n'
-		for node in $OCF_RESKEY_tunnel_server_list
-		do
-			# validating IPv4, IPv6 and FQDN
-			is_ipv4_valid $node || is_ipv6_valid $node \
-				|| is_fqdn_valid $node \
-				|| { ocf_log warn "Detected invalid address in \"tunnel_server_list\" : [${node}]." ; continue ; }
+		# try if the start proccess was fine
+		if is_running $pid
+		then
+			ocf_log info "Tunnel to [${node}] created."
+		else
+			ocf_log err "Unable to create the tunnel to [${node}]."
+			exit $OCF_ERR_GENERIC
+		fi
+	done
+	IFS=$oldIFS
 
-			# do nothing if already started
-			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
-			[ -e "$pid_file" ] && is_running `cat $pid_file` \
-				&& ocf_log info "Tunnel to [$node] already started." && continue
-
-			# start the tunnel otherwise
-			$OCF_RESKEY_ssh_binary ${OCF_RESKEY_ssh_parameters} -p $OCF_RESKEY_ssh_port ${OCF_RESKEY_default_user}@${node} >/dev/null 2>/dev/null &
-			local pid=$!
-			echo $pid > $pid_file \
-				|| { ocf_log err "Unable to store the tunnel PID to host [${node}] in \"$pid_file\"." ; exit $OCF_ERR_GENERIC ; }
-
-			# check if the start operation was fine
-			if is_running $pid
-			then
-				ocf_log info "Tunnel to [${node}] created."
-			else
-				ocf_log err "Unable to create the tunnel to [${node}]."
-				exit $OCF_ERR_GENERIC
-			fi
-		done
-		IFS=$oldIFS
-	fi
 	return $OCF_SUCCESS
 }
 
@@ -122,54 +86,34 @@ sshtunnel_monitor()
 
 	local flag_not_running=0
 
-	# is our tunnel build between all nodes in the cluster?
-	if ocf_is_true $OCF_RESKEY_tunnel_cluster_nodes
+	# If no server configured (empty list), nothing is running
+	server_list=$( get_server_list )
+	if [[ $server_list =~ ^[[:space:]]$ ]]
 	then
+		flag_not_running=1
+	else
 		oldIFS=$IFS
-		IFS=$' \t\n'
-		for node in $( obtain_nodes )
-		do
-			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
+		IFS=$' \t\n' # we need to set this to get the for loop working fine
 
+		for node in $server_list
+		do
 			# check nothing if local node
-			[ $node == "`uname -n`" ] && continue
+			[ "$node" == "`uname -n`" ] && continue
 
 			# checking if $pid_file is running
-			[ -r $pid_file ] \
-				&& is_running `cat $pid_file` && continue
-
-			# if this point is reached, the node desn't have a tunnel
-			ocf_log warn "Tunnel to [${node}] found not running. Possible ssh or network problem."
-			flag_not_running=1
-			break
-		done
-		IFS=$oldIFS
-	fi
-
-	# is our tunnel build also between a server in server_list?
-	if [ ! -z "$OCF_RESKEY_tunnel_server_list" ]
-	then
-		oldIFS=$IFS
-		IFS=$' \t\n'
-		for node in $OCF_RESKEY_tunnel_server_list
-		do
-			# validating IPv4, IPv6 and FQDN
 			local pid_file=$OCF_RESKEY_pid_dir/sshtunnel_${node}.pid
-			is_ipv4_valid $node || is_ipv6_valid $node \
-				|| is_fqdn_valid $node \
-				|| { ocf_log warn "Detected invalid address in \"tunnel_server_list\" : [${node}]." ; continue ; }
-
-			# checking if $pid_file is running
-			[ -r $pid_file ] \
-				&& is_running `cat $pid_file` && continue
+			[ -r $pid_file ] && local pid=`cat $pid_file`
+			[ ! -z "$pid" ] && is_running $pid && continue
 
 			# if this point is reached, the remote server desn't have a tunnel
-			ocf_log warn "Tunnel to [${node}] found not running. Possible ssh or network problem."
+			ocf_log warn "Tunnel to [${node}] found not running. Possible causes: ssh or network problem, a node failover/failback or bad config."
 			flag_not_running=1
 			break
 		done
 		IFS=$oldIFS
 	fi
+
+	# if one connection isn't running, return NOT_RUNNING, otherwise SUCCESS
 	ocf_is_true $flag_not_running && return $OCF_NOT_RUNNING
 	return $OCF_SUCCESS
 }
@@ -183,7 +127,7 @@ sshtunnel_stop()
 	kill_all || exit $OCF_ERR_GENERIC
 
 	# log and exit
-	ocf_log info "All tunnels where stopped successfully."
+	ocf_log info "All tunnels where successfully stopped."
 	return $OCF_SUCCESS
 }
 
@@ -192,7 +136,8 @@ sshtunnel_validate_all()
 	have_binary $OCF_RESKEY_crm_node_binary || { ocf_log err "\"crm_node_binary\" binary not found at [${OCF_RESKEY_crm_node_binary}]." ; return $OCF_ERR_INSTALLED ; }
 	have_binary $OCF_RESKEY_ssh_binary || { ocf_log err "\"ssh_binary\" binary not found at [${OCF_RESKEY_ssh_binary}]." ; return $OCF_ERR_INSTALLED ; }
 	have_binary uname || { ocf_log err "The binary \"uname\" was not found." ; return $OCF_ERR_INSTALLED ; }
-	have_binary dig || { ocf_log err "The binary \"dig\" was not found." ; return $OCF_ERR_INSTALLED ; }
+	have_binary kill || { ocf_log err "The binary \"kill\" was not found." ; return $OCF_ERR_INSTALLED ; }
+	have_binary ps || { ocf_log err "The binary \"ps\" was not found." ; return $OCF_ERR_INSTALLED ; }
 	[ -z "$OCF_RESKEY_ssh_port" ] && { ocf_log err "The parameter \"ssh_port\" is not set." ; return $OCF_ERR_CONFIGURED ; }
 	[[ $OCF_RESKEY_ssh_port =~ ^[0-9]*$ ]] || { ocf_log err "The parameter \"ssh_port\" is not an integer. Expected a possitive integer between 1-35536" ; return $OCF_ERR_CONFIGURED ; }
 	[ "$OCF_RESKEY_ssh_port" -ge 1 ] || { ocf_log err "The parameter \"ssh_port\" is out of range. Needed >= 1." ; return $OCF_ERR_CONFIGURED ; }
@@ -238,6 +183,7 @@ Full IPv6 support is expected.
 			</longdesc>
 			<shortdesc lang="en">ssh client options.</shortdesc>
 			<content type="string" default="-n -N -M" />
+		</parameter>
 		<parameter name="ssh_port" unique="0" required="0">
 			<longdesc lang="en">
 				TCP port for using in connections with all other nodes.
@@ -315,10 +261,9 @@ kill_all()
 
 	ocf_log info "Killing all tunnels..."
 
-	local flag_all_tunnel_killed=0
+	local flag_error_killing_connection=0
 
-	# First, kill all nodes used by the cluster (pacemaker nodes)
-	oldIFS=$IFS ; IFS=$' \t\n'
+	oldIFS=$IFS ; IFS=$' \t\n' # we need to set this to get the for loop working fine
 	for node in $( get_server_list )
 	do
 		# check if any server is obtained from get_server_list(). Break if no.
@@ -332,13 +277,14 @@ kill_all()
 		if [ -w $pid_file ]
 		then
 			local pid=`cat $pid_file`
+
 			# if an empty pid file was found, remove it (We know it belongs to this RA because the name)
 			[ -z "$pid" ] \
-				&& rm -r $pid_file && continue
+				&& { rm -r $pid_file ; continue ; }
 
-			# Actually shut down the connection. Finally...
+			# Finally shut down the connection.
 			kill_tunnel $pid \
-				|| { ocf_log warn "Unable to kill tunnel to [$node]..." ; flag_all_tunnel_killed=1 ; }
+				|| { ocf_log warn "Unable to kill tunnel to [$node]..." ; flag_error_killing_connection=1 ; }
 
 			# And remove the pid file of the connection we just stoped
 			rm -f $pid_file 2>/dev/null || ocf_log warn "Unable to delete pid file \"$pid_file\"..."
@@ -346,13 +292,12 @@ kill_all()
 			ocf_log info "Not killing connection to [${node}] because it seems that doesn't exist (no readable/writable PID file)..."
 		fi
 	done
-	IFS=$oldIFS
 
 	# Finally, remove all remaining data belonging to us
-	oldIFS=$IFS ; IFS=$' \t\n'
 	for pid_file in $( ls $OCF_RESKEY_pid_dir/ | grep sshtunnel )
 	do
 		# check the pid file obtained from the dir
+		local pid_file=$OCF_RESKEY_pid_dir/${pid_file}
 		if [ -w $pid_file ]
 		then
 			local pid=`cat $pid_file`
@@ -378,7 +323,8 @@ kill_all()
 	done
 	IFS=$oldIFS
 
-	return $flag_all_tunnel_killed
+	# return != 0 if any connection was impossible to kill
+	return $flag_error_killing_connection
 }
 
 # int kill_tunnel(pid)
@@ -416,7 +362,12 @@ kill_tunnel()
 # in just one space separated list
 get_server_list()
 {
-	echo "$( obtain_nodes ) ${OCF_RESKEY_tunnel_server_list}" || return 1
+	if ocf_is_true $OCF_RESKEY_tunnel_cluster_nodes
+	then
+		echo "$( obtain_nodes ) ${OCF_RESKEY_tunnel_server_list}" || return 1
+	else
+		echo "${OCF_RESKEY_tunnel_server_list}" || return 1
+	fi
 	return 0
 }
 
@@ -443,53 +394,6 @@ is_running() #int pid
 		[ $? -eq 0 ] && return 0
 	fi
 	return 1
-}
-
-# int is_ipv4_valid(string ip)
-# used to know if a given IP is a valid IPv4
-is_ipv4_valid()
-{
-        local retval=1
-        if [ ! -z $1 ]
-        then
-                egrep '^(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[0-9]{1,2})){3}$' <<< $1 > /dev/null
-                if [ $? -eq 0 ]
-                then
-                        retval=0
-                fi
-        fi
-        return $retval
-}
-
-# int is_ipv6_valid(string ip)
-# used to know if a given IP is a valid IPv6
-is_ipv6_valid()
-{
-        local retval=1
-        if [ ! -z $1 ]
-        then
-		egrep -E '^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))|:)))(%.+)?\s*$' <<< $1 > /dev/null
-                if [ $? -eq 0 ]
-                then
-                        retval=0
-                fi
-        fi
-        return $retval
-}
-
-# int is_fqdn_valid(string fqdn)
-# used to know if a given FQDN is valid (we can get the corresponding ip)
-is_fqdn_valid()
-{
-        local retval=1
-        if [ ! -z $1 ]
-        then
-                if [ `dig +short $1 | wc -l` -ne 0 ] > /dev/null
-                then
-                        retval=0
-                fi
-        fi
-        return $retval
 }
 
 
@@ -533,6 +437,5 @@ case $__OCF_ACTION in
 esac
 rc=$?
 
-# The resource agent may optionally log a debug message
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION returned $rc"
 exit $rc

--- a/heartbeat/sshtunnel
+++ b/heartbeat/sshtunnel
@@ -33,7 +33,7 @@ OCF_RESKEY_tunnel_stop_timeout_default="5"
 [ -z "$OCF_RESKEY_ssh_parameters" ] && OCF_RESKEY_ssh_parameters=$OCF_RESKEY_ssh_parameters_default
 [ -z "$OCF_RESKEY_tunnel_cluster_nodes" ] && OCF_RESKEY_tunnel_cluster_nodes=$OCF_RESKEY_tunnel_cluster_nodes_default
 [ -z "$OCF_RESKEY_tunnel_server_list" ] && OCF_RESKEY_tunnel_server_list=$OCF_RESKEY_tunnel_server_list_default
-[ -z "$OCF_RESKEY_tunnel_pid_dir" ] && OCF_RESKEY_pid_dir=$OCF_RESKEY_pid_dir_default
+[ -z "$OCF_RESKEY_pid_dir" ] && OCF_RESKEY_pid_dir=$OCF_RESKEY_pid_dir_default
 [ -z "$OCF_RESKEY_default_user" ] && OCF_RESKEY_default_user=$OCF_RESKEY_default_user_default
 [ -z "$OCF_RESKEY_tunnel_stop_timeout" ] && OCF_RESKEY_tunnel_stop_timeout=$OCF_RESKEY_tunnel_stop_timeout_default
 

--- a/heartbeat/sshtunnel
+++ b/heartbeat/sshtunnel
@@ -35,7 +35,7 @@ OCF_RESKEY_tunnel_stop_timeout_default="5"
 [ -z "$OCF_RESKEY_tunnel_server_list" ] && OCF_RESKEY_tunnel_server_list=$OCF_RESKEY_tunnel_server_list_default
 [ -z "$OCF_RESKEY_tunnel_pid_dir" ] && OCF_RESKEY_pid_dir=$OCF_RESKEY_pid_dir_default
 [ -z "$OCF_RESKEY_default_user" ] && OCF_RESKEY_default_user=$OCF_RESKEY_default_user_default
-[ -z "$OCF_RESKEY_tunnel_stop_timeout" ] && OCF_RESKEY_stop_timeout=$OCF_RESKEY_stop_timeout_default
+[ -z "$OCF_RESKEY_tunnel_stop_timeout" ] && OCF_RESKEY_tunnel_stop_timeout=$OCF_RESKEY_tunnel_stop_timeout_default
 
 #########################################
 #########################################


### PR DESCRIPTION
This new resource agent adds functionality to automatically create ssh connections (tunnels)
between all configured pacemaker nodes and/or other ssh servers.
By using this RA, the admin could benefit from using transparent ssh, connection multiplexing and
other advantages of ssh prestablished connections.

I rewrite some code as fghass asked for.

The basics of this RA:
It get information about how many and the name of every node in the pacemaker cluster.
Then it creates a SSH connection to every node, except the local node executing the RA.

If you deploy this as a clone, you will get all nodes connected via SSH. If you previously configured your ssh clients and servers properly (key exchange, enable multiplexing, etc..) all tools and services running in the cluster that are based on SSH will benefit from this previously stablished connection (tunnel): those services maybe rsync, recurrent scp, remote commands, and others.
Also, it can connect to other external ssh servers (none of the cluster nodes) so it's easy to deploy vpn-like ssh tunnels and have it in HA.
Both options at the same time, or just one of two, (pacemaker nodes interconnect and external ssh servers connection) is possible as well.

There is no concrete problem to solve but (from my point of view) a nice, interesting and optional functionality.