### PR TITLE
Disable HTTPS SSL certificate hostname checking, tidy debug output

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -2835,7 +2835,7 @@ sub check_http
 	&ld_debug(2, "check_http: url=\"$$r{url}\" "
 		. "virtualhost=\"$virtualhost\"");
 
-	my $ua = new LWP::UserAgent();
+	my $ua = new LWP::UserAgent(ssl_opts => { verify_hostname => 0 });
 
 	my $h = undef;
 	if ($$v{service} eq "http_proxy") {
@@ -2876,13 +2876,15 @@ sub check_http
 	}
 
 	if ($$v{service} eq "https") {
-		&ld_debug(2, "SSL-Cipher: " .
-			$res->header('Client-SSL-Cipher'));
-		&ld_debug(2, "SSL-Cert-Subject: " .
-			$res->header('Client-SSL-Cert-Subject'));
-		&ld_debug(2, "SSL-Cert-Issuer: " .
-			$res->header('Client-SSL-Cert-Issuer'));
+                &ld_debug(2, "SSL-Cipher: " .
+                        ($res->header('Client-SSL-Cipher') || '<not set>'));
+                &ld_debug(2, "SSL-Cert-Subject: " .
+                        ($res->header('Client-SSL-Cert-Subject') || '<not set>'));
+                &ld_debug(2, "SSL-Cert-Issuer: " .
+                        ($res->header('Client-SSL-Cert-Issuer') || '<not set>'));
 	}
+
+	&ld_debug(2, "Return status: " . $res->status_line);
 
 	my $recstr = $$r{receive};
 	if ($res->is_success && (!($recstr =~ /.+/) ||


### PR DESCRIPTION
I just upgraded to Debian Wheezy from Squeeze, and ldirectord checks using request/receive broke.

It turns out that HTTPS checks with request/receive will fail under newer versions of the LWP module due to certificate name checking now being enabled by default. This disables the check again so that service checking by IP only will still succeed. (Setting 'virtualhost' to the correct server name made no difference.)

See http://search.cpan.org/~gaas/libwww-perl-6.01/lib/LWP/UserAgent.pm, $ua->ssl_opts -> "The no checks behaviour was the default for libwww-perl-5.837 and older."

I also added an additional debug output line that shows the Status line so that it is easier to find out why the service has been taken down.

Tidied up the debug output when SSL values are not set (for example, if there has been a certificate error, or simply that the host is unreachable).
