### PR TITLE
Check for compiler flags with -Werror

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,7 +107,7 @@ dnl ===============================================
 dnl Helpers 
 dnl ===============================================
 cc_supports_flag() {
-         local CFLAGS="$@"
+         local CFLAGS="-Werror $@"
          AC_MSG_CHECKING(whether $CC supports "$@")
          AC_COMPILE_IFELSE([int main(){return 0;}] ,[RC=0; AC_MSG_RESULT(yes)],[RC=1; AC_MSG_RESULT(no)])
          return $RC


### PR DESCRIPTION
For example for -fstack-protector, it is accepted by gcc for
all targets, however those targets where it is actually not
supported, it will print a warning like

"-fstack-protector is not supported for this platform"

which raises an error when using -Werror later. So better
not add -fstack-protector then to the CC_EXTRA_FLAGS