### PR TITLE
Fix: mysql: Revert changes to default pidfile detection.

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -82,11 +82,7 @@ else
 	OCF_RESKEY_user_default="mysql"
 	OCF_RESKEY_group_default="mysql"
 	OCF_RESKEY_log_default="/var/log/mysqld.log"
-	if [ -d "/var/run/mysqld/" ]; then
-		OCF_RESKEY_pid_default="/var/run/mysqld/mysqld.pid"
-	else
-		OCF_RESKEY_pid_default="/var/run/mysql/mysqld.pid"
-	fi
+	OCF_RESKEY_pid_default="/var/run/mysql/mysqld.pid"
 	OCF_RESKEY_socket_default="/var/lib/mysql/mysql.sock"
 fi
 OCF_RESKEY_client_binary_default="mysql"


### PR DESCRIPTION
We can't determine anything about the default location of the
mysqld pid file from a directroy in the /var/run directory.  This
logic did not need to be introduced in the first place.
