### PR TITLE
Use explicit shell in oracle/oralsnr (bnc#825517)

### DIFF
--- a/heartbeat/oracle
+++ b/heartbeat/oracle
@@ -216,7 +216,7 @@ execsql() {
 	if [ "$US" = "$ORACLE_OWNER" ]; then
 		sqlplus -S /nolog
 	else
-		su - $ORACLE_OWNER -c ". $ORA_ENVF; sqlplus -S /nolog"
+		su - $ORACLE_OWNER -s /bin/sh -c ". $ORA_ENVF; sqlplus -S /nolog"
 	fi
 }
 

--- a/heartbeat/oralsnr
+++ b/heartbeat/oralsnr
@@ -146,7 +146,7 @@ runasdba() {
 		(
 		echo ". $ORA_ENVF"
 		cat
-		) | su - $ORACLE_OWNER
+		) | su -s $SH - $ORACLE_OWNER
 	fi
 }
 


### PR DESCRIPTION
If the oracle owner user is using a different login shell (such as csh),
problems could arise when executing scriptlets via this shell.
Explicitly make su use /bin/sh.
