### PR TITLE
Low: apache: Allow basic server request monitoring without requiring server-status to be enabled

### DIFF
--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -308,16 +308,55 @@ apache_monitor_10() {
 		return $OCF_ERR_GENERIC
 	fi
 }
+
+# If the user has not provided any basic monitoring 
+# information, allow the agent to verify the server is
+# healthy and capable of processing requests by requesting
+# the http header of website's index 
+attempt_index_monitor_request() {
+	local indexpage=""
+	
+	if [ -n "$OCF_RESKEY_testregex" ]; then
+		return 1;
+	fi
+	if [ -n "$OCF_RESKEY_testregex10" ]; then
+		return 1;
+	fi
+	if [ -n "$OCF_RESKEY_testurl" ]; then
+		return 1;
+	fi
+	if [ -n "$OCF_RESKEY_statusurl" ]; then
+		return 1;
+	fi
+	if [ -n "$OCF_RESKEY_testconffile" ]; then
+		return 1;
+	fi
+
+	indexpage=$(buildlocalurl)
+
+	request_url_header $indexpage
+	if [ $? -ne 0 ]; then
+		return $OCF_ERR_GENERIC
+	fi
+	ocf_log info "Successfully retrieved http header at $indexpage" 
+	return 0
+}
+
 apache_monitor_basic() {
 	if ${ourhttpclient}_func "$STATUSURL" | grep -Ei "$TESTREGEX" > /dev/null
 	then
 		return $OCF_SUCCESS
-	else
-		if ! ocf_is_probe; then
-			ocf_log err "Failed to access httpd status page."
-		fi
-		return $OCF_ERR_GENERIC
 	fi
+
+	attempt_index_monitor_request
+	if [ $? -eq 0 ]; then
+		return $OCF_SUCCESS
+	fi
+
+	if ! ocf_is_probe; then
+		ocf_log err "Failed to access httpd status page."
+	fi
+	return $OCF_ERR_GENERIC
 }
 apache_monitor() {
 	silent_status


### PR DESCRIPTION
By default, the apache agent attempts to detect the location
of the server-status url and retrieve the contents of that URL.
If no regex is set, all this agent does is verify some sort
of html file exists at the server-status url.  Essentially in
the default use-case, the agent is just verifying that the agent
can successfully request something from the webserver.

Requiring the user to enable the server-status feature
just to verify a request/response from the server shouldn't be
necessary.  This patch allows the agent to fall back to
doing a basic http header request of the website's index
if the server-status check fails during a monitor... This will
only occur in the very basic use-case where a user has
not defined any statusurls, regex patterns, or custom test cases.
