### PR TITLE
High: LVM: Merge redhat lvm.sh into heartbeat LVM agent

### DIFF
--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -22,12 +22,16 @@
 #
 #	  OCF parameters are as below:
 #		OCF_RESKEY_volgrpname
-#		
+#    
 #######################################################################
 # Initialization:
 
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
+. ${OCF_FUNCTIONS_DIR}/lvm_functions.sh
+. ${OCF_FUNCTIONS_DIR}/lvm_lv.sh
+. ${OCF_FUNCTIONS_DIR}/lvm_vg.sh
+. ${OCF_FUNCTIONS_DIR}/member_util.sh
 
 #######################################################################
 
@@ -72,9 +76,30 @@ The name of volume group.
 <shortdesc lang="en">Volume group name</shortdesc>
 <content type="string" default="" />
 </parameter>
+
+<parameter name="lvname">
+<longdesc lang="en">
+Name of the logical volume being managed.  This option 
+is invalid when used in combination with 'exclusive=true' 
+unless a clustered volume group is being used with cLVM.
+</longdesc>
+<shortdesc lang="en">
+Logical Volume name (optional).
+</shortdesc>
+<content type="string"/>
+</parameter>
+
 <parameter name="exclusive" unique="0" required="0">
 <longdesc lang="en">
-If set, the volume group will be activated exclusively.
+When set, the volume group will be activated exclusively. 
+Exclusive activation works one of two ways. 
+1. For clustered volume groups, exclusive activation will use 
+clvm, make sure /etc/lvm/lvm.conf has locking_type=3. 
+2. For non-clustered volume groups (no cLVM), exclusive 
+activation will occur using LVM tags. This requires /etc/lvm/lvm.conf 
+locking_type=1 and each node to have its local hostname 
+present in lvm.conf's volume_list preceeded by @. Example. 
+volume_list = [ "@my-hostname" ]
 </longdesc>
 <shortdesc lang="en">Exclusive activation</shortdesc>
 <content type="boolean" default="false" />
@@ -82,8 +107,8 @@ If set, the volume group will be activated exclusively.
 
 <parameter name="partial_activation" unique="0" required="0">
 <longdesc lang="en">
-If set, the volume group will be activated even only partial of the physical
-volumes available. It helps to set to true, when you are using mirroring
+If set, the volume group will be activated even only partial of
+the physical volumes available. It helps to set to true, when you are using mirroring 
 logical volumes.
 </longdesc>
 <shortdesc lang="en">Activate VG even with partial PV only</shortdesc>
@@ -93,13 +118,13 @@ logical volumes.
 </parameters>
 
 <actions>
-<action name="start" timeout="30" />
-<action name="stop" timeout="30" />
-<action name="status" timeout="30" />
-<action name="monitor" depth="0" timeout="30" interval="10" />
-<action name="methods" timeout="5" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="start" timeout="30"/>
+<action name="stop" timeout="30"/>
+<action name="status" timeout="30" interval="60"/>
+<action name="monitor" depth="0" timeout="30" interval="60"/>
+<action name="methods" timeout="5"/>
+<action name="meta-data" timeout="5"/>
+<action name="validate-all" timeout="5"/>
 </actions>
 </resource-agent>
 EOF
@@ -121,244 +146,91 @@ LVM_methods() {
 EOF
 }
 
-#
-#	Return LVM status (silently)
-#
 LVM_status() {
-  local rc=1
-  loglevel="debug"
 
-  # Set the log level of the error message
-  if [ "X${2}" = "X" ]; then
-	loglevel="err"
-	if ocf_is_probe; then
-	  loglevel="warn"
-	else 
-	  if [ ${OP_METHOD} = "stop" ]; then
-	    loglevel="info"
-	  fi
+	if [ -z "$OCF_RESKEY_lvname" ]; then
+		vg_status
+	else
+		lv_status
 	fi
-  fi
-  
-  if [ -d /dev/$1 ]; then
-	test "`cd /dev/$1 && ls`" != ""
-	rc=$?
-	if [ $rc -ne 0 ]; then
-    	ocf_log err "VG $1 with no logical volumes is not supported by this RA!"
+
+	if [ $rc -eq 0 ]; then
+		echo "Volume $OCF_RESKEY_volgrpname is available (running)"
+	else
+		echo "Volume $OCF_RESKEY_volgrpname is not available (stopped)"
 	fi
-  fi
-
-  if [ $rc -ne 0 ]; then
-    	ocf_log $loglevel "LVM Volume $1 is not available (stopped)"
-  fi
-
-  if [ "X${2}" = "X" ]; then
-	# status call return
-  	return $rc
-  fi
-
-  # Report on LVM volume status to stdout...
-  if [ $rc -eq 0 ]; then
-	echo "Volume $1 is available (running)"
-  else
-	echo "Volume $1 is not available (stopped)"
-  fi
-  return $rc
 }
 
-#
-#	Monitor the volume - does it really seem to be working?
-#
-#
 LVM_monitor() {
-  if
-    LVM_status $1
-  then
-    : OK
-  else
-    ocf_log info "LVM Volume $1 is offline"
-    return $OCF_NOT_RUNNING
-  fi
-
-  return $OCF_SUCCESS
+	if [ -z "$OCF_RESKEY_lvname" ]; then
+		vg_status
+	else
+		lv_status
+	fi
 }
 
-#
-#	Enable LVM volume
-#
 LVM_start() {
-  local vgchange_options
-  local active_mode
+	verify_setup || exit 1
 
-  # TODO: This MUST run vgimport as well
-
-  ocf_log info "Activating volume group $1"
-
-  if [ "$LVM_MAJOR" -eq "1" ]; then
-	ocf_run vgscan $1
-  else
-	ocf_run vgscan
-  fi
-
-  active_mode="ly"
-  if ocf_is_true "$OCF_RESKEY_exclusive" ; then
-  	active_mode="ey"
-  fi
-  vgchange_options="-a $active_mode"
-
-  if ocf_is_true "$OCF_RESKEY_partial_activation" ; then
-	vgchange_options="$vgchange_options --partial"
-  fi
-
-  # for clones (clustered volume groups), we'll also have to force
-  # monitoring, even if disabled in lvm.conf.
-  if ocf_is_clone; then
-	vgchange_options="$vgchange_options --monitor y"
-  fi
-
-  ocf_run vgchange $vgchange_options $1 || return $OCF_ERR_GENERIC
-
-  if LVM_status $1; then
-    : OK Volume $1 activated just fine!
-    return $OCF_SUCCESS 
-  else
-    ocf_log err "LVM: $1 did not activate correctly"
-    return $OCF_NOT_RUNNING
-  fi
+	if [ -z "$OCF_RESKEY_lvname" ]; then
+		vg_start
+	else
+		lv_start
+	fi
 }
 
