### PR TITLE
VirtualDomain fixes

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -257,6 +257,15 @@ VirtualDomain_Status() {
 	return $rc
 }
 
+verify_undefined() {
+	for dom in `virsh --connect=${OCF_RESKEY_hypervisor} list --all --name`; do
+		if [ "$dom" = "$DOMAIN_NAME" ]; then
+			virsh $VIRSH_OPTIONS undefine $DOMAIN_NAME > /dev/null 2>&1
+			return
+		fi
+	done
+}
+
 VirtualDomain_Start() {
 	local snapshotimage
 
@@ -275,6 +284,14 @@ VirtualDomain_Start() {
 		ocf_log error "Failed to restore ${DOMAIN_NAME} from state file in ${OCF_RESKEY_snapshot} directory."
 		return $OCF_ERR_GENERIC
 	fi
+
+	# Make sure domain is undefined before creating.
+	# The 'create' command guarantees that the domain will be
+	# undefined on shutdown, but requires the domain to be undefined.
+	# if a user defines the domain
+	# outside of this agent, we have to ensure that the domain
+	# is restored to an 'undefined' state before creating.
+	verify_undefined
 
 	virsh $VIRSH_OPTIONS create ${OCF_RESKEY_config}
 	rc=$?


### PR DESCRIPTION
I introduced a regression recently when I moved the placement of where we initialize the default hypervisor... oops

I've also included a patch that will gracefully handle managing libvirt domains a user has defined outside of this resource agent.
