### PR TITLE
Handle 'named' IP listening when migrating IP address

### DIFF
--- a/heartbeat/named
+++ b/heartbeat/named
@@ -281,7 +281,14 @@ named_monitor() {
        ocf_log err "Got: $output"
        return $OCF_ERR_GENERIC
     fi
-    
+
+    if [ "$(uname)" = "Linux" ]; then
+      LISTENING_IPS=$(ip addr show | grep -o -E '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*/[0-9]*' | cut -d/ -f1 | sort | uniq )
+      NAMED_LISTENING_IPS=$(netstat -nl4 | grep -o -E '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*:53' |cut -d: -f1 | sort | uniq )
+
+      [ "$LISTENING_IPS" = "$NAMED_LISTENING_IPS" ] && ocf_log info "named listens on all ips" || named_reload
+
+    fi
     return $OCF_SUCCESS
 }
 


### PR DESCRIPTION
This adds a functionality to the monitor which should run every 10s, which
checks and compare the IPv4 addresses which the machine listen on and the IPv4
addresses which the named listen on and trigger rndc reload if needed.
