### PR TITLE
pound: use correct default value for control-binary

### DIFF
--- a/heartbeat/pound
+++ b/heartbeat/pound
@@ -37,7 +37,7 @@ OCF_RESKEY_pid_default=/var/run/pound_${OCF_RESKEY_name}.pid
 OCF_RESKEY_socket_path_default=/var/lib/pound/pound.cfg
 
 : ${OCF_RESKEY_binary=${OCF_RESKEY_binary_default}}
-: ${OCF_RESKEY_ctl_binary=${OCF_RESKEY_client_ctl_default}}
+: ${OCF_RESKEY_ctl_binary=${OCF_RESKEY_ctl_binary_default}}
 : ${OCF_RESKEY_pid=${OCF_RESKEY_pid_default}}
 : ${OCF_RESKEY_socket_path=${OCF_RESKEY_socket_path_default}}
 


### PR DESCRIPTION
The variable "OCF_RESKEY_ctl_binary" is initialized with the wrong value, which is always empty. Therefore you can't use op monitor without explicitly defining which ctl_binary is to be used.
