### PR TITLE
repair wrong path for ocf_root when prefix ne default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,7 +60,7 @@ if BUILD_RGMANAGER
 if BUILD_LINUX_HA
 	$(LN_S) ${CLUSTERDATA} $(DESTDIR)${OCF_RA_DIR_PREFIX}/redhat
 endif
-	$(INSTALL) -d $(DESTDIR)/$(LOGDIR)
+	$(INSTALL) -d $(DESTDIR)$(LOGDIR)
 endif
 
 dist-clean-local:

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,7 +67,20 @@ dist-clean-local:
 	rm -f autoconf automake autoheader $(TARFILES)
 
 uninstall-local:
-			rmdir $(DESTDIR)/$(LOGDIR) || :;
+if BUILD_LINUX_HA
+	rm -rf $(DESTDIR)$(HA_RSCTMPDIR)
+	rm -f ${OCF_RA_DIR_PREFIX}/heartbeat/.ocf-binaries
+	rm -f ${OCF_RA_DIR_PREFIX}/heartbeat/.ocf-directories
+	rm -f ${OCF_RA_DIR_PREFIX}/heartbeat/.ocf-returncodes
+	rm -f ${OCF_RA_DIR_PREFIX}/heartbeat/.ocf-shellfuncs
+endif
+if BUILD_RGMANAGER
+if BUILD_LINUX_HA
+	rm -rf $(DESTDIR)${OCF_RA_DIR_PREFIX}/redhat
+endif
+	rm -rf $(DESTDIR)$(LOGDIR) || :; 
+endif
+
 
 BUILT_SOURCES = .version
 .version:

