### PR TITLE
Medium: mysql: test properly for failed process start (bnc#823095)

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -894,6 +894,8 @@ mysql_monitor() {
 }
 
 mysql_start() {
+    local rc pid
+
     if ocf_is_ms; then
         # Initialize the ReaderVIP attribute, monitor will enable it
         set_reader_attr 0
@@ -962,23 +964,22 @@ mysql_start() {
     --datadir=$OCF_RESKEY_datadir \
     --user=$OCF_RESKEY_user $OCF_RESKEY_additional_parameters \
     $mysql_extra_params >/dev/null 2>&1 &
-    rc=$?
-
-    if [ $rc != 0 ]; then
-        ocf_log err "MySQL start command failed: $rc"
-        return $rc
-    fi
+    pid=$!
 
     # Spin waiting for the server to come up.
     # Let the CRM/LRM time us out if required.
     start_wait=1
     while [ $start_wait = 1 ]; do
+        if ! ps $pid > /dev/null 2>&1; then
+            wait $pid
+            ocf_log err "MySQL server failed to start (rc=$?), please check your installation"
+            return $OCF_ERR_GENERIC
+        fi
         mysql_status info
         rc=$?
         if [ $rc = $OCF_SUCCESS ]; then
             start_wait=0
-
-            elif [ $rc != $OCF_NOT_RUNNING ]; then
+        elif [ $rc != $OCF_NOT_RUNNING ]; then
             ocf_log info "MySQL start failed: $rc"
             return $rc
         fi
@@ -1268,3 +1269,5 @@ case "$1" in
  *)     usage
         exit $OCF_ERR_UNIMPLEMENTED;;
 esac
+
+# vi:sw=4:ts=4:et:


### PR DESCRIPTION
The following doesn't work:

```
blah & echo $?
```

This patch changes that to:

```
blah &
pid=$!
loop
    if $pid does not exist
        wait $pid to get the exit code and log error
    monitor
    ...
```

PS: add vi formatting note at the end (expand tabs, tab=4sp)
