### PR TITLE
oracledb.sh: Set RESTART_RETRIES back to 0

### DIFF
--- a/rgmanager/src/resources/oracledb.sh
+++ b/rgmanager/src/resources/oracledb.sh
@@ -120,7 +120,7 @@ export ORACLE_HOSTNAME
 export LD_LIBRARY_PATH=$ORACLE_HOME/lib:$ORACLE_HOME/opmn/lib
 export PATH=$ORACLE_HOME/bin:$ORACLE_HOME/opmn/bin:$ORACLE_HOME/dcm/bin:$PATH
 
-declare -i	RESTART_RETRIES=3
+declare -i	RESTART_RETRIES=0
 declare -r	DB_PROCNAMES="pmon"
 #declare -r	DB_PROCNAMES="pmonXX" # testing
 #declare -r	DB_PROCNAMES="pmon smon dbw0 lgwr"


### PR DESCRIPTION
Restore the previous value of 0 for RESTART_RETRIES as testing
turned up problems when using RESTART_RETRIES=3 and the storage
on which oracle was installed failed.

Signed-off-by: Ryan McCabe rmccabe@redhat.com
