### PR TITLE
Adding READDQUIESCENT Parameter to ldirectord

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -338,6 +338,12 @@ If defined in a virtual server section then the global value is overridden.
 
 Default: I<yes>
 
+B<readdquiescent = >B<yes> | B<no>
+
+If I<yes>, then when real or failback servers are determined
+to be down, they are readded to the kernel's LVS table with weight 0 if
+they do not exist in the table. Setting the value to no, allows manually 
+removing the realserver to manually disable all persistent connections.
 
 B<cleanstop = >B<yes> | B<no>
 
@@ -749,6 +755,7 @@ use vars qw(
 	    $CHECKCOUNT
 	    $FAILURECOUNT
 	    $QUIESCENT
+	    $READDQUIESCENT
 	    $FORKING
 	    $EMAILALERT
 	    $EMAILALERTFREQ
@@ -1255,6 +1262,7 @@ sub set_defaults
 	$MAINTDIR         = undef;
 	$NEGOTIATETIMEOUT = -1;
 	$QUIESCENT        = "no";
+	$READDQUIESCENT   = "no";
 	$SUPERVISED       = "no";
 	$SMTP             = undef;
 }
@@ -1697,6 +1705,11 @@ sub read_config
 			    or &config_error($line,
 					"quiescent must be 'yes' or 'no'");
 			$QUIESCENT = $1;
+		} elsif ($linedata  =~ /^readdquiescent\s*=\s*(.*)/) {
+			($1 eq "yes" || $1 eq "no")
+			    or &config_error($line,
+					"readdquiescent must be 'yes' or 'no'");
+			$READDQUIESCENT = $1;
 		} elsif  ($linedata  =~ /^emailalert\s*=\s*(.*)/) {
 			$EMAILALERT = read_emailalert($line, $1);
 		} elsif  ($linedata  =~ /^emailalertfreq\s*=\s*(\d*)/) {
@@ -2530,7 +2543,12 @@ sub ld_start
 	}
 
 	for my $k (keys (%$server_down)) {
-		my $v = $server_down->{$k};
+		my $v = $server_down->{$k};	
+		if ($READDQUIESCENT eq "no") {
+			# Ensure that the server is initially added
+			service_set(@$v[0], @$v[1], "up", {force => 1});
+		}
+		# Remove Server
 		service_set(@$v[0], @$v[1], "down", {force => 1});
 		delete($server_down->{$k});
 		#sleep 5;
@@ -3839,14 +3857,17 @@ sub _remove_service
 		if (defined($or)) {
 			&system_wrapper("$IPVSADM -e "
 					. "$ipvsadm_args $rforw -w 0");
+			&ld_log("Quiescent $log_args (Weight set to 0)");
+			&ld_emailalert_send("Quiescent $log_args (Weight set to 0)",
+				    $v, $rservice, $currenttime);
 		}
-		else {
+		elsif ($READDQUIESCENT eq "yes") {
 			&system_wrapper("$IPVSADM -a "
 					. "$ipvsadm_args $rforw -w 0");
-		}
-		&ld_log("Quiescent $log_args (Weight set to 0)");
-		&ld_emailalert_send("Quiescent $log_args (Weight set to 0)",
+			&ld_log("Readd Quiescent $log_args (Weight set to 0)");
+			&ld_emailalert_send("Quiescent $log_args (Weight set to 0)",
 				    $v, $rservice, $currenttime);
+		}
 	}
 	else {
 		&system_wrapper("$IPVSADM -d $ipvsadm_args");


### PR DESCRIPTION
This parameter allows modifying the behavior of ldirectord for
quiescent servers. If set to "yes" non existing quiescent servers
will be readded to the kernel's lvs table with weight zero (default).
If set to "no" such servers will not be readded allowing manual removal
of such servers.

When starting ldirectord all real servers are added to the kernel lvs table.

Reason for the Parameter:
We are using LVS for some time now very successfully. Until now we just 
used the ipvsadm command and no backend monitoring via tools like 
ldirector.
Currently we have these requirements which may be fulfilled using 
ipvsadm:
1. Adding and Removing realservers
2. Changing the weight of realservers

For technical reasons some applications have a persistance time of 8 
hours. For maintenance we usually edit the weight of the corrensponding 
realserver to 0 and wait for the persistant connections to time out over 
night. Current users can still work for the day. In emergency situations 
we remove the realserver immedietly and all persistant clients are 
redirected to new real servers.

No we would like to move to ldirectord with backend monitoring. So far 
we have tested and established the fact, that we can still use ipvsadm 
to manually modify the weight of the real server. Ldirector apparently 
does not mess with the weight as long as the state of the real server 
does not change (becomes unavailable).

For maintenance we created a maintenance directory and set 
"quiescent=yes" in Ldirectord. When putting a realserver in maintenance 
mode we just create the appropiate file in the maintenance directory and 
the Ldirectord sets the weight to 0. New connections will be delegated 
to different realservers and the old persistant connections time out 
over night.

Now the problem:
We can still remove the real server with ipvsadm manually. This would 
ensure that even the persistant connections are dropped. Unfortunately 
Ldirectord adds the server again to the virtual server with a weight of 
0. The persistant connections therefore still go on.

Modifying the ldirector configuration file is possible but much more 
complicated on a complex loadbalancer serving several hundred real 
servers.

Therefore I modified the ldirectord to disable this behavior if the global value
READDQUIESCENT = "no"
If the entry is removed from the maintenance directory the realserver is added again by ldirectord.
