### PR TITLE
Low: fs-lib.sh: Optimize fs-lib.sh based filesystem monitor code

### DIFF
--- a/rgmanager/src/resources/utils/fs-lib.sh
+++ b/rgmanager/src/resources/utils/fs-lib.sh
@@ -499,7 +499,7 @@ is_alive()
 {
 	declare errcode
 	declare mount_point="$1"
-	declare file=".writable_test.$(hostname)"
+	declare file
 	declare rw
 
 	if [ $# -ne 1 ]; then
@@ -535,18 +535,8 @@ is_alive()
                 fi
 	done
 	if [ $rw -eq $YES ]; then
-	        file="$mount_point"/$file
-		while true; do
-			if [ -e "$file" ]; then
-				file=${file}_tmp
-				continue
-			else
-			        break
-			fi
-		done
-		touch $file > /dev/null 2> /dev/null
-		errcode=$?
-		if [ $errcode -ne 0 ]; then
+		file=$(mktemp "$mount_point/.check_writable.$(hostname).XXXXXX")
+		if [ ! -e $file ]; then
 			ocf_log err "${OCF_RESOURCE_INSTANCE}: is_alive: failed write test on [$mount_point]. Return code: $errcode"
 			return $NO
 		fi


### PR DESCRIPTION
fs-lib.sh's is_alive function attempts to determine if a filesystem
resource is healthy by writing and reading a file from disk.  The
method used to pick the file name involves a infinite loop where
we try different file names until we get one that doesn't exist.
We don't need to be doing that... Instead we should create a unique
filename based on the resource's instance name and use that for testing.

Resolves: rhbz#1023099
