### PR TITLE
Low: pgsql: support starting as Hot Standby

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -47,6 +47,7 @@ OCF_RESKEY_stop_escalate_default=30
 OCF_RESKEY_monitor_user_default=""
 OCF_RESKEY_monitor_password_default=""
 OCF_RESKEY_monitor_sql_default="select now();"
+OCF_RESKEY_check_wal_receiver_default="false"
 # Defaults for replication
 OCF_RESKEY_rep_mode_default=none
 OCF_RESKEY_node_list_default=""
@@ -76,6 +77,7 @@ OCF_RESKEY_stop_escalate_in_slave_default=30
 : ${OCF_RESKEY_monitor_user=${OCF_RESKEY_monitor_user_default}}
 : ${OCF_RESKEY_monitor_password=${OCF_RESKEY_monitor_password_default}}
 : ${OCF_RESKEY_monitor_sql=${OCF_RESKEY_monitor_sql_default}}
+: ${OCF_RESKEY_check_wal_receiver=${OCF_RESKEY_check_wal_receiver_default}}
 
 # for replication
 : ${OCF_RESKEY_rep_mode=${OCF_RESKEY_rep_mode_default}}
@@ -254,11 +256,16 @@ Number of shutdown retries (using -m fast) before resorting to -m immediate
 
 <parameter name="rep_mode" unique="0" required="0">
 <longdesc lang="en">
-Replication mode may be set to "async" or "sync".
-Both require PostgreSQL 9.1 or later.
-Once set, this parameter requires node_list, master_ip, and
+Replication mode may be set to "async" or "sync" or "slave".
+They require PostgreSQL 9.1 or later.
+Once set, "async" and "sync" require node_list, master_ip, and
 restore_command parameters,as well as configuring postgresql
 for replication (in postgresql.conf and pg_hba.conf).
+
+"slave" means that RA only makes recovery.conf before starting
+to connect to Primary which is running somewhere.
+It dosen't need Master/Slave setting.
+It requires master_ip restore_command parameters.
 </longdesc>
 <shortdesc lang="en">rep_mode</shortdesc>
 <content type="string" default="${OCF_RESKEY_rep_mode_default}" />
@@ -377,6 +384,15 @@ This is optional for replication.
 <shortdesc lang="en">stop escalation_in_slave</shortdesc>
 <content type="integer" default="${OCF_RESKEY_stop_escalate_in_slave_default}" />
 </parameter>
+
+<parameter name="check_wal_receiver" unique="0" required="0">
+<longdesc lang="en">
+If this is true, RA checks wal receiver process and notify its status
+using attribute(normal/ERROR).
+</longdesc>
+<shortdesc lang="en">check_wal_receiver</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_check_wal_receiver_default}" />
+</parameter>
 </parameters>
 
 <actions>
