### PR TITLE
Fix for cifs mounts

### DIFF
--- a/rgmanager/src/resources/utils/fs-lib.sh
+++ b/rgmanager/src/resources/utils/fs-lib.sh
@@ -295,6 +295,9 @@ is_mounted () {
 			tmp_dev="$(printf "$tmp_dev")"
 		fi
 
+		# CIFS mounts can sometimes have trailing slashes
+		# in their first field in /proc/mounts, so strip them.
+		tmp_dev="$(echo $tmp_dev | sed 's/\/*$//g')"
 		real_device "$tmp_dev"
 		tmp_dev="$REAL_DEVICE"
 


### PR DESCRIPTION
Entries for CIFS mounts can sometimes contain trailing slashes
in the device field in /proc/mounts.

For example:
$ mount
//192.168.122.1/test on /mnt type cifs (rw)
$ grep test /proc/mounts
//192.168.122.1/test/ /mnt cifs ...

This patch strips trailing slashes from device names when
reading the contents of /proc/mounts.

Resolves: rhbz#848642
Signed-off-by: Ryan McCabe rmccabe@redhat.com
