### PR TITLE
HA LVM should only remove missing PVs on stop when they belong to mirrors

### DIFF
--- a/rgmanager/src/resources/lvm_by_vg.sh
+++ b/rgmanager/src/resources/lvm_by_vg.sh
@@ -229,7 +229,7 @@ function vg_start_clustered
 		ocf_log err "Failed to activate volume group, $OCF_RESKEY_vg_name"
 		ocf_log notice "Attempting cleanup of $OCF_RESKEY_vg_name"
 
-		if ! vgreduce --removemissing --force $OCF_RESKEY_vg_name; then
+		if ! vgreduce --removemissing --mirrorsonly --force $OCF_RESKEY_vg_name; then
 			ocf_log err "Failed to make $OCF_RESKEY_vg_name consistent"
 			return $OCF_ERR_GENERIC
 		fi


### PR DESCRIPTION
This adds --mirrorsonly to the 3 'vgreduce --removemissing' calls in the
LVM agents.

You'll also notice that it adds another self_fence check after we fail to
remove tags.  In my previous comment, I pointed out that in the case of
single-host by_lv, after we vgreduce we then can't deactivate the logical
volume again because it doesn't exist.  This results in us executing
self_fence, which may have just been a happy accident.  But when we avoid
making metadata changes by adding --mirrorsonly, the subsequent deactivation
is still successful, and thus we miss the self_fence logic.  So, I added
another check so we still catch the failure and fence ourselves in this
situation.

Signed-off-by: John Ruemker jruemker@redhat.com
Signed-off-by: Jonthan Brassow jbrassow@redhat.com
