### PR TITLE
Med: Look for "sm-notify" in $PATH.

### DIFF
--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -13,7 +13,8 @@ else
 fi
 
 DEFAULT_INIT_SCRIPT="/etc/init.d/nfsserver"
-DEFAULT_NOTIFY_CMD="/sbin/sm-notify"
+DEFAULT_NOTIFY_CMD=`which sm-notify`
+DEFAULT_NOTIFY_CMD=${DEFAULT_NOTIFY_CMD:-"/sbin/sm-notify"}
 DEFAULT_NOTIFY_FOREGROUND="false"
 DEFAULT_RPCPIPEFS_DIR="/var/lib/nfs/rpc_pipefs"
 EXEC_MODE=0


### PR DESCRIPTION
Useful for eg. RHEL6-compatible distributions; yes, it can be specified,
but if it works "by default" it's still better.