-#
-#	Disable the LVM volume
-#
 LVM_stop() {
-
-  vgdisplay "$1" 2>&1 | grep 'Volume group .* not found' >/dev/null && {
-    ocf_log info "Volume group $1 not found"
-    return $OCF_SUCCESS
-  }
-  ocf_log info "Deactivating volume group $1"
-  ocf_run vgchange -a ln $1 || return $OCF_ERR_GENERIC
-
-  if
-    LVM_status $1
-  then
-    ocf_log err "LVM: $1 did not stop correctly"
-    return $OCF_ERR_GENERIC 
-  fi
-
-  # TODO: This MUST run vgexport as well
-
-  return $OCF_SUCCESS
+	verify_setup
+	if [ -z "$OCF_RESKEY_lvname" ]; then
+		vg_stop
+	else
+		lv_stop
+	fi
 }
 
-#
-#	Check whether the OCF instance parameters are valid
-#
-LVM_validate_all() {
-  check_binary $AWK
-
-#	Off-the-shelf tests...  
-  VGOUT=`vgck ${VOLUME} 2>&1`
-  
-  if [ $? -ne 0 ]; then
-	ocf_log err "Volume group [$VOLUME] does not exist or contains error! ${VGOUT}"
-	exit $OCF_ERR_GENERIC
-  fi
-
-#	Double-check
-  if 
-    [ "$LVM_MAJOR" -eq "1" ]
-  then
-	VGOUT=`vgdisplay ${VOLUME} 2>&1`
-  else
-	VGOUT=`vgdisplay -v ${VOLUME} 2>&1`
-  fi
-
-  if [ $? -ne 0 ]; then
-	ocf_log err "Volume group [$VOLUME] does not exist or contains error! ${VGOUT}"
-	exit $OCF_ERR_GENERIC
-  fi
-
-  return $OCF_SUCCESS
-}
 #
 #	'main' starts here...
 #
-
-if
-  [ $# -ne 1 ]
-then
-  usage
-  exit $OCF_ERR_ARGS 
+if [ $# -ne 1 ]; then
+	usage
+	exit $OCF_ERR_ARGS 
 fi
 
 case $1 in
-  meta-data)	meta_data
+	meta-data)	meta_data
 		exit $OCF_SUCCESS;;
 
-  methods)	LVM_methods
+	methods)	LVM_methods
 		exit $?;;
 
-  usage)	usage
+	usage)	usage
 		exit $OCF_SUCCESS;;
-  *)		;;
+	*)		;;
 esac
 
-if 
-  [ -z "$OCF_RESKEY_volgrpname" ]
-then
-  ocf_log err "You must identify the volume group name!"
-  exit $OCF_ERR_CONFIGURED 
+if [ -z "$OCF_RESKEY_volgrpname" ]; then
+	ocf_log err "You must identify the volume group name!"
+	exit $OCF_ERR_CONFIGURED 
 fi
 
-# Get the LVM version number, for this to work we assume(thanks to panjiam):
-# 
-# LVM1 outputs like this
-#
-#	# vgchange --version
-#	vgchange: Logical Volume Manager 1.0.3
-#	Heinz Mauelshagen, Sistina Software  19/02/2002 (IOP 10)
-#
-# LVM2 and higher versions output in this format
-#
-#	# vgchange --version
-#	LVM version:     2.00.15 (2004-04-19)
-#	Library version: 1.00.09-ioctl (2004-03-31)
-#	Driver version:  4.1.0
-
-LVM_VERSION=`vgchange --version 2>&1 | \
-	$AWK '/Logical Volume Manager/ {print $5"\n"; exit; }
-	     /LVM version:/ {printf $3"\n"; exit;}'`
-rc=$?
-
-if
-  ( [ $rc -ne 0 ] || [ -z "$LVM_VERSION" ] )
-then
-  ocf_log err "LVM: $1 could not determine LVM version. Try 'vgchange --version' manually and modify $0 ?"
-  exit $OCF_ERR_INSTALLED
-fi
-LVM_MAJOR="${LVM_VERSION%%.*}"
-
-VOLUME=$OCF_RESKEY_volgrpname
-OP_METHOD=$1
 # What kind of method was invoked?
-case "$1" in
+case $1 in
 
-  start)	LVM_start $VOLUME
+	start)	LVM_start
 		exit $?;;
 
-  stop)		LVM_stop $VOLUME
+	stop)	LVM_stop
 		exit $?;;
 
-  status)	LVM_status $VOLUME $1
+	status)	LVM_status
 		exit $?;;
 
-  monitor)	LVM_monitor $VOLUME
+	monitor)	LVM_monitor
 		exit $?;;
 
-  validate-all)	LVM_validate_all
-		;;
+	validate-all)	verify_setup
+		exit $?;;
 
-  *)		usage
+	*)	usage
 		exit $OCF_ERR_UNIMPLEMENTED;;
 esac

--- a/heartbeat/Makefile.am
+++ b/heartbeat/Makefile.am
@@ -131,6 +131,10 @@ ocfcommon_DATA		= ocf-shellfuncs 	\
 			  ocf-returncodes 	\
  			  ocf-rarun		\
 			  apache-conf.sh 	\
+			  lvm_functions.sh	\
+			  lvm_lv.sh	\
+			  lvm_vg.sh	\
+			  member_util.sh	\
 			  http-mon.sh    	\
 			  sapdb-nosha.sh	\
 			  sapdb.sh		\

