### PR TITLE
High: nfsserver: Cleanup shared nfs dir mount

### DIFF
--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -262,13 +262,16 @@ prepare_directory ()
 
 is_bound ()
 {
-	mount | grep -q "$1 on $2 type none (.*bind)"
-	return $?
+	if mount | grep -q "on $1 type"; then
+		return 0
+	fi
+
+	return 1
 }
 
 bind_tree ()
 {
-	if is_bound $fp /var/lib/nfs; then
+	if is_bound /var/lib/nfs; then
 		ocf_log debug "$fp is already bound to /var/lib/nfs"
 		return 0
 	fi
@@ -280,7 +283,7 @@ unbind_tree ()
 	if `mount | grep -q " on $rpcpipefs_umount_dir"`; then
 		umount -t rpc_pipefs $rpcpipefs_umount_dir
 	fi
-	if is_bound $fp /var/lib/nfs; then
+	if is_bound /var/lib/nfs; then
 		umount /var/lib/nfs
 	fi
 }


### PR DESCRIPTION
I am testing nfs-server failover using DRBD as the shared storage.  I noticed when trying to do a failover that the DRBD drive could not transition between master and slave on the two nodes because the nfsserver agent never unmounted the device from the /var/lib/nfs directory.

Apparently the way we parse the 'mount' output is either outdated or does not catch my scenario.  I've left the old method in and added another check that searches to see if the /var/lib/nfs directory is mounted to the same device as our shared directory.  This solves my situation.
