### PR TITLE
Change default location for catalina.out and catalina.pid to be in CATALINA_BASE instead of CATALINA_HOME.

### DIFF
--- a/heartbeat/tomcat
+++ b/heartbeat/tomcat
@@ -128,13 +128,13 @@ rotate_catalina_out()
 	fi
 
 	# Clean up and set permissions on required files
-	rm -rf "$CATALINA_HOME"/temp/* "$CATALINA_OUT"
+	rm -rf "$CATALINA_BASE"/temp/* "$CATALINA_OUT"
 	mkfifo -m700 "$CATALINA_OUT"
 	chown --dereference "$RESOURCE_TOMCAT_USER" "$CATALINA_OUT" || true
 
 	# -s is required because tomcat5.5's login shell is /bin/false
 	su - -s /bin/sh $RESOURCE_TOMCAT_USER \
-        	-c "$ROTATELOGS -l \"$CATALINA_HOME/logs/catalina_%F.log\" $CATALINA_ROTATETIME" \
+        	-c "$ROTATELOGS -l \"$CATALINA_BASE/logs/catalina_%F.log\" $CATALINA_ROTATETIME" \
         	< "$CATALINA_OUT" > /dev/null 2>&1 &
 }
 
@@ -365,7 +365,7 @@ Instance directory of Tomcat
 <longdesc lang="en">
 Log file name of Tomcat
 </longdesc>
-<shortdesc>Log file name of Tomcat, defaults to catalina_home/logs/catalina.out</shortdesc>
+<shortdesc>Log file name of Tomcat, defaults to catalina_base/logs/catalina.out</shortdesc>
 <content type="string" default="" />
 </parameter>
 
@@ -475,11 +475,11 @@ validate_all_tomcat()
 		port=${RESOURCE_STATUSURL##*:}
 		port=${port%%/*}
 		ocf_log debug "Tomcat port is $port"
-		ocf_log debug "grep port=\"$port\" $CATALINA_HOME/conf/server.xml"
+		ocf_log debug "grep port=\"$port\" $CATALINA_BASE/conf/server.xml"
 		if [ "$port" -gt 0 ]; then
-			grep "port=\"$port\"" $CATALINA_HOME/conf/server.xml > /dev/null 2>&1
+			grep "port=\"$port\"" $CATALINA_BASE/conf/server.xml > /dev/null 2>&1
 			if [ $? -ne 0 ]; then
-				ocf_log err "Your configured status URL specifies a port ($port), but the server does not have a connector listening to that port in $CATALINA_HOME/conf/server.xml"
+				ocf_log err "Your configured status URL specifies a port ($port), but the server does not have a connector listening to that port in $CATALINA_BASE/conf/server.xml"
 				notinstalled=1
 			fi
 		fi


### PR DESCRIPTION
If a multi-instance setup is used, CATALINA_HOME and CATALINA_BASE will differ and CATALINA_BASE is the place, where
the instance lives. CATALINA_HOME is the base for all instances, so it is not a good default location for the files
mentioned above.

If used as a single-instance setup, both variables CATALINA_HOME and CATALINA_BASE will be the same anyway.
