### PR TITLE
Low: pgsql: fix grep failure when using pacemaker 1.1.10

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -898,7 +898,7 @@ pgsql_replication_monitor() {
 
     # I can't get master node name from $OCF_RESKEY_CRM_meta_notify_master_uname on monitor,
     # so I will get master node name using crm_mon -n
-    crm_mon -n1 | tr -d "\t" | tr -d " " | grep -q "^${RESOURCE_NAME}:.*[):]Master"
+    crm_mon -n1 | tr -d "\t" | tr -d " " | grep -q "^${RESOURCE_NAME}[(:].*[):]Master"
     if [ $? -ne 0 ] ; then
         # If I am Slave and Master is not exist
         ocf_log info "Master does not exist."


### PR DESCRIPTION
I fixed regex because "crm_mon" doesn't display meaningless IDs when using pacemaker 1.1.10.

before

```
pgsql:0   (ocf::heartbeat:pgsql): Started
```

after

```
pgsql   (ocf::heartbeat:pgsql): Started
```

ref : https://github.com/ClusterLabs/pacemaker/commit/b3f5b2de2906d52e3cb888f08143fa0ec7c48ce3#tools/crm_mon.c
