### PR TITLE
High: Raid1: prevent md arrays as clone resources to avoid data corruption

### DIFF
--- a/heartbeat/Raid1
+++ b/heartbeat/Raid1
@@ -461,7 +461,7 @@ if [ -z "$MDDEV" ] ; then
 	exit $OCF_ERR_CONFIGURED
 fi
 
-if [ -n "OCF_RESKEY_CRM_meta_clone_max" ]; then
+if ocf_is_clone; then
 	ocf_log err "md RAID arrays are NOT safe to run as a clone!"
 	exit $OCF_ERR_CONFIGURED
 fi


### PR DESCRIPTION
I have seen customers do this by accident, and they were under the impression that it all "worked". (They did not test the failure cases where this causes random data corruption, such as multiple nodes resyncing at once.)

This patch will prevent md RAID arrays from being cloned.
