### PR TITLE
No longer define a domain, but use "virsh create" to start it non-persis...

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -537,7 +537,7 @@ if [ ! -r $OCF_RESKEY_config ]; then
 fi
 
 # Retrieve the domain name from the xml file.
-DOMAIN_NAME=`egrep ".*$" ${OCF_RESKEY_config} |sed -e 's/.*(.*)<\/name>$/\1/' 2>/dev/null`
+DOMAIN_NAME=`egrep '.*<name>.*</name>$' ${OCF_RESKEY_config} | sed -e 's/.*<name>\(.*\)<\/name>$/\1/' 2>/dev/null`
 if [ -z $DOMAIN_NAME ]; then
 	ocf_log err "This is unexpected. Cannot determine domain name."
 	exit $OCF_ERR_GENERIC


### PR DESCRIPTION
...tent

See ticket #240:
- no longer define a domain, but use "virsh create" to start it
- get rid of the statefile (which is then no longer needed) and remove 2 unused functions then
- take into account "domstate" output for not defined domains
