### PR TITLE
pound: No error when stopping pound and no pound is running

### DIFF
--- a/heartbeat/pound
+++ b/heartbeat/pound
@@ -231,6 +231,15 @@ pound_stop() {
 
     # kill the pound process
     pid=$(cat $OCF_RESKEY_pid)
+    ocf_run kill -s 0 $pid
+    rc=$?
+
+    if [ $rc -ne 0 ]; then
+        ocf_log warn "Pound pid is not a valid process. Assume it is already stopped"
+        rm -f $OCF_RESKEY_pid
+        return $OCF_SUCCESS
+    fi
+
     ocf_run kill -s TERM $pid
     rc=$?
 


### PR DESCRIPTION
If pound died and left over a pid-file the stop command will exit with an error code.

This patch will change that, so that it checks if a program can be found for the pid. If no program is running with the pid, the pid-file will be removed and the exit code will be "OK".
