### PR TITLE
Med: tools/sfex_lib.c: sfex_init fails on a 64 bit big endian platform

### DIFF
--- a/tools/sfex_lib.c
+++ b/tools/sfex_lib.c
@@ -52,6 +52,8 @@ unsigned long sector_size = 0;
 int
 prepare_lock (const char *device)
 {
+  int sec_tmp = 0;
+
   do {
     dev_fd = open (device, O_RDWR | O_DIRECT | O_SYNC);
     if (dev_fd == -1) {
@@ -65,7 +67,8 @@ prepare_lock (const char *device)
   }
   while (1);
 
-  ioctl(dev_fd, BLKSSZGET, &sector_size);
+  ioctl(dev_fd, BLKSSZGET, &sec_tmp);
+  sector_size = (unsigned long)sec_tmp;
   if (sector_size == 0) {
 	  cl_log(LOG_ERR, "Get sector size failed: %s\n", strerror(errno));
 	  exit(EXIT_FAILURE);


### PR DESCRIPTION
sfex_init failed on a 64 bit big endian platform.
Message at that time is the following.
 "ERROR: Failed to allocate aligned memory"

The same problem also occurs in sfex_stat,sfex_daemon that use the sfex_lib.

This issue caused by difference of the variable type.
The ioctl() system call return sector_size as a int type,
but sector_size is defined as a unsigned long type in the sfex_lib.

This patch has made the following changes to the sfex_lib.
- add a new int value(sec_tmp) for ioctl() argument.
- in after ioctl(), a new value(sec_tmp) is copied to sector_size as unsigned long.
