### PR TITLE
IPaddr2: fixing LVS support issues for IPv4/IPv6

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -781,7 +781,7 @@ ip_start() {
 	
 	if [ "$ip_status" = "no" ]; then
 		if ocf_is_true ${OCF_RESKEY_lvs_support}; then
-			for i in `find_interface $OCF_RESKEY_ip $NETMASK`; do
+			for i in `find_interface $OCF_RESKEY_ip 32`; do
 				case $i in
 				lo*)
 					remove_conflicting_loopback $OCF_RESKEY_ip 32 255.255.255.255 lo


### PR DESCRIPTION
This pull request will fix two issues below:
- 1) 8d49b4d  Medium: IPaddr2: Add parameters to control IPv6 source address selection  

This new option is necessary to be enabled in LVS Direct Routing (ldirectord) configuration for IPv6 because the linux kernel behaves slightly different from IPv4.

The problem is described in the issues below. I'm going to fix this issue using 'ip addrlabel' feature. An alternative solution is to use 'preferred_lft 0' option but I consider that using 'ip addrlabel' is preferable. The details is discussed in the issue below. 

*\*   kskmori/resource-agents#2 : IPaddr2 Dualstack LVS IPv6 Deprecated Source Address
*\*   ClusterLabs/resource-agents#68 : Allow ipv6addr to mark new address as deprecated
- 2)  06e00ab Medium: IPaddr2: fix lvs_support to work correctly.

The patch is proposed by tobiasstein in this issue:

*\* ClusterLabs/resource-agents#78 : IPaddr2 LVS_SUPPORT does not find Virtual IP on loopback interface

Although I'm still thinking that lvs_support option is no longer necessary to work with LVS, but obviously the current code does not work well, and the fix seems right.
