### PR TITLE
Add corosync as HA_cluster_type in Filesystem RA

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -342,7 +342,7 @@ ocfs2_init()
 	OCFS2_SLES10=""
 	if [ "X$HA_cluster_type" = "Xcman" ]; then
 		return
-	elif [ "X$HA_cluster_type" != "Xopenais" ]; then
+	elif [ "X$HA_cluster_type" != "Xopenais" -a "X$HA_cluster_type" != "Xcorosync" ]; then
 		if grep -q "SUSE Linux Enterprise Server 10" /etc/SuSE-release >/dev/null 2>&1 ; then
 			OCFS2_SLES10="yes"
 			ocf_log info "$DEVICE: Enabling SLES10 compatibility mode for OCFS2."


### PR DESCRIPTION
With the move to corosync cluster stack, we need to check for
cluster type "corosync" as well.
