### PR TITLE
Medium: IPaddr2: fix waiting the completion of IPv6 address allocation

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -667,6 +667,19 @@ run_send_arp() {
 # Run send_ua to note send ICMPv6 Unsolicited Neighbor Advertisements.
 #
 run_send_ua() {
+	# Wait until the allocated IPv6 address gets ready by checking
+	# "tentative" flag is disappeared, otherwise send_ua can not
+	# send the unsolicited advertisement requests.
+	for i in 1 2 3 4 5; do
+		$IP2UTIL -o -f $FAMILY addr show dev $NIC \
+			| grep -q -e "$OCF_RESKEY_ip/$NETMASK .* tentative"
+		[ $? -ne 0 ] && break;
+		if [ $i -eq 5 ]; then
+			ocf_log warn "$OCF_RESKEY_ip is still 'tentative' status. (ignored)"
+			break;
+		fi
+		sleep 1
+	done
 	ARGS="-i $OCF_RESKEY_arp_interval -c $OCF_RESKEY_arp_count $OCF_RESKEY_ip $NETMASK $NIC"
 	ocf_log info "$SENDUA $ARGS"
 	$SENDUA $ARGS || ocf_log err "Could not send ICMPv6 Unsolicited Neighbor Advertisements."

--- a/heartbeat/IPv6addr.c
+++ b/heartbeat/IPv6addr.c
@@ -313,18 +313,6 @@ main(int argc, char* argv[])
 	}
 
 	if (senduaflg) {
-		/* An error of bind() occurs when I don't call is_addr6_available.	*/
-		for (i = 0; i < QUERY_COUNT; i++) {
-			if (0 == is_addr6_available(&addr6)) {
-				break;
-			}
-			sleep(1);
-		}
-		if (i == QUERY_COUNT) {
-			cl_log(LOG_ERR, "failed to ping the address");
-			return OCF_ERR_GENERIC;
-		}
-
 		/* Send unsolicited advertisement packet to neighbor */
 		for (i = 0; i < count; i++) {
 			send_ua(&addr6, prov_ifname);


### PR DESCRIPTION
Make sure the IPv6 address allocation has completed by checking
a tentative flag in the ip command output rather than using ping.
Using ping may cause IPv6 duplicate address detection fail in
LVS configuration. The behavior may vary depending on the kernel version.

See below for details:
  https://github.com/ClusterLabs/resource-agents/issues/180