--- a/configure.ac
+++ b/configure.ac
@@ -154,13 +154,11 @@ AC_ARG_WITH(initdir,
 OCF_ROOT_DIR="/usr/lib/ocf"
 AC_ARG_WITH(ocf-root,
     [  --with-ocf-root=DIR      directory for OCF scripts [${OCF_ROOT_DIR}]],
-    [ if test x"$withval" = xprefix; then OCF_ROOT_DIR=${prefix}; else
-	 OCF_ROOT_DIR="$withval"; fi ])
+    [ OCF_ROOT_DIR="$withval" ])
 HA_RSCTMPDIR=${localstatedir}/run/resource-agents
 AC_ARG_WITH(rsctmpdir,
     [  --with-rsctmpdir=DIR      directory for resource agents state files [${HA_RSCTMPDIR}]],
-    [ if test x"$withval" = xprefix; then HA_RSCTMPDIR=${prefix}; else
-	 HA_RSCTMPDIR="$withval"; fi ])
+    [ HA_RSCTMPDIR="$withval" ])
 
 AC_ARG_ENABLE([libnet],
  [  --enable-libnet 	Use libnet for ARP based funcationality, [default=try]], 
@@ -393,26 +391,18 @@ HA_VARLIBHBDIR=${localstatedir}/lib/heartbeat
 AC_DEFINE_UNQUOTED(HA_VARLIBHBDIR,"$HA_VARLIBHBDIR", Whatever this used to mean)
 AC_SUBST(HA_VARLIBHBDIR)
 
-OCF_RA_DIR="${OCF_ROOT_DIR}/resource.d/"
+OCF_RA_DIR="${OCF_ROOT_DIR}/resource.d"
 AC_DEFINE_UNQUOTED(OCF_RA_DIR,"$OCF_RA_DIR", Location for OCF RAs)
 AC_SUBST(OCF_RA_DIR)
 
-if test "${prefix}" = "/usr"; then
- OCF_RA_DIR_PREFIX="$OCF_RA_DIR"
-else
- OCF_RA_DIR_PREFIX="${prefix}/$OCF_RA_DIR"
-fi
+OCF_RA_DIR_PREFIX="$OCF_RA_DIR"
 AC_SUBST(OCF_RA_DIR_PREFIX)
 
-OCF_LIB_DIR="${OCF_ROOT_DIR}/lib/"
+OCF_LIB_DIR="${OCF_ROOT_DIR}/lib"
 AC_DEFINE_UNQUOTED(OCF_LIB_DIR,"$OCF_LIB_DIR", Location for shared code for OCF RAs)
 AC_SUBST(OCF_LIB_DIR)
 
-if test "${prefix}" = "/usr"; then
- OCF_LIB_DIR_PREFIX="$OCF_LIB_DIR"
-else
- OCF_LIB_DIR_PREFIX="${prefix}/$OCF_LIB_DIR"
-fi
+OCF_LIB_DIR_PREFIX="$OCF_LIB_DIR"
 AC_SUBST(OCF_LIB_DIR_PREFIX)
 
 dnl ===============================================
@@ -758,7 +748,7 @@ else
 		-Wno-strict-aliasing
 		-Wpointer-arith 
 		-Wstrict-prototypes
-    		-Wunsigned-char
+		-Wunsigned-char
 		-Wwrite-strings"
 
 # Additional warnings it might be nice to enable one day

--- a/configure.ac
+++ b/configure.ac
@@ -239,7 +239,7 @@ AC_SUBST(INITDIR)
 if test "${prefix}" = "/usr"; then
  INITDIRPREFIX="$INITDIR" 
 else
- INITDIRPREFIX="${prefix}/$INITDIR"
+ INITDIRPREFIX="${prefix}$INITDIR"
 fi
 
 AC_SUBST(INITDIRPREFIX)

--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -235,7 +235,9 @@ ha_log() {
           [ -n "$HA_DEBUGLOG" ]
         then
           : appending to $HA_DEBUGLOG
-          echo "$HA_LOGTAG:	"`hadate`"${*}" >> $HA_DEBUGLOG
+		  if [ "$HA_LOGFILE"x != "$HA_DEBUGLOG"x ]; then
+            echo "$HA_LOGTAG:	"`hadate`"${*}" >> $HA_DEBUGLOG
+          fi
         fi
 }
 

--- a/ldirectord/Makefile.am
+++ b/ldirectord/Makefile.am
@@ -37,7 +37,7 @@ harddir			= $(sysconfdir)/ha.d/resource.d
 
 .PHONY: install-exec-hook
 install-exec-hook:
-	$(mkinstalldirs) $(DESTDIR)$(harddir)
+	$(MKDIR_P) $(DESTDIR)$(harddir)
 	cd $(DESTDIR)$(harddir) && ln -s -f $(sbindir)/ldirectord .
 
 .PHONY: uninstall-hook

--- a/ldirectord/init.d/Makefile.am
+++ b/ldirectord/init.d/Makefile.am
@@ -25,7 +25,7 @@ initd_SCRIPTS	        = ldirectord
 
 install-initdSCRIPTS: $(initd_SCRIPTS)
 	@$(NORMAL_INSTALL)
-	$(mkinstalldirs) $(DESTDIR)$(initddir)
+	$(MKDIR_P) $(DESTDIR)$(initddir)
 	@list='$(initd_SCRIPTS)'; for p in $$list; do \
 	  f="`echo $$p|sed '$(transform)'`"; \
 	  if test -f $$p; then \


### PR DESCRIPTION
I compile resource-agents after ClusterLabs-resource-agents.
With ClusterLabs-resource-agents I use 

``` shell
export PREFIX=/opt/ha
./configure --prefix=$PREFIX --enable-fatal-warnings=no --with-daemon-user=${CLUSTER_USER} --with-daemon-group=${CLUSTER_GROUP} --with-ocf-root=$PREFIX/lib/ocf.
```

/opt/ha/include/heartbeat/glue_config.h contains now the definition of OCF_ROOT_DIR.

See below the values constructed in configure.ac when the options --prefix and/or --with-ocf-root are used.
OCF_RA_DIR_PREFIX is used in Makefile.am and the value is obviously wrong.

When the patch is used the values are "/opt/ha/lib/ocf/resource.d/" and "/opt/ha/lib/ocf/lib/".

I checked with Solaris 11U6 and openSuse 12.2.

I added some "rm .." to Makefile.am because "gmake install" produces errors with ${LN_S} when used more than once

The patch was reviewed from Fabio Di Nitto, see here http://lists.corosync.org/pipermail/discuss/2012-September/002027.html.

``` shell
# ./configure --enable-fatal-warnings=no
...
  Prefix                   = /usr
...
  OCF_ROOT_DIR             = /opt/ha/lib/ocf
  OCF_RA_DIR               = /opt/ha/lib/ocf/resource.d/
  OCF_RA_DIR_PREFIX        = /opt/ha/lib/ocf/resource.d/
  OCF_LIB_DIR              = /opt/ha/lib/ocf/lib/
  OCF_LIB_DIR_PREFIX       = /opt/ha/lib/ocf/lib/
....

# ./configure --enable-fatal-warnings=no --prefix=/opt/ha
...  
  Prefix                   = /opt/ha
...
  OCF_ROOT_DIR             = /opt/ha/lib/ocf
  OCF_RA_DIR               = /opt/ha/lib/ocf/resource.d/
  OCF_RA_DIR_PREFIX        = /opt/ha//opt/ha/lib/ocf/resource.d/
  OCF_LIB_DIR              = /opt/ha/lib/ocf/lib/
  OCF_LIB_DIR_PREFIX       = /opt/ha//opt/ha/lib/ocf/lib/
...

# ./configure --enable-fatal-warnings=no --prefix=/opt/ha --with-ocf-root=/opt/ha/lib/ocf
...
  Prefix                   = /opt/ha
...
  OCF_ROOT_DIR             = /opt/ha/lib/ocf
  OCF_RA_DIR               = /opt/ha/lib/ocf/resource.d/
  OCF_RA_DIR_PREFIX        = /opt/ha//opt/ha/lib/ocf/resource.d/
  OCF_LIB_DIR              = /opt/ha/lib/ocf/lib/
  OCF_LIB_DIR_PREFIX       = /opt/ha//opt/ha/lib/ocf/lib/
...
```
