### PR TITLE
Medium: build: Place resource state information in /var/run/... by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,20 @@ extract_header_define() {
 	  rm -f ${Cfile}.c ${Cfile}
 	}
 
+AC_MSG_NOTICE(Sanitizing prefix: ${prefix})
+case $prefix in
+  NONE)
+	prefix=/usr
+	dnl Fix default variables - "prefix" variable if not specified
+	if test "$localstatedir" = "\${prefix}/var"; then
+		localstatedir="/var"
+	fi
+	if test "$sysconfdir" = "\${prefix}/etc"; then
+		sysconfdir="/etc"
+	fi
+	;;
+esac
+
 dnl ===============================================
 dnl Configure Options
 dnl ===============================================
@@ -201,11 +215,6 @@ dnl ===============================================
 
 INIT_EXT=""
 echo Our Host OS: $host_os/$host
-
-AC_MSG_NOTICE(Sanitizing prefix: ${prefix})
-case $prefix in
-  NONE)	prefix=/usr;;
-esac
 
 AC_MSG_NOTICE(Sanitizing exec_prefix: ${exec_prefix})
 case $exec_prefix in


### PR DESCRIPTION
We need the localstatedir variable to point to /var instead of /usr/var.
This defauls the resource temporary storage to live under /var/run instead
of /usr/var/run.  This distinction is very important as the /var/run
directory is cleaned on startup in many distros, while the /usr/var/run
directory is not. By not having the resource agents place things such
as pid files into temporary storage, bad things can happen if those pid
files persist after a restart... Such as resource agents thinking they are
running after a restart because the pid file still exists and some
new process is using the same pid.
