### PR TITLE
Low: pgsql: fix string processing of crm_mon's output on Pacemaker 1.1.8

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -825,7 +825,7 @@ pgsql_replication_monitor() {
 
     # I can't get master node name from $OCF_RESKEY_CRM_meta_notify_master_uname on monitor,
     # so I will get master node name using crm_mon -n
-    crm_mon -n1 | tr -d "\t" | grep -q "^${RESOURCE_NAME}:.* Master"
+    crm_mon -n1 | tr -d "\t" | tr -d " " | grep -q "^${RESOURCE_NAME}:.*Master$"
     if [ $? -ne 0 ] ; then
         # If I am Slave and Master is not exist
         ocf_log info "Master does not exist."


### PR DESCRIPTION
Replication mode dosen't work on Pacemaker 1.1.8
because the output of "crm_mon -n" is different from one
on Pacemaker 1.0.x.

So I fix string processing to work on 1.1.8 and 1.0.12.
