### PR TITLE
Add mkdir support for Filesystem mount point

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -134,7 +134,7 @@ The mount point for the filesystem.
 
 <parameter name="mkdir" required="0">
 <longdesc lang="en">
-Create the mount point directory if missing?
+Control mount point creation. If set, and the mount point directory does not exist then it will be created. If unset, a non-existant mount point directory causes an error.
 </longdesc>
 <shortdesc lang="en">mkdir?</shortdesc>
 <content type="boolean" default="no" />
@@ -529,7 +529,7 @@ Filesystem_start()
 
 	if [ ! -d "$MOUNTPOINT" ] ; then
 		if ocf_is_true "$MKDIR" ; then
-			mkdir $MOUNTPOINT
+			ocf_run mkdir -p $MOUNTPOINT
 			if [ ! -d "$MOUNTPOINT" ] ; then
 				ocf_log err "Couldn't make directory [$MOUNTPOINT] to use as a mount point"
 				exit $OCF_ERR_INSTALLED


### PR DESCRIPTION
It is useful to support the creation of the mount point for some types of configurations.

A new 'mkdir' call is implemented before the mount, based upon a new RA parameter 'mkdir' that defaults to 'no' for compatibility with previous releases.

Passed basic testing (mounts successfully both where the mount point directory is missing and already exists) but could probably do with some eyes from an RA/shell expert.
