### PR TITLE
Low: VirtualDomain: Avoid potentially blocking 'virsh' execution during meta-data action

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -18,13 +18,11 @@
 
 # Defaults
 OCF_RESKEY_force_stop_default=0
-OCF_RESKEY_hypervisor_default="$(virsh --quiet uri)"
 OCF_RESKEY_autoset_utilization_cpu_default="true"
 OCF_RESKEY_autoset_utilization_hv_memory_default="true"
 OCF_RESKEY_migrateport_default=$(( 49152 + $(ocf_maybe_random) % 64 ))
 
 : ${OCF_RESKEY_force_stop=${OCF_RESKEY_force_stop_default}}
-: ${OCF_RESKEY_hypervisor=${OCF_RESKEY_hypervisor_default}}
 : ${OCF_RESKEY_autoset_utilization_cpu=${OCF_RESKEY_autoset_utilization_cpu_default}}
 : ${OCF_RESKEY_autoset_utilization_hv_memory=${OCF_RESKEY_autoset_utilization_hv_memory_default}}
 : ${OCF_RESKEY_migrateport=${OCF_RESKEY_migrateport_default}}
@@ -67,9 +65,10 @@ for this virtual domain.
 <longdesc lang="en">
 Hypervisor URI to connect to. See the libvirt documentation for
 details on supported URI formats. The default is system dependent.
+Determine the system's default uri by running 'virsh --quiet uri'.
 </longdesc>
 <shortdesc lang="en">Hypervisor URI</shortdesc>
-<content type="string" default="${OCF_RESKEY_hypervisor_default}"/>
+<content type="string"/>
 </parameter>
 
 <parameter name="force_stop" unique="0" required="0">
@@ -530,6 +529,9 @@ case $1 in
 		exit $OCF_SUCCESS
 		;;
 esac
+
+OCF_RESKEY_hypervisor_default="$(virsh --quiet uri)"
+: ${OCF_RESKEY_hypervisor=${OCF_RESKEY_hypervisor_default}}
 
 # Everything except usage and meta-data must pass the validate test
 VirtualDomain_Validate_All || exit $?


### PR DESCRIPTION
We need meta-data actions to be fast.  Forking the call to 'virsh' to determine the default uri is causing some problems with pacemaker.  Pacemaker has to retrieve agent's meta-data to determine if things like reloads are possible.  To avoid blocking the crmd, pacemaker places a very short timeout period on these operations.  VirtualDomain actually hits time timeout period because the 'virsh' fork sometimes blocks for a short period of time.
