### PR TITLE
Low : nfsserver : add a new parameter for specify the rpc_pipefs mount point

### DIFF
--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -14,6 +14,7 @@ fi
 
 DEFAULT_INIT_SCRIPT="/etc/init.d/nfsserver"
 DEFAULT_NOTIFY_CMD="/sbin/sm-notify"
+DEFAULT_RPCPIPEFS_DIR="/var/lib/nfs/rpc_pipefs"
 
 nfsserver_meta_data() {
 	cat <<END
@@ -75,6 +76,19 @@ IP addresses.
 <content type="string"/>
 </parameter>
 
+<parameter name="rpcpipefs_dir" unique="0" required="0">
+<longdesc lang="en">
+The mount point for the sunrpc file system. Default is $DEFAULT_RPCPIPEFS_DIR . 
+This script will mount(bind) nfs_shared_infodir on /var/lib/nfs/ (can not be changed),
+and this script will mount the sunrpc file system on $DEFAULT_RPCPIPEFS_DIR (default, can be changed by this parameter).
+If you want to move only rpc_pipefs/ (e.g. to keep rpc_pipefs/ local) from default , please set this value.
+</longdesc>
+<shortdesc lang="en">
+The mount point for the sunrpc file system.
+</shortdesc>
+<content type="string" default="$DEFAULT_RPCPIPEFS_DIR" />
+</parameter>
+
 </parameters>
 
 <actions>
@@ -116,6 +130,14 @@ fp="$OCF_RESKEY_nfs_shared_infodir"
 : ${OCF_RESKEY_nfs_init_script="$DEFAULT_INIT_SCRIPT"}
 : ${OCF_RESKEY_nfs_notify_cmd="$DEFAULT_NOTIFY_CMD"}
 
+if [ -z ${OCF_RESKEY_rpcpipefs_dir} ]; then
+	rpcpipefs_make_dir=$fp/rpc_pipefs
+	rpcpipefs_umount_dir=${DEFAULT_RPCPIPEFS_DIR}
+else
+	rpcpipefs_make_dir=${OCF_RESKEY_rpcpipefs_dir}
+	rpcpipefs_umount_dir=${OCF_RESKEY_rpcpipefs_dir}
+fi
+
 nfsserver_monitor ()
 {
 	fn=`mktemp`
@@ -137,7 +159,7 @@ nfsserver_monitor ()
 prepare_directory ()
 {
 	[ -d "$fp" ] || mkdir -p $fp
-	[ -d "$fp/rpc_pipefs" ] || mkdir -p $fp/rpc_pipefs
+	[ -d "$rpcpipefs_make_dir" ] || mkdir -p $rpcpipefs_make_dir
 	[ -d "$fp/sm" ] || mkdir -p $fp/sm
 	[ -d "$fp/sm.ha" ] || mkdir -p $fp/sm.ha
 	[ -d "$fp/sm.bak" ] || mkdir -p $fp/sm.bak
@@ -161,8 +183,8 @@ bind_tree ()
 
 unbind_tree ()
 {
-	if `mount | grep -q "rpc_pipefs on /var/lib/nfs/rpc_pipefs"`; then
-		umount /var/lib/nfs/rpc_pipefs
+	if `mount | grep -q " on $rpcpipefs_umount_dir"`; then
+		umount -t rpc_pipefs $rpcpipefs_umount_dir
 	fi
 	if is_bound $fp /var/lib/nfs; then
 		umount /var/lib/nfs


### PR DESCRIPTION
The rpc_pipefs mount point is hard-coded in nfsserver RA (/var/lib/nfs/rpc_pipefs), so can't move rpc_pipefs to other directory.

I refered http://wiki.linux-ha.org/HaNFS to setup of HA NFS servers with nfsserver RA, but could not keep the rpc_pipefs directory local.
I solved that problem by rewriting directly the RA (/var/lib/nfs/rpc_pipefs -> /var/lib/rpc_pipefs).

So , I add a new parameter(rpcpipefs_dir) to nfsserver RA , that specify mount point of the rpc_pipefs.
New parameter's default is /var/lib/nfs/rpc_pipefs, so if new parameter is not specified, RA will work the same way as the previous.

For more infomation , please reference to description in the RA.

Thanks,
