### PR TITLE
add redis resource agent script

### DIFF
--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -7,6 +7,8 @@
 : ${OCF_RESKEY_config:=/etc/redis/redis.conf}
 : ${OCF_RESKEY_user:=redis}
 : ${OCF_RESKEY_rundir:=/var/run/redis}
+: ${OCF_RESKEY_pidfile_name:=redis-server.pid}
+: ${OCF_RESKEY_socket_name:=redis.sock}
 : ${OCF_RESKEY_port:=6379}
 
 REDIS_SERVER="$OCF_RESKEY_bin"
@@ -14,8 +16,8 @@ REDIS_CLIENT="$OCF_RESKEY_client_bin"
 REDIS_CONFIG="$OCF_RESKEY_config"
 REDIS_USER="$OCF_RESKEY_user"
 REDIS_RUNDIR="$OCF_RESKEY_rundir"
-REDIS_PIDFILE="$OCF_RESKEY_rundir/redis-server.pid"
-REDIS_SOCKET="$OCF_RESKEY_rundir/redis.sock"
+REDIS_PIDFILE="$OCF_RESKEY_rundir/$OCF_RESKEY_pidfile_name"
+REDIS_SOCKET="$OCF_RESKEY_rundir/$OCF_RESKEY_socket_name"
 REDIS_REPLICATION_PORT="$OCF_RESKEY_port"
 
 function meta_data() {
@@ -73,6 +75,24 @@ Directory to store socket and pid file in
 </longdesc>
 <shortdesc lang="en">Redis var/run dir</shortdesc>
 <content type="string" default="${OCF_RESKEY_rundir}"/>
+</parameter>
+
+<parameter name="pidfile_name" unique="0" required="0">
+<longdesc lang="en">
+The filename to use for the pidfile. Will be created in the rundir. 
+Should only be a basename, not a full path.
+</longdesc>
+<shortdesc lang="en">Redis pidfile name</shortdesc>
+<content type="string" default="${OCF_RESKEY_pidfile_name}"/>
+</parameter>
+
+<parameter name="socket_name" unique="0" required="0">
+<longdesc lang="en">
+The filename to use for the socket. Will be crated in the rundir. 
+Should only be a basename, not a full path.
+</longdesc>
+<shortdesc lang="en">Redis socket name</shortdesc>
+<content type="string" default="${OCF_RESKEY_socket_name}"/>
 </parameter>
 
 <parameter name="port" unique="0" required="0">
@@ -184,7 +204,7 @@ function start() {
 
 	while true; do
 		# wait for redis to start
-		typeset -A info=
+		typeset -A info
 		while read line; do
 			[[ "$line" == "#"* ]] && continue
 			[[ "$line" != *":"* ]] && continue
@@ -226,7 +246,7 @@ function stop() {
 	pid="$(<"$REDIS_PIDFILE")"
 	kill -TERM "$pid"
 
-	for (( i=0; i<10; i++ )); do
+	while true; do
 		monitor
 		status=$?
 		if (( status == OCF_NOT_RUNNING )); then
@@ -239,15 +259,6 @@ function stop() {
 		fi
 		sleep 1
 	done
-	monitor
-	status=$?
-	if (( status == OCF_NOT_RUNNING )); then
-		crm_master_reboot -D
-		return $OCF_SUCCESS
-	fi
-
-	ocf_log err "stop: Unknown error while stopping"
-	return $OCF_ERR_GENERIC
 }
 
 function promote() {
@@ -286,6 +297,15 @@ function demote() {
 	master_host="${OCF_RESKEY_CRM_meta_notify_promote_uname// /}"
 	: "${master_host:=${OCF_RESKEY_CRM_meta_notify_master_uname// /}}"
 	master_port="${REDIS_REPLICATION_PORT}"
+
+	# The elected master has to remain a slave during startup.
+        # During this period a placeholder master host is assigned.
+	current_host=$(crm_node -n)
+	if [ "$master_host" == "$current_host" ]
+	then
+		ocf_log debug "this slave will soon become master, setting placeholder master in the meantime"
+		master_host="no-such-master"
+	fi
 	redis_client slaveof "$master_host" "$master_port"
 
 	monitor

--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -1,0 +1,368 @@
+#!/bin/bash
+
+. ${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs
+
+: ${OCF_RESKEY_bin:=/usr/bin/redis-server}
+: ${OCF_RESKEY_client_bin:=/usr/bin/redis-cli}
+: ${OCF_RESKEY_config:=/etc/redis/redis.conf}
+: ${OCF_RESKEY_user:=redis}
+: ${OCF_RESKEY_rundir:=/var/run/redis}
+: ${OCF_RESKEY_port:=6379}
+
+REDIS_SERVER="$OCF_RESKEY_bin"
+REDIS_CLIENT="$OCF_RESKEY_client_bin"
+REDIS_CONFIG="$OCF_RESKEY_config"
+REDIS_USER="$OCF_RESKEY_user"
+REDIS_RUNDIR="$OCF_RESKEY_rundir"
+REDIS_PIDFILE="$OCF_RESKEY_rundir/redis-server.pid"
+REDIS_SOCKET="$OCF_RESKEY_rundir/redis.sock"
+REDIS_REPLICATION_PORT="$OCF_RESKEY_port"
+
+function meta_data() {
+	cat <<EOI
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="redis">
+<version>1.0</version>
+
+<longdesc lang="en">
+Resource agent script for redis server. 
+
+This resource fully supports master/slave replication. The master preference of a node is determined by the 'slave_priority' parameter of the redis config.
+When taking the resource from 'unmanaged' to 'managed', the currently active master will be given a priority of 1000 (plus 1 for each active connection). The default 'slave_priority' is 100, so the master will stay master. For a slave to become master after converting the resource to managed, set a slave_priority greater than 1000.
+</longdesc>
+
+<shortdesc lang="en">Redis server</shortdesc>
+
+<parameters>
+<parameter name="bin" unique="0" required="0">
+<longdesc lang="en">
+Path to \`redis-server\`
+</longdesc>
+<shortdesc lang="en">Path to \`redis-server\`</shortdesc>
+<content type="string" default="${OCF_RESKEY_bin}" />
+</parameter>
+
+<parameter name="client_bin" unique="0" required="0">
+<longdesc lang="en">
+Path to \`redis-cli\`
+</longdesc>
+<shortdesc lang="en">Path to \`redis-cli\`</shortdesc>
+<content type="string" default="${OCF_RESKEY_client_bin}" />
+</parameter>
+
+<parameter name="config" unique="0" required="0">
+<longdesc lang="en">
+Path to 'redis.conf'
+</longdesc>
+<shortdesc lang="en">Path to 'redis.conf'</shortdesc>
+<content type="string" default="${OCF_RESKEY_config}" />
+</parameter>
+
+<parameter name="user" unique="0" required="0">
+<longdesc lang="en">
+User to run redis as
+</longdesc>
+<shortdesc lang="en">Redis user</shortdesc>
+<content type="string" default="${OCF_RESKEY_user}" />
+</parameter>
+
+<parameter name="rundir" unique="0" required="0">
+<longdesc lang="en">
+Directory to store socket and pid file in
+</longdesc>
+<shortdesc lang="en">Redis var/run dir</shortdesc>
+<content type="string" default="${OCF_RESKEY_rundir}"/>
+</parameter>
+
+<parameter name="port" unique="0" required="0">
+<longdesc lang="en">
+Port for replication client to connect to on remote server
+</longdesc>
+<shortdesc lang="en">Replication port</shortdesc>
+<content type="string" default="${OCF_RESKEY_port}"/>
+</parameter>
+</parameters>
+
+<actions>
+<action name="start" timeout="120" />
+<action name="stop" timeout="120" />
+<action name="status" timeout="60" />
+<action name="monitor" depth="0" timeout="30" interval="20" />
+<action name="monitor" role="Master" depth="0" timeout="30" interval="20" />
+<action name="monitor" role="Slave" depth="0" timeout="30" interval="60" />
+<action name="promote" timeout="120" />
+<action name="demote" timeout="120" />
+<action name="notify" timeout="90" />
+<action name="validate-all" timeout="5" />
+<action name="meta-data" timeout="5" />
+</actions>
+</resource-agent>
+EOI
+}
+
+function crm_master() {
+	"${HA_SBIN_DIR}/crm_master" -l reboot "$@"
+}
+
+function stripcr() {
+    sed 's/\r//'
+}
+
+function monitor() {
+	pid="$(<"$REDIS_PIDFILE")"
+	pidof "$REDIS_SERVER" | grep -q "\<$pid\>" || return $OCF_NOT_RUNNING
+
+	ocf_log debug "monitor: redis-server running under pid $pid"
+
+	typeset -A info
+	while read line; do
+		[[ "$line" == "#"* ]] && continue
+		[[ "$line" != *":"* ]] && continue
+		IFS=':' read -r key value <<< "$line"
+		info[$key]="$value"
+	done < <("$REDIS_CLIENT" -s "$REDIS_SOCKET" info | stripcr)
+	if [[ -z "${info[role]}" ]]; then
+		ocf_log err "monitor: Could not get role from \`$REDIS_CLIENT -s $REDIS_SOCKET info\`"
+	fi
+
+	if ocf_is_ms; then
+		# Here we see if a score has already been set.
+		score="$(crm_master --get-value --quiet)"
+		if [[ -z "$score" ]]; then
+			score="${info[slave_priority]}"
+			if [[ -z "$score" ]]; then
+				if [[ "${info[role]}" == "master" ]]; then
+					score=1000
+				else
+					score=1
+				fi
+			fi
+			score=$(( score + info[connected_clients] ))
+			#score=$(( score + ${info[connected_clients]} ))
+			ocf_log debug "monitor: Setting master score to '$score'"
+			crm_master -v "$score"
+		fi
+
+		if [[ "${info[role]}" == "master" ]]; then
+			return $OCF_RUNNING_MASTER
+		fi
+
+		if [[ -n "$CHECK_SLAVE_STATE" ]]; then
+			if [[ "${info[master_link_status]}" != "up" ]]; then
+				ocf_log err "monitor: Slave mode link has failed (link=${info[master_link_status]})"
+				return $OCF_ERR_GENERIC
+			fi
+			if [[ "${info[master_host]}" != "${OCF_RESKEY_CRM_meta_notify_master_uname}" ]]; then
+				ocf_log err "monitor: Slave mode current master does not match running master. current=${info[master_host]}, running=${OCF_RESKEY_CRM_meta_notify_master_uname}"
+				return $OCF_ERR_GENERIC
+			fi
+		fi
+	fi
+	return $OCF_SUCCESS
+}
+
+function start() {
+	monitor
+	status=$?
+
+	if (( status == OCF_SUCCESS )) || (( status == OCF_RUNNING_MASTER )); then
+		ocf_log info "start: redis is already running"
+		return $OCF_SUCCESS
+	fi
+
+	[[ ! -d "$REDIS_RUNDIR" ]] && mkdir -p "$REDIS_RUNDIR"
+	chown -R redis "$REDIS_RUNDIR"
+
+	ocf_log info "start: $REDIS_SERVER --daemonize yes --unixsocket '$REDIS_SOCKET' --pidfile '$REDIS_PIDFILE'"
+	output="$(su "$REDIS_USER" -s /bin/sh -c "cd '$REDIS_RUNDIR'; exec '$REDIS_SERVER' --daemonize yes --unixsocket '$REDIS_SOCKET' --pidfile '$REDIS_PIDFILE'" 2>&1)"
+
+	while true; do
+		# wait for redis to start
+		typeset -A info=
+		while read line; do
+			[[ "$line" == "#"* ]] && continue
+			[[ "$line" != *":"* ]] && continue
+			IFS=':' read -r key value <<< "$line"
+			info[$key]="$value"
+		done < <("$REDIS_CLIENT" -s "$REDIS_SOCKET" info | stripcr)
+
+		if (( info[loading] == 0 )); then
+			break
+		elif (( info[loading] == 1 )); then
+			sleep "${info[loading_eta_seconds]}"
+		else
+			ocf_log err "start: Unknown error waiting for redis to start"
+			return $OCF_ERR_GENERIC
+		fi
+	done
+
+	ocf_is_ms && demote # pacemaker expects resources to start in slave mode
+
+	monitor
+	status=$?
+	if (( status == OCF_SUCCESS )) || (( status == OCF_RUNNING_MASTER )); then
+		return $OCF_SUCCESS
+	fi
+
+	ocf_log err "start: Unknown error starting redis. output=${output//$'\n'/; }"
+	return $status
+}
+
+function stop() {
+	monitor
+	status=$?
+
+	if (( status == OCF_NOT_RUNNING )); then
+		ocf_log info "stop: redis is already stopped"
+		return $OCF_SUCCESS
+	fi
+
+	pid="$(<"$REDIS_PIDFILE")"
+	kill -TERM "$pid"
+
+	for (( i=0; i<10; i+ )); do
+		monitor
+		status=$?
+		if (( status == OCF_NOT_RUNNING )); then
+			crm_master -D
+			return $OCF_SUCCESS
+		fi
+		if (( status != OCF_RUNNING_MASTER )) && (( status != OCF_SUCCESS )); then
+			ocf_log err "stop: Unknown error while stopping"
+			return $OCF_ERR_GENERIC
+		fi
+		sleep 1
+	done
+	monitor
+	status=$?
+	if (( status == OCF_NOT_RUNNING )); then
+		crm_master -D
+		return $OCF_SUCCESS
+	fi
+
+	ocf_log err "stop: Unknown error while stopping"
+	return $OCF_ERR_GENERIC
+}
+
+function promote() {
+	monitor
+	status=$?
+
+	if (( status == OCF_RUNNING_MASTER )); then
+		ocf_log info "promote: Already running as master"
+		return $OCF_SUCCESS
+	elif (( status != OCF_SUCCESS )); then
+		ocf_log err "promote: Node is not running as a slave"
+		return $OCF_ERR_GENERIC
+	fi
+
+	ocf_log info "$REDIS_CLIENT -s '$REDIS_SOCKET' slaveof no one"
+	ocf_run "$REDIS_CLIENT" -s "$REDIS_SOCKET" slaveof no one
+
+	monitor
+	status=$?
+	if (( status == OCF_RUNNING_MASTER )); then
+		return $OCF_SUCCESS
+	fi
+
+	ocf_log err "promote: Unknown error while promoting to master (status=$status)"
+	return $OCF_ERR_GENERIC
+}
+
+function demote() {
+	CHECK_SLAVE_STATE=1 monitor
+	status=$?
+
+	if (( status == OCF_SUCCESS )); then
+		ocf_log info "demote: Already running as slave"
+		return $OCF_SUCCESS
+	fi
+
+	master_host="${OCF_RESKEY_CRM_meta_notify_promote_uname// /}"
+	: "${master_host:=${OCF_RESKEY_CRM_meta_notify_master_uname// /}}"
+	master_port="${REDIS_REPLICATION_PORT}"
+	ocf_log info "$REDIS_CLIENT -s '$REDIS_SOCKET' slaveof '$master_host' '$master_port'"
+	ocf_run "$REDIS_CLIENT" -s "$REDIS_SOCKET" slaveof "$master_host" "$master_port"
+
+	monitor
+	status=$?
+
+	if (( status == OCF_SUCCESS )); then
+		return $OCF_SUCCESS
+	fi
+	ocf_log err "demote: Unexpected error setting slave mode (status=$status)"
+	return $OCF_ERR_GENERIC
+}
+
+function notify() {
+	mode="${OCF_RESKEY_CRM_meta_notify_type}-${OCF_RESKEY_CRM_meta_notify_operation}"
+	case "$mode" in
+		post-demote|post-promote) # change the master
+			monitor
+			status=$?
+			if (( status == OCF_SUCCESS )); then # were a slave
+				demote
+			fi
+			;;
+	esac
+	return $OCF_SUCCESS
+}
+
+function validate() {
+	if [[ -x "$REDIS_SERVER" ]]; then
+		ocf_log err "validate: $REDIS_SERVER does not exist or is not executable"
+		return $OCF_ERR_INSTALLED
+	fi
+	if [[ -x "$REDIS_CLIENT" ]]; then
+		ocf_log err "validate: $REDIS_CLIENT does not exist or is not executable"
+		return $OCF_ERR_INSTALLED
+	fi
+	if [[ -f "$REDIS_CONFIG" ]]; then
+		ocf_log err "validate: $REDIS_CONFIG does not exist"
+		return $OCF_ERR_CONFIGURED
+	fi
+	if !  getent passwd "$REDIS_USER" &>/dev/null; then
+		ocf_log err "validate: $REDIS_USER is not a valid user"
+		return $OCF_ERR_CONFIGURED
+	fi
+}
+
+ocf_log debug "action=${1:-$__OCF_ACTION} notify_type=${OCF_RESKEY_CRM_meta_notify_type} notify_operation=${OCF_RESKEY_CRM_meta_notify_operation} master_host=${OCF_RESKEY_CRM_meta_notify_master_uname} slave_host=${OCF_RESKEY_CRM_meta_notify_slave_uname} promote_host=${OCF_RESKEY_CRM_meta_notify_promote_uname} demote_host=${OCF_RESKEY_CRM_meta_notify_demote_uname}; params: bin=${OCF_RESKEY_bin} client_bin=${OCF_RESKEY_client_bin} config=${OCF_RESKEY_config} user=${OCF_RESKEY_user} rundir=${OCF_RESKEY_rundir} port=${OCF_RESKEY_port}"
+
+case "${1:-$__OCF_ACTION}" in
+	status|monitor)
+		monitor
+		;;
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	restart)
+		stop && start
+		;;
+	promote)
+		promote
+		;;
+	demote)
+		demote
+		;;
+	notify)
+		notify
+		;;
+	meta-data)
+		meta_data
+		;;
+	validate-all)
+		validate
+		;;
+	*)
+		echo "Usage: $0 {monitor|start|stop|restart|promote|demote|notify|validate-all|meta-data}"
+		exit $OCF_ERR_UNIMPLEMENTED
+		;;
+esac
+status=$?
+ocf_log debug "exit_status=$status"
+exit $status

--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -197,7 +197,7 @@ function start() {
 	fi
 
 	[[ ! -d "$REDIS_RUNDIR" ]] && mkdir -p "$REDIS_RUNDIR"
-	chown -R redis "$REDIS_RUNDIR"
+	chown -R "$REDIS_USER" "$REDIS_RUNDIR"
 
 	ocf_log info "start: $REDIS_SERVER --daemonize yes --unixsocket '$REDIS_SOCKET' --pidfile '$REDIS_PIDFILE'"
 	output="$(su "$REDIS_USER" -s /bin/sh -c "cd '$REDIS_RUNDIR'; exec '$REDIS_SERVER' '$REDIS_CONFIG' --daemonize yes --unixsocket '$REDIS_SOCKET' --pidfile '$REDIS_PIDFILE'" 2>&1)"
@@ -253,7 +253,7 @@ function stop() {
 			crm_master_reboot -D
 			return $OCF_SUCCESS
 		fi
-		if (( status != OCF_RUNNING_MASTER )) && (( status != OCF_SUCCESS )) && (( status != OCF_ERR_GENERIC )); then # we allow OCF_ERR_GENERIC because monitor can generate an error if we probe redis in the middle of shutdown (the sucket won't be responding but the process is up)
+		if (( status != OCF_RUNNING_MASTER )) && (( status != OCF_SUCCESS )) && (( status != OCF_ERR_GENERIC )); then # we allow OCF_ERR_GENERIC because monitor can generate an error if we probe redis in the middle of shutdown (the socket won't be responding but the process is up)
 			ocf_log err "stop: Unknown error while stopping"
 			return $OCF_ERR_GENERIC
 		fi
@@ -299,13 +299,14 @@ function demote() {
 	master_port="${REDIS_REPLICATION_PORT}"
 
 	# The elected master has to remain a slave during startup.
-        # During this period a placeholder master host is assigned.
-	current_host=$(crm_node -n)
-	if [ "$master_host" == "$current_host" ]
-	then
-		ocf_log debug "this slave will soon become master, setting placeholder master in the meantime"
+	# During this period a placeholder master host is assigned.
+	current_host="$(crm_node -n)"
+	if [[ "$master_host" == "$current_host" ]]; then
 		master_host="no-such-master"
 	fi
+
+	ocf_log info "demote: Setting master to '$master_host'"
+
 	redis_client slaveof "$master_host" "$master_port"
 
 	monitor

--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -124,6 +124,7 @@ function monitor() {
 		info[$key]="$value"
 	done < <(redis_client info)
 	if [[ -z "${info[role]}" ]]; then
+		pidof "$REDIS_SERVER" | grep -q "\<$pid\>" || return $OCF_NOT_RUNNING
 		ocf_log err "monitor: Could not get role from \`$REDIS_CLIENT -s $REDIS_SOCKET info\`"
 		return $OCF_ERR_GENERIC
 	fi
@@ -232,7 +233,7 @@ function stop() {
 			crm_master_reboot -D
 			return $OCF_SUCCESS
 		fi
-		if (( status != OCF_RUNNING_MASTER )) && (( status != OCF_SUCCESS )); then
+		if (( status != OCF_RUNNING_MASTER )) && (( status != OCF_SUCCESS )) && (( status != OCF_ERR_GENERIC )); then # we allow OCF_ERR_GENERIC because monitor can generate an error if we probe redis in the middle of shutdown (the sucket won't be responding but the process is up)
 			ocf_log err "stop: Unknown error while stopping"
 			return $OCF_ERR_GENERIC
 		fi

--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -51,7 +51,7 @@ Path to \`redis-cli\`
 <content type="string" default="${OCF_RESKEY_client_bin}" />
 </parameter>
 
-<parameter name="config" unique="0" required="0">
+<parameter name="config" unique="1" required="0">
 <longdesc lang="en">
 Path to 'redis.conf'
 </longdesc>
@@ -67,7 +67,7 @@ User to run redis as
 <content type="string" default="${OCF_RESKEY_user}" />
 </parameter>
 
-<parameter name="rundir" unique="0" required="0">
+<parameter name="rundir" unique="1" required="0">
 <longdesc lang="en">
 Directory to store socket and pid file in
 </longdesc>
@@ -105,8 +105,9 @@ function crm_master() {
 	"${HA_SBIN_DIR}/crm_master" -l reboot "$@"
 }
 
-function stripcr() {
-    sed 's/\r//'
+function redis_client() {
+	ocf_log debug "redis_client: '$REDIS_CLIENT' -s '$REDIS_SOCKET' $@"
+	"$REDIS_CLIENT" -s "$REDIS_SOCKET" "$@" | sed 's/\r//'
 }
 
 function monitor() {
@@ -121,13 +122,17 @@ function monitor() {
 		[[ "$line" != *":"* ]] && continue
 		IFS=':' read -r key value <<< "$line"
 		info[$key]="$value"
-	done < <("$REDIS_CLIENT" -s "$REDIS_SOCKET" info | stripcr)
+	done < <(redis_client info)
 	if [[ -z "${info[role]}" ]]; then
 		ocf_log err "monitor: Could not get role from \`$REDIS_CLIENT -s $REDIS_SOCKET info\`"
+		return $OCF_ERR_GENERIC
 	fi
 
 	if ocf_is_ms; then
 		# Here we see if a score has already been set.
+		# If score isn't set we the redis setting 'slave_priority'.
+		# If that isn't set, we default to 1000 for a master, and 1 for slave.
+		# We then add 1 for each connected client
 		score="$(crm_master --get-value --quiet)"
 		if [[ -z "$score" ]]; then
 			score="${info[slave_priority]}"
@@ -139,7 +144,6 @@ function monitor() {
 				fi
 			fi
 			score=$(( score + info[connected_clients] ))
-			#score=$(( score + ${info[connected_clients]} ))
 			ocf_log debug "monitor: Setting master score to '$score'"
 			crm_master -v "$score"
 		fi
@@ -175,7 +179,7 @@ function start() {
 	chown -R redis "$REDIS_RUNDIR"
 
 	ocf_log info "start: $REDIS_SERVER --daemonize yes --unixsocket '$REDIS_SOCKET' --pidfile '$REDIS_PIDFILE'"
-	output="$(su "$REDIS_USER" -s /bin/sh -c "cd '$REDIS_RUNDIR'; exec '$REDIS_SERVER' --daemonize yes --unixsocket '$REDIS_SOCKET' --pidfile '$REDIS_PIDFILE'" 2>&1)"
+	output="$(su "$REDIS_USER" -s /bin/sh -c "cd '$REDIS_RUNDIR'; exec '$REDIS_SERVER' '$REDIS_CONFIG' --daemonize yes --unixsocket '$REDIS_SOCKET' --pidfile '$REDIS_PIDFILE'" 2>&1)"
 
 	while true; do
 		# wait for redis to start
@@ -185,7 +189,7 @@ function start() {
 			[[ "$line" != *":"* ]] && continue
 			IFS=':' read -r key value <<< "$line"
 			info[$key]="$value"
-		done < <("$REDIS_CLIENT" -s "$REDIS_SOCKET" info | stripcr)
+		done < <(redis_client info)
 
 		if (( info[loading] == 0 )); then
 			break
@@ -257,8 +261,7 @@ function promote() {
 		return $OCF_ERR_GENERIC
 	fi
 
-	ocf_log info "$REDIS_CLIENT -s '$REDIS_SOCKET' slaveof no one"
-	ocf_run "$REDIS_CLIENT" -s "$REDIS_SOCKET" slaveof no one
+	redis_client slaveof no one
 
 	monitor
 	status=$?
@@ -282,8 +285,7 @@ function demote() {
 	master_host="${OCF_RESKEY_CRM_meta_notify_promote_uname// /}"
 	: "${master_host:=${OCF_RESKEY_CRM_meta_notify_master_uname// /}}"
 	master_port="${REDIS_REPLICATION_PORT}"
-	ocf_log info "$REDIS_CLIENT -s '$REDIS_SOCKET' slaveof '$master_host' '$master_port'"
-	ocf_run "$REDIS_CLIENT" -s "$REDIS_SOCKET" slaveof "$master_host" "$master_port"
+	redis_client slaveof "$master_host" "$master_port"
 
 	monitor
 	status=$?

--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -101,7 +101,7 @@ Port for replication client to connect to on remote server
 EOI
 }
 
-function crm_master() {
+function crm_master_reboot() {
 	"${HA_SBIN_DIR}/crm_master" -l reboot "$@"
 }
 
@@ -133,7 +133,7 @@ function monitor() {
 		# If score isn't set we the redis setting 'slave_priority'.
 		# If that isn't set, we default to 1000 for a master, and 1 for slave.
 		# We then add 1 for each connected client
-		score="$(crm_master --get-value --quiet)"
+		score="$(crm_master_reboot --get-value --quiet)"
 		if [[ -z "$score" ]]; then
 			score="${info[slave_priority]}"
 			if [[ -z "$score" ]]; then
@@ -145,7 +145,7 @@ function monitor() {
 			fi
 			score=$(( score + info[connected_clients] ))
 			ocf_log debug "monitor: Setting master score to '$score'"
-			crm_master -v "$score"
+			crm_master_reboot -v "$score"
 		fi
 
 		if [[ "${info[role]}" == "master" ]]; then
@@ -229,7 +229,7 @@ function stop() {
 		monitor
 		status=$?
 		if (( status == OCF_NOT_RUNNING )); then
-			crm_master -D
+			crm_master_reboot -D
 			return $OCF_SUCCESS
 		fi
 		if (( status != OCF_RUNNING_MASTER )) && (( status != OCF_SUCCESS )); then
@@ -241,7 +241,7 @@ function stop() {
 	monitor
 	status=$?
 	if (( status == OCF_NOT_RUNNING )); then
-		crm_master -D
+		crm_master_reboot -D
 		return $OCF_SUCCESS
 	fi
 

--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -226,7 +226,7 @@ function stop() {
 	pid="$(<"$REDIS_PIDFILE")"
 	kill -TERM "$pid"
 
-	for (( i=0; i<10; i+ )); do
+	for (( i=0; i<10; i++ )); do
 		monitor
 		status=$?
 		if (( status == OCF_NOT_RUNNING )); then

--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -216,6 +216,12 @@ function start() {
 			break
 		elif (( info[loading] == 1 )); then
 			sleep "${info[loading_eta_seconds]}"
+		elif pidof "$REDIS_SERVER" >/dev/null; then
+			# unknown error, but the process still exists.
+			# This check is mainly because redis daemonizes before it starts listening, causing `redis-cli` to fail
+			#   See https://github.com/antirez/redis/issues/2368
+			# It's possible that the `pidof` will pick up a different redis, but in that case, the start operation will just time out
+			sleep 1
 		else
 			ocf_log err "start: Unknown error waiting for redis to start"
 			return $OCF_ERR_GENERIC


### PR DESCRIPTION
I tried some of the existing redis resource agent scripts in the pull requests here and ran into a plethora of issues so I ended up creating my own. This was written completely from scratch, not done by rewriting code from another resource agent, and as such the code is a lot simpler than the other redis scripts (less than half the size).

* It does not use `start-stop-daemon`, and thus is not dependent upon debian/ubuntu
* It properly sets the default master priority based on the `slave_priority` setting from the redis config.
* It preserves the currently running master when taking the resource from unmanaged to managed. This is important as I needed to convert a single redis server into a pacemaker master/slave cluster without shutting redis down.
* It properly starts each client up in slave mode, and wait for pacemaker to promote it to master.