### PR TITLE
Stop repeated erroneous emails for the fallback server.

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -3873,7 +3873,7 @@ sub _remove_service
 		&system_wrapper("$IPVSADM -d $ipvsadm_args");
 		&ld_log("Deleted $log_args");
 		&ld_emailalert_send("Deleted $log_args", $v,
-				    $rservice, $currenttime);
+				    $rservice, $tag eq "fallback" ? 0 : $currenttime);
 	}
 }
 


### PR DESCRIPTION
Hi,

There has been a longstanding bug in ldirectord whereby it sends repeated e-mails informing that the fallback server is down (although the e-mails call it a real server) and it is in fact up.

When ldirectord starts up it adds the fallback server first, then adds all realservers, then deletes the fallback server.

The e-mail alert code for "delete" sets $currenttime, which causes ld_emailalert_send to add an entry into the EMAILSTATUS hash. This in turn means that every emailalertfreq, an e-mail is sent out with the subject "Inaccessible real server: 127.0.0.1:80..."

This patch sets $currenttime to 0 when the deleted e-mail is sent and the tag is set to "fallback", ensuring that no e-mails are ever repeatedly sent for a fallback server notification. They continue to be sent for real servers.

Cheers,

Matthew
