### PR TITLE
Medium: apache: put back config file existence test

### DIFF
--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -522,6 +522,10 @@ apache_validate_all() {
 		ocf_log err "HTTPD $HTTPD not found or is not an executable!"
 		return $OCF_ERR_INSTALLED
 	fi
+	if [ ! -f $CONFIGFILE ]; then
+		ocf_log err "Configuration file $CONFIGFILE not found!"
+		return $OCF_ERR_INSTALLED
+	fi
 	return $OCF_SUCCESS
 }
 


### PR DESCRIPTION
This test got erroneously removed in changeset 6e4207 (because of
a misleading comment).
