### PR TITLE
Low: pgsql: fix grep failure when using pacemaker 1.0.13

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -898,7 +898,7 @@ pgsql_replication_monitor() {
 
     # I can't get master node name from $OCF_RESKEY_CRM_meta_notify_master_uname on monitor,
     # so I will get master node name using crm_mon -n
-    crm_mon -n1 | tr -d "\t" | tr -d " " | grep -q "^${RESOURCE_NAME}:.*)Master"
+    crm_mon -n1 | tr -d "\t" | tr -d " " | grep -q "^${RESOURCE_NAME}:.*[):]Master"
     if [ $? -ne 0 ] ; then
         # If I am Slave and Master is not exist
         ocf_log info "Master does not exist."


### PR DESCRIPTION
The specification of crm_mon on Pacemaker 1.0.13 is changed as below.

On 1.0.12

```
# crm_mon -n1 | grep Master
        pgsql:0 (ocf::heartbeat:pgsql) Master
```

On 1.0.13 

```
# crm_mon -n1 | grep Master
        pgsql:0 (ocf::heartbeat:pgsql): Master
```

colon is added after ")"
