### PR TITLE
oracle: explicitly require bash (bnc#825517)

### DIFF
--- a/heartbeat/oracle
+++ b/heartbeat/oracle
@@ -216,7 +216,7 @@ execsql() {
 	if [ "$US" = "$ORACLE_OWNER" ]; then
 		sqlplus -S /nolog
 	else
-		su - $ORACLE_OWNER -c ". $ORA_ENVF; sqlplus -S /nolog"
+		su - $ORACLE_OWNER -s /bin/bash -c ". $ORA_ENVF; sqlplus -S /nolog"
 	fi
 }
 


### PR DESCRIPTION
If the oracle owner is using csh, for example, the "." command is not working as expected, but an error message is logged for every RA invocation.