--- a/heartbeat/lvm_functions.sh
+++ b/heartbeat/lvm_functions.sh
@@ -1,0 +1,366 @@
+#!/bin/bash
+#
+# Copyright (C) 1997-2003 Sistina Software, Inc.  All rights reserved.
+# Copyright (C) 2004-2011 Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#
+
+##
+# returns mode to stdout
+#
+# 0 = normal (non-exclusive) local activation
+# 1 = tagged-exclusive activation
+# 2 = clvm-exclusive activation
+##
+get_vg_mode()
+{
+	if ocf_is_true "$OCF_RESKEY_exclusive"; then
+		if [[ "$(vgs -o attr --noheadings $OCF_RESKEY_volgrpname)" =~ .....c ]]; then
+			return 2
+		else
+			return 1
+		fi
+	else
+		return 0
+	fi
+}
+
+get_activate_options()
+{
+	local options="-a"
+
+	get_vg_mode
+	case $? in
+	0) options="${options}ly";;
+	1) options="${options}y";;
+	2) options="${options}ey";;
+	esac
+
+	if ocf_is_true "$OCF_RESKEY_partial_activation"; then
+		options="$options --partial"
+	fi
+
+	echo $options
+}
+
+is_dev_present()
+{
+	local dev=$1
+
+	#
+	# Check if all links/device nodes are present
+	#
+	if [ -h "$dev" ]; then
+		realdev=$(readlink -f $dev)
+		if [ $? -ne 0 ]; then
+			ocf_log err "Failed to follow link, $dev"
+			return $OCF_ERR_ARGS
+		fi
+
+		if [ ! -b $realdev ]; then
+			ocf_log err "Device node for $dev is not present"
+			return $OCF_ERR_GENERIC
+		fi
+	else
+		ocf_log err "Symbolic link for $dev is not present"
+		return $OCF_ERR_NOT_RUNNING
+	fi
+
+	return $OCF_SUCCESS
+}
+
+# vg_tag_owner
+#
+# Returns:
+#    1 == We are the owner
+#    2 == We can claim it
+#    0 == Owned by someone else
+function vg_tag_owner
+{
+	local owner=`vgs -o tags --noheadings $OCF_RESKEY_volgrpname | tr -d ' '`
+	local my_name=$(local_node_name)
+
+	if [ -z "$my_name" ]; then
+		ocf_log err "Unable to determine cluster node name"
+		return 0
+	fi
+
+	if [ -z "$owner" ]; then
+		# No-one owns this VG yet, so we can claim it
+		return 2
+	fi
+
+	if [ $owner != $my_name ]; then
+		if is_node_member_clustat $owner ; then
+			ocf_log err "  $owner owns $OCF_RESKEY_volgrpname and is still a cluster member"
+			return 0
+		fi
+		return 2
+	fi
+
+	return 1
+}
+
+function lvm_major_version
+{
+	# Get the LVM version number, for this to work we assume(thanks to panjiam):
+	# 
+	# LVM1 outputs like this
+	#
+	#	# vgchange --version
+	#	vgchange: Logical Volume Manager 1.0.3
+	#	Heinz Mauelshagen, Sistina Software  19/02/2002 (IOP 10)
+	#
+	# LVM2 and higher versions output in this format
+	#
+	#	# vgchange --version
+	#	LVM version:     2.00.15 (2004-04-19)
+	#	Library version: 1.00.09-ioctl (2004-03-31)
+	#	Driver version:  4.1.0
+
+	LVM_VERSION=`vgchange --version 2>&1 | \
+		$AWK '/Logical Volume Manager/ {print $5"\n"; exit; }
+		     /LVM version:/ {printf $3"\n"; exit;}'`
+	rc=$?
+
+	if
+	  ( [ $rc -ne 0 ] || [ -z "$LVM_VERSION" ] )
+	then
+	  ocf_log err "LVM: could not determine LVM version. Defaulting to version 2."
+	  return 2
+	fi
+	LVM_MAJOR="${LVM_VERSION%%.*}"
+
+	if [ "$LVM_MAJOR" -eq "1" ]; then
+		return 1
+	fi
+
+	return 2
+}
+
+function restore_transient_failed_pvs()
+{
+	local a=0
+	local -a results
+
+	results=(`pvs -o name,volgrpname,attr --noheadings | grep $OCF_RESKEY_volgrpname | grep -v 'unknown device'`)
+	while [ ! -z "${results[$a]}" ] ; do
+		if [[ ${results[$(($a + 2))]} =~ ..m ]] &&
+			[ $OCF_RESKEY_volgrpname == ${results[$(($a + 1))]} ]; then
+
+			ocf_log notice "Attempting to restore missing PV, ${results[$a]} in $OCF_RESKEY_volgrpname"
+			vgextend --restoremissing $OCF_RESKEY_volgrpname ${results[$a]}
+			if [ $? -ne 0 ]; then
+				ocf_log notice "Failed to restore ${results[$a]}"
+			else
+				ocf_log notice "  ${results[$a]} restored"
+			fi
+		fi
+		a=$(($a + 3))
+	done
+}
+
+function prep_for_activation()
+{
+	lvm_major_version
+	if [ $? -eq 1 ]; then
+		ocf_run vgscan $OCF_RESKEY_volgrpname
+	else
+		ocf_run vgscan
+	fi
+
+	if [[ $(vgs -o attr --noheadings $OCF_RESKEY_volgrpname) =~ ...p ]]; then
+		ocf_log err "Volume group \"$OCF_RESKEY_volgrpname\" has PVs marked as missing"
+		restore_transient_failed_pvs
+	fi
+}
+
+function strip_tags
+{
+	local i
+
+	for i in `vgs --noheadings -o tags $OCF_RESKEY_volgrpname | sed s/","/" "/g`; do
+		ocf_log info "Stripping tag, $i"
+
+		# LVM version 2.02.98 allows changing tags if PARTIAL
+		vgchange --deltag $i $OCF_RESKEY_volgrpname
+	done
+
+	if [ ! -z `vgs -o tags --noheadings $OCF_RESKEY_volgrpname | tr -d ' '` ]; then
+		ocf_log err "Failed to remove ownership tags from $OCF_RESKEY_volgrpname"
+		return $OCF_ERR_GENERIC
+	fi
+
+	return $OCF_SUCCESS
+}
+
+function strip_and_add_tag
+{
+	if ! strip_tags; then
+		ocf_log err "Failed to remove tags from volume group, $OCF_RESKEY_volgrpname"
+		return $OCF_ERR_GENERIC
+	fi
+
+	vgchange --addtag $(local_node_name) $OCF_RESKEY_volgrpname
+	if [ $? -ne 0 ]; then
+		ocf_log err "Failed to add ownership tag to $OCF_RESKEY_volgrpname"
+		return $OCF_ERR_GENERIC
+	fi
+
+	ocf_log info "New tag \"$(local_node_name)\" added to $OCF_RESKEY_volgrpname"
+
+	return $OCF_SUCCESS
+}
+
+function verify_exclusive_setup()
+{
+	##
+	# Having cloned lvm resources with exclusive vg activation makes no sense at all.
+	##
+	if ocf_is_clone; then
+		ocf_log_err "HA LVM: cloned lvm resources can not be activated exclusively"
+		return $OCF_ERR_CONFIGURED
+	fi
+
+	##
+	#  Are we using the "tagging" or "CLVM" variant for exclusive activation?
+	#  The CLVM variant will have the cluster attribute set.
+	##
+	if [[ "$(vgs -o attr --noheadings --config 'global{locking_type=0}' $OCF_RESKEY_volgrpname 2>/dev/null)" =~ .....c ]]; then
+		# Is clvmd running?
+		if ! ps -C clvmd >& /dev/null; then
+			ocf_log err "HA LVM: $OCF_RESKEY_volgrpname has the cluster attribute set, but 'clvmd' is not running"
+			return $OCF_ERR_GENERIC
+		fi
+		return $OCF_SUCCESS
+	fi
+
+	##
+	# The "tagging" variant is being used if we have gotten this far.
+	##
+
+	##
+	# Make sure they are not trying to activate by logical volume
+	# when tagging variant is in use.
+	##
+	if [ -n "$OCF_RESKEY_lvname" ]; then
+		# Notes on why this is not safe.
+		# When tags are being used, the entire volume group and logical volumes
+		# have to be owned by a single node, logical volumes from from the same
+		# volume group can not be split across multilple nodes unless cLVM
+		# is in use to lock the volume group metadata
+		ocf_log err "HA LVM: Only volume groups with the cluster attribute can have individual logical volumes activated exclusively."
+		ocf_log_err "The volume group, $OCF_RESKEY_volgrpname, lacks the cluster attribute."
+		ocf_log err "To correct this, remove the lv name from the config which will activate the entire group exclusively using ownership tags,"
+		ocf_log err "or convert the group, $OCF_RESKEY_volgrpname, to a cluster group which requires the use of cLVM ."
+	fi
+
+	##
+	# The default for lvm.conf:activation/volume_list is empty,
+	# this must be changed for HA LVM.
+	##
+	if ! lvm dumpconfig activation/volume_list >& /dev/null; then
+		ocf_log err "HA LVM:  Improper setup detected"
+		ocf_log err "* \"volume_list\" not specified in lvm.conf."
+		return $OCF_ERR_GENERIC
+	fi
+
+	##
+	# Machine's cluster node name must be present as
+	# a tag in lvm.conf:activation/volume_list
+	##
+	if ! lvm dumpconfig activation/volume_list | grep $(local_node_name); then
+		ocf_log err "HA LVM:  Improper setup detected"
+		ocf_log err "* @$(local_node_name) missing from \"volume_list\" in lvm.conf"
+		return $OCF_ERR_GENERIC
+	fi
+
+	##
+	# The volume group to be failed over must NOT be in
+	# lvm.conf:activation/volume_list; otherwise, machines
+	# will be able to activate the VG regardless of the tags
+	##
+	if lvm dumpconfig activation/volume_list | grep "\"$OCF_RESKEY_volgrpname\""; then
+		ocf_log err "HA LVM:  Improper setup detected"
+		ocf_log err "* $OCF_RESKEY_volgrpname found in \"volume_list\" in lvm.conf"
+		return $OCF_ERR_GENERIC
+	fi
+
+	##
+	# Next, we need to ensure that their initrd has been updated
+	# If not, the machine could boot and activate the VG outside
+	# the control of pacemaker
+	##
+	# Fixme: we might be able to perform a better check...
+	if [ "$(find /boot -name *.img -newer /etc/lvm/lvm.conf)" == "" ]; then
+		ocf_log err "HA LVM:  Improper setup detected"
+		ocf_log err "* initrd image needs to be newer than lvm.conf"
+
+		# While dangerous if not done the first time, there are many
+		# cases where we don't simply want to fail here.  Instead,
+		# keep warning until the user remakes the initrd - or has
+		# it done for them by upgrading the kernel.
+		#return $OCF_ERR_GENERIC
+	fi
+
+	return $OCF_SUCCESS
+
+}
+
+function verify_setup
+{
+	check_binary $AWK
+
+	##
+	# Off-the-shelf tests...  
+	##
+	VGOUT=`vgck ${OCF_RESKEY_volgrpname} 2>&1`
+	if [ $? -ne 0 ]; then
+		ocf_log err "Volume group [$OCF_RESKEY_volgrpname] does not exist or contains error! ${VGOUT}"
+		exit $OCF_ERR_GENERIC
+	fi
+
+	##
+	# Does the Volume Group exist?
+	#  1) User may have forgotten to create it
+	#  2) User may have misspelled it in the config file
+	##
+	lvm_major_version
+	if [ $? -eq 1 ]; then
+		VGOUT=`vgdisplay ${OCF_RESKEY_volgrpname} 2>&1`
+	else
+		VGOUT=`vgdisplay -v ${OCF_RESKEY_volgrpname} 2>&1`
+	fi
+	if [ $? -ne 0 ]; then
+		ocf_log err "Volume group [$OCF_RESKEY_volgrpname] does not exist or contains error! ${VGOUT}"
+		exit $OCF_ERR_GENERIC
+	fi
+
+	##
+	# If exclusive activation is not enabled, then
+	# further checking of proper setup is not necessary
+	##
+	if ! ocf_is_true "$OCF_RESKEY_exclusive"; then
+		return $OCF_SUCCESS;
+	fi
+
+	##
+	# exclusive activation is in use. do more checks
+	##
+	verify_exclusive_setup
+	return $?
+}
+