@@ -485,6 +501,11 @@ pgsql_real_start() {
     if [ -n "$OCF_RESKEY_socketdir" ]
     then
         check_socket_dir
+    fi
+
+    if [ "$OCF_RESKEY_rep_mode" = "slave" ]; then
+        rm -f $RECOVERY_CONF
+        make_recovery_conf || return $OCF_ERR_GENERIC
     fi
 
     # Set options passed to pg_ctl
@@ -665,6 +686,10 @@ pgsql_real_stop() {
     local count
     local stop_escalate
 
+    if ocf_is_true ${OCF_RESKEY_check_wal_receiver}; then
+        attrd_updater -n "$PGSQL_WAL_RECEIVER_STATUS_ATTR" -D -q
+    fi
+
     if ! pgsql_status
     then
         #Already stopped
@@ -776,6 +801,21 @@ pgsql_status() {
      false
 }
 
+pgsql_wal_receiver_status() {
+    local PID
+    local receiver_parent_pids
+
+    PID=`head -n 1 $PIDFILE`
+    receiver_parent_pids=`ps -ef | tr -s " " | grep "[w]al receiver process" | cut -d " " -f 3`
+    if echo "$receiver_parent_pids" | grep -q -w "$PID" ; then
+        attrd_updater -n "$PGSQL_WAL_RECEIVER_STATUS_ATTR" -v "normal" -q
+        return 0
+    fi
+    attrd_updater -n "$PGSQL_WAL_RECEIVER_STATUS_ATTR" -v "ERROR" -q
+    ocf_log warn "wal receiver process is not running"
+    return 1
+}
+
 #
 # pgsql_real_monitor
 #
@@ -792,6 +832,10 @@ pgsql_real_monitor() {
     then
         ocf_log info "PostgreSQL is down"
         return $OCF_NOT_RUNNING
+    fi
+
+    if ocf_is_true ${OCF_RESKEY_check_wal_receiver}; then
+        pgsql_wal_receiver_status
     fi
 
     if is_replication; then
@@ -1159,7 +1203,7 @@ have_master_right() {
 }
 
 is_replication() {
-    if [ "$OCF_RESKEY_rep_mode" != "none" ]; then
+    if [ "$OCF_RESKEY_rep_mode" != "none" -a "$OCF_RESKEY_rep_mode" != "slave" ]; then
         return 0
     fi
     return 1
@@ -1553,22 +1597,25 @@ pgsql_validate_all() {
         return $OCF_ERR_CONFIGURED
     fi
 
-    if is_replication; then
+    if is_replication || [ "$OCF_RESKEY_rep_mode" = "slave" ]; then
         version=`cat $OCF_RESKEY_pgdata/PG_VERSION`
         if [ `printf "$version\n9.1" | sort -n | head -1` != "9.1" ]; then
             ocf_log err "Replication mode needs PostgreSQL 9.1 or higher."
             return $OCF_ERR_INSTALLED
         fi
+        if [ ! -n "$OCF_RESKEY_master_ip" ]; then
+            ocf_log err "master_ip can't be empty."
+            return $OCF_ERR_CONFIGURED
+        fi
+    fi
+
+    if is_replication; then
         if ! ocf_is_ms; then
-            ocf_log err "Replication requires Master/Slave configuration."
+            ocf_log err "Replication(rep_mode=async or sync) requires Master/Slave configuration."
             return $OCF_ERR_CONFIGURED
         fi
         if [ ! "$OCF_RESKEY_rep_mode" = "sync" -a ! "$OCF_RESKEY_rep_mode" = "async" ]; then
             ocf_log err "Invalid rep_mode : $OCF_RESKEY_rep_mode"
-            return $OCF_ERR_CONFIGURED
-        fi
-        if [ ! -n "$OCF_RESKEY_master_ip" ]; then
-            ocf_log err "master_ip can't be empty."
             return $OCF_ERR_CONFIGURED
         fi
         if [ ! -n "$NODE_LIST" ]; then
@@ -1592,6 +1639,13 @@ pgsql_validate_all() {
         if ! mkdir -p $OCF_RESKEY_tmpdir || ! chown $OCF_RESKEY_pgdba $OCF_RESKEY_tmpdir || ! chmod 700 $OCF_RESKEY_tmpdir; then
             ocf_log err "Can't create directory $OCF_RESKEY_tmpdir or it is not readable by $OCF_RESKEY_pgdba"
             return $OCF_ERR_PERM
+        fi
+    fi
+
+    if [ "$OCF_RESKEY_rep_mode" = "slave" ]; then
+        if ocf_is_ms; then
+            ocf_log err "Replication(rep_mode=slave) requires no Master/Slave configuration."
+            return $OCF_ERR_CONFIGURED
         fi
     fi
 
@@ -1663,9 +1717,12 @@ fi
 
 PIDFILE=${OCF_RESKEY_pgdata}/postmaster.pid
 BACKUPLABEL=${OCF_RESKEY_pgdata}/backup_label
+RESOURCE_NAME=`echo $OCF_RESOURCE_INSTANCE | cut -d ":" -f 1`
+PGSQL_WAL_RECEIVER_STATUS_ATTR="${RESOURCE_NAME}-receiver-status"
+RECOVERY_CONF=${OCF_RESKEY_pgdata}/recovery.conf
+NODENAME=`uname -n | tr '[A-Z]' '[a-z]'`
 
 if is_replication; then
-    RECOVERY_CONF=${OCF_RESKEY_pgdata}/recovery.conf
     REP_MODE_CONF=${OCF_RESKEY_tmpdir}/rep_mode.conf
     PGSQL_LOCK=${OCF_RESKEY_tmpdir}/PGSQL.lock
     XLOG_NOTE_FILE=${OCF_RESKEY_tmpdir}/xlog_note
@@ -1683,13 +1740,11 @@ if is_replication; then
     CHECK_XLOG_LOC_SQL="select pg_last_xlog_replay_location(),pg_last_xlog_receive_location()"
     CHECK_REPLICATION_STATE_SQL="select application_name,upper(state),upper(sync_state) from pg_stat_replication"
 
-    RESOURCE_NAME=`echo $OCF_RESOURCE_INSTANCE | cut -d ":" -f 1`
     PGSQL_STATUS_ATTR="${RESOURCE_NAME}-status"
     PGSQL_DATA_STATUS_ATTR="${RESOURCE_NAME}-data-status"
     PGSQL_XLOG_LOC_NAME="${RESOURCE_NAME}-xlog-loc"
     PGSQL_MASTER_BASELINE="${RESOURCE_NAME}-master-baseline"
 
-    NODENAME=`uname -n | tr '[A-Z]' '[a-z]'`
     NODE_LIST=`echo $OCF_RESKEY_node_list | tr '[A-Z]' '[a-z]'`
 fi
 


### PR DESCRIPTION
I added new option to start PostgreSQL as Hot Standby.
It's useful for using replication from active site to standby site.
- rep_mode=slave starts PostgreSQL as Hot Standby to connect to Primary.
- add check_wal_receiver parameter which check wal receiver process
  and notify its status using attribut to know replication status.
