### PR TITLE
Medium: ldirector: fix using service name for real servers (bnc#836759)

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -1985,7 +1985,7 @@ sub _ld_read_config_real_resolve
 				" (could not resolve host)");
 		}
 		if( defined($port) ){
-			$resolved_port=&ld_getservbyname($port);
+			$resolved_port=&ld_getservbyname($port,"");
 			unless( defined($resolved_port) ){
 				&config_error($line,
 					"invalid port ($port) for real server" .


### PR DESCRIPTION
virtual = mail:smtp
        checktimeout = 30
        checkinterval = 120
        failurecount = 1
        protocol = tcp
        scheduler = nq
        real = g1:smtp masq

yields:

Use of uninitialized value $protocol in getservbyname at /usr/sbin/ldirectord
line 5115, <CFGFILE> line 22.

Only the "real" setting is affected.