--- a/heartbeat/lvm_lv.sh
+++ b/heartbeat/lvm_lv.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+#
+# Copyright (C) 1997-2003 Sistina Software, Inc.  All rights reserved.
+# Copyright (C) 2004-2011 Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#
+
+function lv_status
+{
+	local lv_path=$OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname 
+	local dev="/dev/$OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname"
+
+	#
+	# Check if device is active
+	#
+	if [[ ! "$(lvs -o attr --noheadings $lv_path)" =~ ....a. ]]; then
+		return $OCF_NOT_RUNNING
+	fi
+
+	#
+	# Check if all links/device nodes are present
+	#
+	is_dev_present $dev
+	return $?
+}
+
+function lv_start_normal
+{
+	local lv_path=$OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname 
+	local lvchange_options=$(get_activate_options)
+	local res
+
+	ocf_log info "Activating logical volume $lvpath with options '$lvchange_options'"
+
+	if ! ocf_run lvchange $lvchange_options $lv_path; then
+		ocf_log err "Failed to activate logical volume, $lv_path"
+		return $OCF_ERR_GENERIC
+	fi
+
+	lv_status
+	res=$?
+	if [ $res -ne $OCF_SUCCESS ]; then
+		ocf_log err "LVM: $OCF_RESKEY_volgrpname did not activate correctly"
+		return $res
+	fi
+
+	return $OCF_SUCCESS 
+}
+
+function lv_start_exclusive
+{
+	if lv_start_normal; then
+		return $OCF_SUCCESS
+	fi
+
+	# FAILED exclusive activation:
+	# This can be caused by an LV being active remotely.
+	# Before attempting a repair effort, we should attempt
+	# to deactivate the LV cluster-wide; but only if the LV
+	# is not open.  Otherwise, it is senseless to attempt.
+	if ! [[ "$(lvs -o attr --noheadings $OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname)" =~ ....ao ]]; then
+		# We'll wait a small amount of time for some settling before
+		# attempting to deactivate.  Then the deactivate will be
+		# immediately followed by another exclusive activation attempt.
+		sleep 5
+		if ! lvchange -an $OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname; then
+			# Someone could have the device open.
+			# We can't do anything about that.
+			ocf_log err "Unable to perform required deactivation of $OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname before starting"
+			return $OCF_ERR_GENERIC
+		fi
+
+		if lv_start_normal; then
+			# Second attempt after deactivation was successful, we now
+			# have the lock exclusively
+			return $OCF_SUCCESS
+		fi
+	fi
+
+	# Failed to activate:
+	# This could be due to a device failure (or another machine could
+	# have snuck in between the deactivation/activation).  We don't yet
+	# have a mechanism to check for remote activation, so we will proceed
+	# with repair action.
+	ocf_log err "Failed to activate logical volume, $OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname"
+	ocf_log notice "Attempting cleanup of $OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname"
+
+	# This part is only necessary for mirrored logical volumes.
+	if ! lvconvert --repair --use-policies $OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname; then
+		ocf_log err "Failed to cleanup $OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname"
+		return $OCF_ERR_GENERIC
+	fi
+
+	if ! lv_start_normal; then
+		ocf_log err "Failed second attempt to activate $OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname"
+		return $OCF_ERR_GENERIC
+	fi
+
+	ocf_log notice "Second attempt to activate $OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname successful"
+	return $OCF_SUCCESS
+}
+
+function lv_start
+{
+	# scan for vg, restore transient failed pvs
+	prep_for_activation
+
+	get_vg_mode
+	case $? in
+	0) lv_start_normal;;
+	1) return $OCF_ERR_GENERIC;; # validation prevents us from ever getting here.
+	2) lv_start_exclusive;;
+	esac
+}
+
+function lv_stop
+{
+	local lv_path="$OCF_RESKEY_volgrpname/$OCF_RESKEY_lvname"
+
+	ocf_log info "Deactivating logical volume $lv_path"
+	while ! ocf_run lvchange -aln $lv_path; do
+		a=$(($a + 1))
+		if [ $a -gt 10 ]; then
+			break;
+		fi
+		ocf_log err "Unable to deactivate $OCF_RESKEY_volgrpname, retrying($a)"
+		sleep 1
+		which udevadm >& /dev/null && udevadm settle
+	done
+
+	lv_status
+	# make sure lv isn't still running
+	if [ $? -eq $OCF_SUCCESS ]; then
+		ocf_log err "LVM: $lv_path did not stop correctly."
+		return $OCF_ERR_GENERIC 
+	fi
+
+	return $OCF_SUCCESS
+}

