### PR TITLE
ethmonitor now up to snuff

### DIFF
--- a/heartbeat/ethmonitor
+++ b/heartbeat/ethmonitor
@@ -381,7 +381,6 @@ if_check () {
 if_usage() {
 	cat <<END
 usage: $0 {start|stop|status|monitor|validate-all|meta-data}
-crm_simulate -S -L -VVV
 Expects to have a fully populated OCF RA-compliant environment set.
 END
 }


### PR DESCRIPTION
The check now properly checks for a real, active (with link) Ethernet interface, vs. just checking to see if the interface is defined.  It still has two fall-through tests if the first one fails for whatever reason.
