### PR TITLE
Low: pgsql: change pgsql-status into UNKNOWN when validation is failed on stop

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1659,7 +1659,10 @@ rc=$?
 if [ $rc -ne 0 ]
 then
     case "$1" in
-        stop)    exit $OCF_SUCCESS;;
+        stop)    if is_replication; then
+                    change_pgsql_status "$NODENAME" "UNKNOWN"
+                 fi
+                 exit $OCF_SUCCESS;;
         monitor) exit $OCF_NOT_RUNNING;;
         status)  exit $OCF_NOT_RUNNING;;
         *)       exit $rc;;


### PR DESCRIPTION
change pgsql-status into UNKNOWN if slave's disk is broken and
pgsql_validate_all is failed on stop in order to pgsql-status
not remaining in HS.
