### PR TITLE
rhbz824153:  Add "by VG" HA-LVM support for RAID logical volumes

### DIFF
--- a/rgmanager/src/resources/lvm_by_vg.sh
+++ b/rgmanager/src/resources/lvm_by_vg.sh
@@ -41,6 +41,7 @@ function vg_owner
 
 	if [ $owner != $my_name ]; then
 		if is_node_member_clustat $owner ; then
+			ocf_log err "  $owner owns $OCF_RESKEY_vg_name and is still a cluster member"
 			return 0
 		fi
 		return 2
@@ -49,40 +50,40 @@ function vg_owner
 	return 1
 }
 
-function _strip_tags
+restore_transient_failed_pvs()
+{
+        local a=0
+        local -a results
+
+        results=(`pvs -o name,vg_name,attr --noheadings | grep $OCF_RESKEY_vg_name | grep -v 'unknown device'`)
+        while [ ! -z "${results[$a]}" ] ; do
+                if [[ ${results[$(($a + 2))]} =~ ..m ]] &&
+                   [ $OCF_RESKEY_vg_name == ${results[$(($a + 1))]} ]; then
+                        ocf_log notice "Attempting to restore missing PV, ${results[$a]} in $OCF_RESKEY_vg_name"
+                        vgextend --restoremissing $OCF_RESKEY_vg_name ${results[$a]}
+                        if [ $? -ne 0 ]; then
+                                ocf_log notice "Failed to restore ${results[$a]}"
+                        else
+                                ocf_log notice "  ${results[$a]} restored"
+                        fi
+                fi
+                a=$(($a + 3))
+        done
+}
+
+function strip_tags
 {
 	local i
 
 	for i in `vgs --noheadings -o tags $OCF_RESKEY_vg_name | sed s/","/" "/g`; do
 		ocf_log info "Stripping tag, $i"
+
+		# LVM version 2.02.98 allows changing tags if PARTIAL
 		vgchange --deltag $i $OCF_RESKEY_vg_name
 	done
 
 	if [ ! -z `vgs -o tags --noheadings $OCF_RESKEY_vg_name | tr -d ' '` ]; then
 		ocf_log err "Failed to remove ownership tags from $OCF_RESKEY_vg_name"
-		return $OCF_ERR_GENERIC
-	fi
-
-	return $OCF_SUCCESS
-}
-
-function strip_tags
-{
-	if ! _strip_tags; then
-		ocf_log notice "Attempting cleanup of $OCF_RESKEY_vg_name"
-
-		if ! vgreduce --removemissing --force --config \
-			"activation { volume_list = \"$OCF_RESKEY_vg_name\" }" \
-			$OCF_RESKEY_vg_name; then
-
-			ocf_log err "Failed to make $OCF_RESKEY_vg_name consistent"
-			return $OCF_ERR_GENERIC
-		fi
-
-		ocf_log notice "Cleanup of $OCF_RESKEY_vg_name successful"
-	fi
-	if ! _strip_tags; then
-		ocf_log err "Failed 2nd attempt to remove tags from, $OCF_RESKEY_vg_name"
 		return $OCF_ERR_GENERIC
 	fi
 
@@ -301,28 +302,50 @@ function vg_start_single
 		;;
 	esac
 
-	if ! strip_and_add_tag ||
-	   ! vgchange -ay $OCF_RESKEY_vg_name; then
+	if ! strip_and_add_tag; then
+		# Errors printed by sub-function
+		return $OCF_ERR_GENERIC
+	fi
+
+	if ! vgchange -ay $OCF_RESKEY_vg_name; then
 		ocf_log err "Failed to activate volume group, $OCF_RESKEY_vg_name"
-		ocf_log notice "Attempting cleanup of $OCF_RESKEY_vg_name"
+		ocf_log err "Attempting activation of logical volumes one-by-one."
 
-		if ! vgreduce --removemissing --force --config \
-			"activation { volume_list = \"$OCF_RESKEY_vg_name\" }" \
-			$OCF_RESKEY_vg_name; then
+		results=(`lvs -o name,attr --noheadings $OCF_RESKEY_vg_name 2> /dev/null`)
+		a=0
+		while [ ! -z ${results[$a]} ]; do
+			if [[ ${results[$(($a + 1))]} =~ r.......p ]] ||
+		   	   [[ ${results[$(($a + 1))]} =~ R.......p ]]; then
+				# Attempt "partial" activation of any RAID LVs
+				ocf_log err "Attempting partial activation of ${OCF_RESKEY_vg_name}/${results[$a]}"
+				if ! lvchange -ay --partial ${OCF_RESKEY_vg_name}/${results[$a]}; then
+					ocf_log err "Failed attempt to activate ${OCF_RESKEY_vg_name}/${results[$a]} in partial mode"
+					return $OCF_ERR_GENERIC
+				fi
+				ocf_log notice "Activation of ${OCF_RESKEY_vg_name}/${results[$a]} in partial mode succeeded"
+			elif [[ ${results[$(($a + 1))]} =~ m.......p ]] ||
+		   	     [[ ${results[$(($a + 1))]} =~ M.......p ]]; then
+				ocf_log err "Attempting repair and activation of ${OCF_RESKEY_vg_name}/${results[$a]}"
+				if ! lvconvert --repair --use-policies ${OCF_RESKEY_vg_name}/${results[$a]}; then
+					ocf_log err "Failed to repair ${OCF_RESKEY_vg_name}/${results[$a]}"
+					return $OCF_ERR_GENERIC
+				fi
+				if ! lvchange -ay ${OCF_RESKEY_vg_name}/${results[$a]}; then
+					ocf_log err "Failed to activate ${OCF_RESKEY_vg_name}/${results[$a]}"
+					return $OCF_ERR_GENERIC
+				fi
+				ocf_log notice "Repair and activation of ${OCF_RESKEY_vg_name}/${results[$a]} succeeded"
+			else
+				ocf_log err "Attempting activation of non-redundant LV ${OCF_RESKEY_vg_name}/${results[$a]}"
+				if ! lvchange -ay ${OCF_RESKEY_vg_name}/${results[$a]}; then
+					ocf_log err "Failed to activate ${OCF_RESKEY_vg_name}/${results[$a]}"
+					return $OCF_ERR_GENERIC
+				fi
+				ocf_log notice "Successfully activated non-redundant LV ${OCF_RESKEY_vg_name}/${results[$a]}"
+			fi
+			a=$(($a + 2))
+		done
 
-			ocf_log err "Failed to make $OCF_RESKEY_vg_name consistent"
-			return $OCF_ERR_GENERIC
-		fi
-
-		ocf_log notice "Cleanup of $OCF_RESKEY_vg_name successful"
-
-		if ! strip_and_add_tag ||
-		   ! vgchange -ay $OCF_RESKEY_vg_name; then
-			ocf_log err "Failed second attempt to activate $OCF_RESKEY_vg_name"
-			return $OCF_ERR_GENERIC
-		fi
-
-		ocf_log notice "Second attempt to activate $OCF_RESKEY_vg_name successful"
 		return $OCF_SUCCESS
 	else
 		# The activation commands succeeded, but did they do anything?
@@ -370,15 +393,10 @@ function vg_start
 	local a=0
 	local results
 
-	results=(`lvs -o name,attr --noheadings $OCF_RESKEY_vg_name 2> /dev/null`)
-	while [ ! -z ${results[$a]} ]; do
-		if [[ ! ${results[$(($a + 1))]} =~ ^r ]] ||
-		   [[ ! ${results[$(($a + 1))]} =~ ^R ]]; then
-			ocf_log err "RAID LVs are not supported without an 'lv_name' specification"
-                	return $OCF_ERR_GENERIC
-		fi
-		a=$(($a + 2))
-	done
+	if [[ $(vgs -o attr --noheadings $OCF_RESKEY_vg_name) =~ ...p ]]; then
+                ocf_log err "Volume group \"$OCF_RESKEY_vg_name\" has PVs marked as missing"
+                restore_transient_failed_pvs
+        fi
 
 	if [[ "$(vgs -o attr --noheadings $OCF_RESKEY_vg_name)" =~ .....c ]]; then
 		vg_start_clustered


### PR DESCRIPTION
This commit addresses rhbz824153.  Specifically, it enables the use
of RAID logical volumes in HA-LVM when using the "tagging" (i.e.
not "clvm") method.  A previous commit handled only a single logical
volume per service (i.e. "by LV"), this patch finishes the job by
handling all the LVs in a particular volume group per service (i.e. "by VG").
