### PR TITLE
High: postgres-8: Shutdown postgres with SIGINT before forcing SIGQUIT

### DIFF
--- a/rgmanager/src/resources/postgres-8.metadata
+++ b/rgmanager/src/resources/postgres-8.metadata
@@ -77,8 +77,8 @@
     </parameters>
 
     <actions>
-        <action name="start" timeout="0"/>
-	<action name="stop" timeout="0"/>
+        <action name="start" timeout="30"/>
+	<action name="stop" timeout="30"/>
 
 	<!-- Checks to see if it''s mounted in the right place -->
 	<action name="status" interval="1m" timeout="10"/>

--- a/rgmanager/src/resources/postgres-8.sh
+++ b/rgmanager/src/resources/postgres-8.sh
@@ -33,6 +33,7 @@ declare PSQL_pid_file="`generate_name_for_pid_file`"
 declare PSQL_conf_dir="`generate_name_for_conf_dir`"
 declare PSQL_gen_config_file="$PSQL_conf_dir/postgresql.conf"
 declare PSQL_kill_timeout="5"
+declare PSQL_stop_timeout="15"
 declare PSQL_wait_after_start="2"
 
 verify_all()
@@ -172,8 +173,8 @@ stop()
 {
 	clog_service_stop $CLOG_INIT
 
-	## Send -KILL signal immediately
-	stop_generic_sigkill "$PSQL_pid_file" 0 "$PSQL_kill_timeout"
+	## Send -INT to close connections and stop.  -QUIT is used if -INT signal does not stop process.
+	stop_generic_sigkill "$PSQL_pid_file" "$PSQL_stop_timeout" "$PSQL_kill_timeout" "-INT"
 	if [ $? -ne 0 ]; then
 		clog_service_stop $CLOG_FAILED
 		return $OCF_ERR_GENERIC

--- a/rgmanager/src/resources/utils/ra-skelet.sh
+++ b/rgmanager/src/resources/utils/ra-skelet.sh
@@ -49,8 +49,13 @@ stop_generic()
 {
 	declare pid_file="$1"
 	declare stop_timeout="$2"
+	declare stop_sig="$3"
 	declare pid;
 	declare count=0;
+
+	if [ -z "$stop_sig" ]; then
+		stop_sig="-TERM"
+	fi
 
 	if [ ! -e "$pid_file" ]; then
 		clog_check_file_exist $CLOG_FAILED_NOT_FOUND "$pid_file"
@@ -76,7 +81,7 @@ stop_generic()
 		return 0;
 	fi
 
-	kill -TERM "$pid"
+	kill $stop_sig "$pid"
 
 	if [ $? -ne 0 ]; then
 		return $OCF_ERR_GENERIC
@@ -102,12 +107,16 @@ stop_generic_sigkill() {
 	declare pid_file="$1"
 	declare stop_timeout="$2"
 	declare kill_timeout="$3"
+	declare stop_sig="$4"
 	declare pid
-	
+
+	if [ -z "$stop_sig" ]; then
+		stop_sig="-TERM"
+	fi
 	## If stop_timeout is equal to zero then we do not want
 	## to give -TERM signal at all.
 	if [ $stop_timeout -ne 0 ]; then
-		stop_generic "$pid_file" "$stop_timeout"
+		stop_generic "$pid_file" "$stop_timeout" "$stop_sig"
 		if [ $? -eq 0 ]; then
 			return 0;
 		fi


### PR DESCRIPTION
SIGINT should be attempted shutdown the postgres server before
issuing a SIGQUIT to force the shutdown.  The shutdown signals
are documented here.
http://www.postgresql.org/docs/8.4/static/server-shutdown.html

Resolves: rhbz#871659
