### PR TITLE
LVM agents:  Retry VG shutdown to cope with udev collisions

### DIFF
--- a/rgmanager/src/resources/lvm_by_vg.sh
+++ b/rgmanager/src/resources/lvm_by_vg.sh
@@ -419,7 +419,16 @@ function vg_stop_clustered
 
 	#  Shut down the volume group
 	#  Do we need to make this resilient?
-	vgchange -aln $OCF_RESKEY_vg_name
+	a=0
+	while ! vgchange -aln $OCF_RESKEY_vg_name; do
+		a=$(($a + 1))
+		if [ $a -gt 10 ]; then
+			break;
+		fi
+		ocf_log err "Unable to deactivate $OCF_RESKEY_vg_name, retrying($a)"
+		sleep 1
+		which udevadm >& /dev/null && udevadm settle
+	done
 
 	#  Make sure all the logical volumes are inactive
 	active=0


### PR DESCRIPTION
When trying to shutdown a VG, a failure can occur due to udev
opening an LV.  A error with a message similar to the following
can occur:
  lvm[25454]: Can't deactivate volume group "vg1" with 1 open logical volume(s)
Allowing udev to settle and trying the operation again helps to
resolve the issue.

Helps to resolve rhbz729812.