--- a/heartbeat/lvm_vg.sh
+++ b/heartbeat/lvm_vg.sh
@@ -1,0 +1,464 @@
+#!/bin/bash
+#
+# Copyright (C) 1997-2003 Sistina Software, Inc.  All rights reserved.
+# Copyright (C) 2004-2011 Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#
+
+
+##
+# All volume group variants call into this function for status.
+# Some variants (tags) call this function and proceed with some
+# other tests as well.
+##
+function vg_status_normal
+{
+	local i
+	local dev
+	local res=$OCF_NOT_RUNNING
+
+	#
+	# Check that all LVs are active
+	#
+	for i in `lvs $OCF_RESKEY_volgrpname --noheadings -o attr`; do
+		if [[ ! $i =~ ....a. ]]; then
+			return $OCF_NOT_RUNNING
+		fi
+	done
+
+	#
+	# Check if all links/device nodes are present
+	#
+	for i in `lvs $OCF_RESKEY_volgrpname --noheadings -o name`; do
+		dev="/dev/$OCF_RESKEY_volgrpname/$i"
+
+		is_dev_present $dev
+		res=$?
+		if [ $res -ne $OCF_SUCCESS ]; then
+			# err log happens in is_dev_present
+			return $res
+		fi
+	done
+
+	return $res
+}
+
+function vg_status_tagged
+{
+	local my_name=$(local_node_name)
+	local res
+
+	vg_status_normal
+	res=$?
+	if [ $res -ne $OCF_SUCCESS ]; then
+		# errors are logged in vg_status_normal
+		return $res
+	fi
+
+	#
+	# Verify that we are the correct owner
+	#
+	vg_tag_owner
+	if [ $? -ne 1 ]; then
+		ocf_log err "WARNING: $OCF_RESKEY_volgrpname should not be active"
+		ocf_log err "WARNING: $my_name does not own $OCF_RESKEY_volgrpname"
+		ocf_log err "WARNING: Attempting shutdown of $OCF_RESKEY_volgrpname"
+
+		vgchange -an $OCF_RESKEY_volgrpname
+		return $OCF_ERR_GENERIC
+	fi
+
+	return $OCF_SUCCESS
+}
+
+##
+# Main status function for volume groups
+##
+function vg_status
+{
+	get_vg_mode
+	case $? in
+	0) vg_status_normal;;
+	1) vg_status_tagged;; # slighty different because we verify tag ownership
+	2) vg_status_normal;; # cluster exclusive is same as normal status.
+	esac
+
+	return $?
+}
+
+function vg_start_normal
+{
+	local vgchange_options=$(get_activate_options)
+	local res
+
+	ocf_log info "Activating volume group $OCF_RESKEY_volgrpname with options '$vgchange_options'"
+
+	# for clones (clustered volume groups), we'll also have to force
+	# monitoring, even if disabled in lvm.conf.
+	if ocf_is_clone; then
+		vgchange_options="$vgchange_options --monitor y"
+	fi
+
+	if ! ocf_run vgchange $vgchange_options $OCF_RESKEY_volgrpname; then
+		ocf_log err "Failed to activate volume group, $OCF_RESKEY_volgrpname"
+		return $OCF_ERR_GENERIC
+	fi
+
+	vg_status_normal
+	res=$?
+	if [ $res -ne $OCF_SUCCESS ]; then
+		ocf_log err "LVM: $OCF_RESKEY_volgrpname did not activate correctly"
+		return $res
+	fi
+
+	# OK Volume $OCF_RESKEY_volgrpname activated just fine!
+	return $OCF_SUCCESS 
+}
+
+function vg_start_exclusive
+{
+	local vgchange_options=$(get_activate_options)
+	local a
+	local results
+	local all_pvs
+	local resilience
+	local try_again=false
+
+	ocf_log info "Starting volume group, $OCF_RESKEY_volgrpname, exclusively with options '$vgchange_options'"
+
+	if ! vg_start_normal; then
+		try_again=true
+
+		# Failure to activate:
+		# This could be caused by a remotely active LV.  Before
+		# attempting any repair of the VG, we will first attempt
+		# to deactivate the VG cluster-wide.
+		# We must check for open LVs though, since these cannot
+		# be deactivated.  We have no choice but to go one-by-one.
+
+		# Allow for some settling
+		sleep 5
+
+		results=(`lvs -o name,attr --noheadings $OCF_RESKEY_volgrpname 2> /dev/null`)
+		a=0
+		while [ ! -z "${results[$a]}" ]; do
+			if [[ ! ${results[$(($a + 1))]} =~ ....ao ]]; then
+				if ! lvchange -an $OCF_RESKEY_volgrpname/${results[$a]}; then
+					ocf_log err "Unable to perform required deactivation of $OCF_RESKEY_volgrpname before starting"
+					return $OCF_ERR_GENERIC
+				fi
+			fi
+			a=$(($a + 2))
+		done
+	fi
+
+	if $try_again && ! vgchange $vgchange_options $OCF_RESKEY_volgrpname; then
+		ocf_log err "Failed to activate volume group, $OCF_RESKEY_volgrpname"
+		ocf_log notice "Attempting cleanup of $OCF_RESKEY_volgrpname"
+
+		if ! vgreduce --removemissing --force $OCF_RESKEY_volgrpname; then
+			ocf_log err "Failed to make $OCF_RESKEY_volgrpname consistent"
+			return $OCF_ERR_GENERIC
+		fi
+
+		if ! vgchange $vgchange_options $OCF_RESKEY_volgrpname; then
+			ocf_log err "Failed second attempt to activate $OCF_RESKEY_volgrpname"
+			return $OCF_ERR_GENERIC
+		fi
+
+		ocf_log notice "Second attempt to activate $OCF_RESKEY_volgrpname successful"
+		return $OCF_SUCCESS
+	else
+		# The activation commands succeeded, but did they do anything?
+		# Make sure all the logical volumes are active
+		results=(`lvs -o name,attr --noheadings 2> /dev/null $OCF_RESKEY_volgrpname`)
+		a=0
+		while [ ! -z "${results[$a]}" ]; do
+			if [[ ! ${results[$(($a + 1))]} =~ ....a. ]]; then
+				all_pvs=(`pvs --noheadings -o name 2> /dev/null`)
+				resilience=" --config devices{filter=["
+				for i in ${all_pvs[*]}; do
+					resilience=$resilience'"a|'$i'|",'
+				done
+				resilience=$resilience"\"r|.*|\"]}"
+
+				vgchange $vgchange_options $OCF_RESKEY_volgrpname $resilience
+				break
+			fi
+			a=$(($a + 2))
+		done
+
+		#  We need to check the LVs again if we made the command resilient
+		if [ ! -z "$resilience" ]; then
+			results=(`lvs -o name,attr --noheadings $OCF_RESKEY_volgrpname $resilience 2> /dev/null`)
+			a=0
+			while [ ! -z ${results[$a]} ]; do
+				if [[ ! ${results[$(($a + 1))]} =~ ....a. ]]; then
+					ocf_log err "Failed to activate $OCF_RESKEY_volgrpname"
+					return $OCF_ERR_GENERIC
+				fi
+				a=$(($a + 2))
+			done
+			ocf_log err "Orphan storage device in $OCF_RESKEY_volgrpname slowing operations"
+		fi
+	fi
+
+	return $OCF_SUCCESS
+}
+
+function vg_start_tagged
+{
+	local a
+	local results
+	local all_pvs
+	local resilience
+	local vgchange_options=$(get_activate_options)
+
+	ocf_log info "Starting volume group, $OCF_RESKEY_volgrpname, exclusively using tags with the options '$vgchange_options'"
+
+	vg_tag_owner
+	case $? in
+	0)
+		ocf_log info "Someone else owns this volume group"
+		return $OCF_ERR_GENERIC
+		;;
+	1)
+		ocf_log info "I own this volume group"
+		;;
+	2)
+		ocf_log info "I can claim this volume group"
+		;;
+	esac
+
+	if ! strip_and_add_tag; then
+		# Errors printed by sub-function
+		return $OCF_ERR_GENERIC
+	fi
+
+	if ! vgchange $vgchange_options $OCF_RESKEY_volgrpname; then
+		ocf_log err "Failed to activate volume group, $OCF_RESKEY_volgrpname"
+		ocf_log err "Attempting activation of logical volumes one-by-one."
+
+		results=(`lvs -o name,attr --noheadings $OCF_RESKEY_volgrpname 2> /dev/null`)
+		a=0
+		while [ ! -z ${results[$a]} ]; do
+			if [[ ${results[$(($a + 1))]} =~ r.......p ]] ||
+				[[ ${results[$(($a + 1))]} =~ R.......p ]]; then
+				# Attempt "partial" activation of any RAID LVs
+				ocf_log err "Attempting partial activation of ${OCF_RESKEY_volgrpname}/${results[$a]}"
+				if ! lvchange -ay --partial ${OCF_RESKEY_volgrpname}/${results[$a]}; then
+					ocf_log err "Failed attempt to activate ${OCF_RESKEY_volgrpname}/${results[$a]} in partial mode"
+					return $OCF_ERR_GENERIC
+				fi
+				ocf_log notice "Activation of ${OCF_RESKEY_volgrpname}/${results[$a]} in partial mode succeeded"
+			elif [[ ${results[$(($a + 1))]} =~ m.......p ]] ||
+				[[ ${results[$(($a + 1))]} =~ M.......p ]]; then
+				ocf_log err "Attempting repair and activation of ${OCF_RESKEY_volgrpname}/${results[$a]}"
+				if ! lvconvert --repair --use-policies ${OCF_RESKEY_volgrpname}/${results[$a]}; then
+					ocf_log err "Failed to repair ${OCF_RESKEY_volgrpname}/${results[$a]}"
+					return $OCF_ERR_GENERIC
+				fi
+				if ! lvchange -ay ${OCF_RESKEY_volgrpname}/${results[$a]}; then
+					ocf_log err "Failed to activate ${OCF_RESKEY_volgrpname}/${results[$a]}"
+					return $OCF_ERR_GENERIC
+				fi
+				ocf_log notice "Repair and activation of ${OCF_RESKEY_volgrpname}/${results[$a]} succeeded"
+			else
+				ocf_log err "Attempting activation of non-redundant LV ${OCF_RESKEY_volgrpname}/${results[$a]}"
+				if ! lvchange -ay ${OCF_RESKEY_volgrpname}/${results[$a]}; then
+					ocf_log err "Failed to activate ${OCF_RESKEY_volgrpname}/${results[$a]}"
+					return $OCF_ERR_GENERIC
+				fi
+				ocf_log notice "Successfully activated non-redundant LV ${OCF_RESKEY_volgrpname}/${results[$a]}"
+			fi
+			a=$(($a + 2))
+		done
+
+		return $OCF_SUCCESS
+	else
+		# The activation commands succeeded, but did they do anything?
+		# Make sure all the logical volumes are active
+		results=(`lvs -o name,attr --noheadings $OCF_RESKEY_volgrpname 2> /dev/null`)
+		a=0
+		while [ ! -z ${results[$a]} ]; do
+			if [[ ! ${results[$(($a + 1))]} =~ ....a. ]]; then
+				all_pvs=(`pvs --noheadings -o name 2> /dev/null`)
+				resilience=" --config devices{filter=["
+				for i in ${all_pvs[*]}; do
+					resilience=$resilience'"a|'$i'|",'
+				done
+				resilience=$resilience"\"r|.*|\"]}"
+
+				vgchange $vgchange_options $OCF_RESKEY_volgrpname $resilience
+				break
+			fi
+			a=$(($a + 2))
+		done
+
+		#  We need to check the LVs again if we made the command resilient
+		if [ ! -z "$resilience" ]; then
+			results=(`lvs -o name,attr --noheadings $OCF_RESKEY_volgrpname $resilience 2> /dev/null`)
+			a=0
+			while [ ! -z ${results[$a]} ]; do
+				if [[ ! ${results[$(($a + 1))]} =~ ....a. ]]; then
+					ocf_log err "Failed to activate $OCF_RESKEY_volgrpname"
+					return $OCF_ERR_GENERIC
+				fi
+				a=$(($a + 2))
+			done
+			ocf_log err "Orphan storage device in $OCF_RESKEY_volgrpname slowing operations"
+		fi
+	fi
+
+	return $OCF_SUCCESS
+}
+
+##
+# Main start function for volume groups
+##
+function vg_start
+{
+	# scan for vg, restore transient failed pvs
+	prep_for_activation
+
+	get_vg_mode
+	case $? in
+	0) vg_start_normal;;
+	1) vg_start_tagged;;
+	2) vg_start_exclusive;;
+	esac
+
+	return $?
+}
+
+function vg_stop_normal
+{
+	vgdisplay "$OCF_RESKEY_volgrpname" 2>&1 | grep 'Volume group .* not found' >/dev/null && {
+		ocf_log info "Volume group $OCF_RESKEY_volgrpname not found"
+		return $OCF_SUCCESS
+	}
+	ocf_log info "Deactivating volume group $OCF_RESKEY_volgrpname"
+	ocf_run vgchange -aln $OCF_RESKEY_volgrpname || return $OCF_ERR_GENERIC
+
+	vg_status_normal
+	# make sure vg isn't still running
+	if [ $? -eq $OCF_SUCCESS ]; then
+		ocf_log err "LVM: $OCF_RESKEY_volgrpname did not stop correctly"
+		return $OCF_ERR_GENERIC 
+	fi
+
+	return $OCF_SUCCESS
+}
+
+function vg_stop_exclusive
+{
+	local a
+	local results
+
+	#  Shut down the volume group
+	#  Do we need to make this resilient?
+	a=0
+	while ! vgchange -aln $OCF_RESKEY_volgrpname; do
+		a=$(($a + 1))
+		if [ $a -gt 10 ]; then
+			break;
+		fi
+		ocf_log err "Unable to deactivate $OCF_RESKEY_volgrpname, retrying($a)"
+		sleep 1
+		which udevadm >& /dev/null && udevadm settle
+	done
+
+	#  Make sure all the logical volumes are inactive
+	active=0
+	results=(`lvs -o name,attr --noheadings $OCF_RESKEY_volgrpname 2> /dev/null`)
+	a=0
+	while [ ! -z ${results[$a]} ]; do
+		if [[ ${results[$(($a + 1))]} =~ ....a. ]]; then
+			active=1
+			break
+		fi
+                a=$(($a + 2))
+	done
+
+	# lvs may not show active volumes if all PVs in VG are gone
+	dmsetup table | grep -q "^${OCF_RESKEY_volgrpname//-/--}-[^-]"
+	if [ $? -eq 0 ]; then
+		active=1
+	fi
+
+	if [ $active -ne 0 ]; then
+		ocf_log err "Logical volume $OCF_RESKEY_volgrpname/${results[$a]} failed to shutdown"
+		return $OCF_ERR_GENERIC
+	fi
+
+	return $OCF_SUCCESS
+}
+
+function vg_stop_tagged
+{
+	local a
+	local results
+
+	#  Shut down the volume group
+	#  Do we need to make this resilient?
+	vgchange -an $OCF_RESKEY_volgrpname
+
+	#  Make sure all the logical volumes are inactive
+	active=0
+	results=(`lvs -o name,attr --noheadings $OCF_RESKEY_volgrpname 2> /dev/null`)
+	a=0
+	while [ ! -z ${results[$a]} ]; do
+		if [[ ${results[$(($a + 1))]} =~ ....a. ]]; then
+			active=1
+			break
+		fi
+	        a=$(($a + 2))
+	done
+
+	# lvs may not show active volumes if all PVs in VG are gone
+	dmsetup table | grep -q "^${OCF_RESKEY_volgrpname//-/--}-[^-]"
+	if [ $? -eq 0 ]; then
+		active=1
+	fi
+
+	if [ $active -ne 0 ]; then
+		ocf_log err "Logical volume $OCF_RESKEY_volgrpname/${results[$a]} failed to shutdown"
+		return $OCF_ERR_GENERIC
+	fi
+
+	#  Make sure we are the owner before we strip the tags
+	vg_tag_owner
+	if [ $? -ne 0 ]; then
+		strip_tags
+	fi
+
+	return $OCF_SUCCESS
+}
+
+##
+# Main stop function for volume groups
+##
+function vg_stop
+{
+	get_vg_mode
+	case $? in
+	0) vg_stop_normal;;
+	1) vg_stop_tagged;;
+	2) vg_stop_exclusive;;
+	esac
+
+	return $?
+}

