### PR TITLE
High: fix netfs unmount/self_fence integration

### DIFF
--- a/rgmanager/src/resources/utils/fs-lib.sh
+++ b/rgmanager/src/resources/utils/fs-lib.sh
@@ -916,6 +916,10 @@ stop: Could not match $OCF_RESKEY_device with a real device"
         *)		force_umount="" ;;
 	esac
 
+	#
+	# self_fence _MUST_ be initialized before calling do_pre_unmount
+	# The netfs agent depends on the self_fence variable.
+	#
 	case ${OCF_RESKEY_self_fence} in
         $YES_STR)	self_fence=$YES ;;
 	on)		self_fence=$YES ;;


### PR DESCRIPTION
a nfs mount, where the nfs server goes away, can hang literally
forever.

even with soft nfs mount option, some operations such as sync and
umount can hang (depending on an endless matrix of kernel versions).

we recently exposed self_fence for netfs, but that's just too late
in the process. In some cases, with many nfs umount operation
in progress (generally 5 are enough to reproduce), it's possible
that we will never hit self_fence.

we address the problem by checking if the RPC/NFS/MOUNTD (mountd
only for nfs < version 4, that doesn't use mountd) are alive via
rpcinfo calls. In case there are no responses from them, we will
proceed to just self_fence as there is no point to keep
trying.

rpcinfo calls do attempt to contact the server 4 times, once
every 15 seconds, so this code path could theoretically,
if the network or server are only loosing packets, add an
extra 3 minutes to a stop operation.

Signed-off-by: Fabio M. Di Nitto fdinitto@redhat.com
