### PR TITLE
make SQUID_PIDS[2] work for systems with IPv6 as well

### DIFF
--- a/heartbeat/Squid
+++ b/heartbeat/Squid
@@ -194,7 +194,7 @@ get_pids()
 	# Seek by port
 	SQUID_PIDS[2]=$(
 		netstat -apn |
-		awk '/tcp.*[0-9]+\.[0-9]+\.+[0-9]+\.[0-9]+:'$SQUID_PORT' / && $7~/^[1-9]/ {
+		awk '/tcp.*:'$SQUID_PORT' .*LISTEN/ && $7~/^[1-9]/ {
 			sub("\\/.*", "", $7); print $7; exit}')
 }
 


### PR DESCRIPTION
When IPv6 is configured on a machine in addition to IPv4, the output of netstat looks different and the awk command in the squid ressource agent does not find anything matching, which causes SQUID_PID[2] to be empty and thus the monitor command always thinks squid is not running.

The netstat output on such a machine looks like this:

```
# netstat -anp | grep 3128
tcp        0      0 :::3128                     :::*                        LISTEN      17880/(squid-1)
```

Removing the IP matching code in the awk filter does the job, but there is another potential problem. netstat output sorts sockets in the LISTEN state before the ones in the ESTABLISHED state; that is why there is the exit command in awk. But netstat also sorts all IPv4 sockets (both, LISTEN and ESTABLISHED) before any IPv6 sockets. Thus, listening on :::3128 and at the same time having a client from the local machine connected via IPv4 would cause the PID of that client process to be parsed which is different from the main squid PID and thus the monitor command would fail again. netstat -lnp on Linux should work fine, as it lists only sockets in the LISTEN state, but the -l option is not portable to other unix derivates. A more portable solution is to match for the LISTEN string as well.

Again, output from netstat to show the problem:

```
# netstat -anp | grep 3128
tcp        0      0 127.0.0.1:45427             127.0.0.1:3128              ESTABLISHED 22922/nc            
tcp        0      0 :::3128                     :::*                        LISTEN      17880/(squid-1)     
tcp        0      0 ::ffff:127.0.0.1:3128       ::ffff:127.0.0.1:45427      ESTABLISHED 17880/(squid-1)   
```
