### PR TITLE
Want to fix "ethmonitor does not return the correct link status"

### DIFF
--- a/heartbeat/ethmonitor
+++ b/heartbeat/ethmonitor
@@ -255,7 +255,7 @@ if_init() {
 # get the link status on $NIC
 # asks ip about running (up) interfaces, returns the number of matching interface names that are up
 get_link_status () {
-	$IP2UTIL -o link show up dev "$NIC" | grep -c "$NIC"
+	$IP2UTIL -o link show up dev "$NIC" | grep -v 'NO-CARRIER' | grep -c "$NIC"
 }
 
 # returns the number of received rx packets on $NIC


### PR DESCRIPTION
The function get_link_status in ethmonitor does not return the correct link status in the following scenarios:
1). when the wire is unplugged from network interface
eth0: mtu 1500 qdisc mq state DOWN qlen 1000
2). when lower layer is down for a VLAN
vlan2@bond0: mtu 1500 qdisc noqueue state LOWERLAYERDOWN

Fix the issue NO.#235: https://github.com/ClusterLabs/resource-agents/issues/235
