### PR TITLE
low: dhcpd: Add non-chroot support

### DIFF
--- a/heartbeat/dhcpd
+++ b/heartbeat/dhcpd
@@ -218,7 +218,7 @@ dhcpd_validate_all() {
 dhcpd_monitor() {
     # Assume chrooted mode is being used, but if not update the PIDF
     # variable to point to the non-chrooted PID file.
-    PIDF="$OCF_RESKEY_chrooted_path$OCF_RESKEY_pid"
+    PIDF="$OCF_RESKEY_chrooted_path/$OCF_RESKEY_pid"
 
     if ! ocf_is_true $OCF_RESKEY_chrooted ; then
 	PIDF=`dirname $OCF_RESKEY_pid`/dhcpd/`basename $OCF_RESKEY_pid`
@@ -426,7 +426,7 @@ dhcpd_start() {
     # incidentally contains the pid of a running process. If this process is not a 'dhcpd',
     # we remove the pid. (dhcpd itself only checks whether the pid is alive or not.)
 
-    PIDF="$OCF_RESKEY_chrooted_path$OCF_RESKEY_pid"
+    PIDF="$OCF_RESKEY_chrooted_path/$OCF_RESKEY_pid"
 
     if ocf_is_true $OCF_RESKEY_chrooted ; then
 	ocf_log info "Starting dhcpd [chroot] service."
@@ -477,7 +477,7 @@ dhcpd_stop () {
 	    ;;
     esac
 
-    PIDF="$OCF_RESKEY_chrooted_path$OCF_RESKEY_pid"
+    PIDF="$OCF_RESKEY_chrooted_path/$OCF_RESKEY_pid"
 
     if ! ocf_is_true $OCF_RESKEY_chrooted ; then
 	PIDF=`dirname $OCF_RESKEY_pid`/dhcpd/`basename $OCF_RESKEY_pid`


### PR DESCRIPTION
This pull request adds support for non-chroot environments within the DHCPD agent.

Note: I am submitting this against my branch, because for some reason the master branch thinks it is already in sync. However, all of the needed changes are there.
