### PR TITLE
LVM agents:  Deactivate remotely active LVs before attempting EX activat...

### DIFF
--- a/rgmanager/src/resources/lvm_by_vg.sh
+++ b/rgmanager/src/resources/lvm_by_vg.sh
@@ -367,6 +367,19 @@ function vg_start_single
 ##
 function vg_start
 {
+	local a=0
+	local results
+
+	results=(`lvs -o name,attr --noheadings $OCF_RESKEY_vg_name 2> /dev/null`)
+	while [ ! -z ${results[$a]} ]; do
+		if [[ ! ${results[$(($a + 1))]} =~ ^r ]] ||
+		   [[ ! ${results[$(($a + 1))]} =~ ^R ]]; then
+			ocf_log err "RAID LVs are not supported without an 'lv_name' specification"
+                	return $OCF_ERR_GENERIC
+		fi
+		a=$(($a + 2))
+	done
+
 	if [[ "$(vgs -o attr --noheadings $OCF_RESKEY_vg_name)" =~ .....c ]]; then
 		vg_start_clustered
 	else


### PR DESCRIPTION
These changes address rhbz729812.  When a clustered volume group is part of
an HA LVM setup (an active/passive installation), the LVs that are activated
as part of the 'clvmd' startup may cause problems with the initialization of
HA LVM.  This is because HA LVM requires that logical volumes be active
exclusively.  If a remote machine activates the LVs via the 'clvmd' init
script before the local machine runs the service manager, it will be
impossible to activate the LVs exclusively.

Should the exclusive activation fail, the solution is to first attempt to
deactivate the LVs cluster-wide (unless the LVs are open - in which case
a deactivation would obviously fail).  If the deactivation is successful,
then another attempt can be made to activate exclusively.

This isn't a perfect solution.  It is still possible for yet another machine
to attempt a 'clvmd' activation between the time we deactivate and try again
for the exclusive activation.  This does substantially close the gap for
problems though.  If this solution proves to be insufficient, then 'lvs' or
some other command will need to be given the capabilities to report whether
an LV is active remotely or not.  This would give us the ability to distiguish
between a activation that fails because '--partial' was not used and an
exclusive activation that failed because another machine has the LV open
remotely.