--- a/heartbeat/member_util.sh
+++ b/heartbeat/member_util.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# Copyright (C) 1997-2003 Sistina Software, Inc.  All rights reserved.
+# Copyright (C) 2004-2011 Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#
+
+#
+# Use corosync-quorumtool to figure out if the specified node is a member
+# of the cluster.  Returns 1 if not a member, and
+# 0 if the node is happily running.
+#
+# Tested on RHEL6 and F17  Note that the old version of this function utilized
+# clustat, which had introspection in to the configuration.
+# If a node was not found, the old version would return '2', but the only
+# consumer of this function never cared about that value.
+#
+is_node_member_clustat()
+{
+	# Still having a tag while (a) online but (b) not running pacemaker 
+	# (e.g. crm_node) or rgmanager not considered adequate for things like
+	# the LVM agent - so we use corosync-quorumtool instead.  The function
+	# name really should be changed.
+	#
+	# corosync 1.4.1 output looks like:
+	#
+	#  # corosync-quorumtool  -l
+	#  Nodeid     Name
+	#     1   rhel6-1
+	#     2   rhel6-2
+	#
+	# corosync 2.0.1 output looks like:
+	#  # corosync-quorumtool -l
+	#
+	#  Membership information
+	#  ----------------------
+	#      Nodeid      Votes Name
+	#           1          1 rhel7-1.priv.redhat.com
+	#           2          1 rhel7-2.priv.redhat.com
+	#
+	corosync-quorumtool -l | grep -v "^Nodeid" | grep -i " $1\$" &> /dev/null
+	return $?
+}
+
+
+#
+# Print the local node name to stdout
+# Returns 0 if could be found, 1 if not
+# Tested on RHEL6 (cman) and Fedora 17 (corosync/pacemaker)
+#
+local_node_name()
+{
+	local node nid localid
+
+	if which magma_tool &> /dev/null; then
+		# Use magma_tool, if available.
+		line=$(magma_tool localname | grep "^Local")
+
+		if [ -n "$line" ]; then
+			echo ${line/* = /}
+			return 0
+		fi
+	fi
+
+	if which cman_tool &> /dev/null; then
+		# Use cman_tool
+
+		line=$(cman_tool status | grep -i "Node name: $1")
+		[ -n "$line" ] || return 1
+		echo ${line/*name: /}
+		return 0
+	fi
+
+	if ! which crm_node &> /dev/null; then
+		# no crm_node? :(
+		return 2
+	fi
+
+	localid=$(crm_node -i)
+	crm_node -l | while read nid node; do
+		if [ "$nid" = "$localid" ]; then
+			echo $node
+			return 0
+		fi
+	done
+
+	return 1
+}
+


### PR DESCRIPTION
= Overview =
This is a part of a project aimed at reducing duplicate redhat
and heartbeat agent functionality.

= New Features=
This patch leaves the original LVM heartbeat functionality
intact while adding these addition features from the redhat agent.
1. Exclusive activation using volume group tags.  This feature
   allows a volume group to live on shared storage within the cluster
   without requiring the use of cLVM for metadata locking.
2. individual logical volume activation for local and cluster
   volume groups by using the new 'lvname' option.
3. Better setup validation when the 'exclusive' option is enabled.
   This patch validates that when exclusive activation is enabled, either
   a cluster volume group is in use with cLVM, or the tags variant is
   configured correctly.  These new checks also makes it impossible to
   enable the exclusive activation for cloned resources.

= Moved Functionality =
Functionality from the original heartbeat agent has moved into new
function names and files. This is a map to understanding where the
original functionality lives within the new merged agent.
- LVM_monitor and LVM_status --> vg_status_normal() in lvm_vg.sh
  The new monitor function does additional checking to verify
  both the volume group and each logical volume is correctly activated.
- LVM_start() ---> vg_start_normal() in lvm_vg.sh
- LVM_stop()  ---> vg_stop_normal() in lvm_vg.sh
- LVM_validate_all() ---> verify_setup() in lvm_functions.sh
  The new function also does the new exclusive activation setup
  validation checks.
