### PR TITLE
High: IPv6addr: Split send_ua utility out of IPv6addr.c source so it can be re-used in IPaddr2 without requiring cluster-glue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -714,7 +714,8 @@ AM_CONDITIONAL(USE_LIBNET, test "x$libnet_version" != "xnone" )
 dnl ************************************************************************
 dnl * Check for netinet/icmp6.h to enable the IPv6addr resource agent
 AC_CHECK_HEADERS(netinet/icmp6.h,[],[],[#include <sys/types.h>])
-AM_CONDITIONAL(USE_IPV6ADDR, test "$ac_cv_header_netinet_icmp6_h" = yes && test "$ac_cv_header_heartbeat_glue_config_h" = yes)
+AM_CONDITIONAL(USE_IPV6ADDR_AGENT, test "$ac_cv_header_netinet_icmp6_h" = yes && test "$ac_cv_header_heartbeat_glue_config_h" = yes)
+AM_CONDITIONAL(IPV6ADDR_COMPATIBLE, test "$ac_cv_header_netinet_icmp6_h" = yes)
 
 dnl ========================================================================
 dnl Compiler flags

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -134,7 +134,7 @@ man_MANS	       = ocf_heartbeat_AoEtarget.7 \
                           ocf_heartbeat_vmware.7 \
                           ocf_heartbeat_zabbixserver.7
 
-if USE_IPV6ADDR
+if USE_IPV6ADDR_AGENT
 man_MANS           	+= ocf_heartbeat_IPv6addr.7
 endif
 

--- a/heartbeat/IPv6addr_utils.c
+++ b/heartbeat/IPv6addr_utils.c
@@ -1,0 +1,147 @@
+
+/*
+ * This program manages IPv6 address with OCF Resource Agent standard.
+ *
+ * Author: Huang Zhen <zhenh@cn.ibm.com>
+ * Copyright (c) 2004 International Business Machines
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <IPv6addr.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h> /* for inet_pton */
+#include <net/if.h> /* for if_nametoindex */
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <errno.h>
+
+/* Send an unsolicited advertisement packet
+ * Please refer to rfc4861 / rfc3542
+ */
+int
+send_ua(struct in6_addr* src_ip, char* if_name)
+{
+	int status = -1;
+	int fd;
+
+	int ifindex;
+	int hop;
+	struct ifreq ifr;
+	u_int8_t *payload = NULL;
+	int    payload_size;
+	struct nd_neighbor_advert *na;
+	struct nd_opt_hdr *opt;
+	struct sockaddr_in6 src_sin6;
+	struct sockaddr_in6 dst_sin6;
+
+	if ((fd = socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6)) == -1) {
+		printf("ERROR: socket(IPPROTO_ICMPV6) failed: %s",
+		       strerror(errno));
+		return status;
+	}
+	/* set the outgoing interface */
+	ifindex = if_nametoindex(if_name);
+	if (setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_IF,
+		       &ifindex, sizeof(ifindex)) < 0) {
+		printf("ERROR: setsockopt(IPV6_MULTICAST_IF) failed: %s",
+		       strerror(errno));
+		goto err;
+	}
+	/* set the hop limit */
+	hop = 255; /* 255 is required. see rfc4861 7.1.2 */
+	if (setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS,
+		       &hop, sizeof(hop)) < 0) {
+		printf("ERROR: setsockopt(IPV6_MULTICAST_HOPS) failed: %s",
+		       strerror(errno));
+		goto err;
+	}
+
+	/* set the source address */
+	memset(&src_sin6, 0, sizeof(src_sin6));
+	src_sin6.sin6_family = AF_INET6;
+	src_sin6.sin6_addr = *src_ip;
+	src_sin6.sin6_port = 0;
+	if (IN6_IS_ADDR_LINKLOCAL(&src_sin6.sin6_addr) ||
+	    IN6_IS_ADDR_MC_LINKLOCAL(&src_sin6.sin6_addr)) {
+		src_sin6.sin6_scope_id = ifindex;
+	}
+
+	if (bind(fd, (struct sockaddr *)&src_sin6, sizeof(src_sin6)) < 0) {
+		printf("ERROR: bind() failed: %s", strerror(errno));
+		goto err;
+	}
+
+
+	/* get the hardware address */
+	memset(&ifr, 0, sizeof(ifr));
+	strncpy(ifr.ifr_name, if_name, sizeof(ifr.ifr_name) - 1);
+	if (ioctl(fd, SIOCGIFHWADDR, &ifr) < 0) {
+		printf("ERROR: ioctl(SIOCGIFHWADDR) failed: %s", strerror(errno));
+		goto err;
+	}
+
+	/* build a neighbor advertisement message */
+	payload_size = sizeof(struct nd_neighbor_advert)
+			 + sizeof(struct nd_opt_hdr) + HWADDR_LEN;
+	payload = memalign(sysconf(_SC_PAGESIZE), payload_size);
+	if (!payload) {
+		printf("ERROR: malloc for payload failed");
+		goto err;
+	}
+	memset(payload, 0, payload_size);
+
+	/* Ugly typecast from ia64 hell! */
+	na = (struct nd_neighbor_advert *)((void *)payload);
+	na->nd_na_type = ND_NEIGHBOR_ADVERT;
+	na->nd_na_code = 0;
+	na->nd_na_cksum = 0; /* calculated by kernel */
+	na->nd_na_flags_reserved = ND_NA_FLAG_OVERRIDE;
+	na->nd_na_target = *src_ip;
+
+	/* options field; set the target link-layer address */
+	opt = (struct nd_opt_hdr *)(payload + sizeof(struct nd_neighbor_advert));
+	opt->nd_opt_type = ND_OPT_TARGET_LINKADDR;
+	opt->nd_opt_len = 1; /* The length of the option in units of 8 octets */
+	memcpy(payload + sizeof(struct nd_neighbor_advert)
+			+ sizeof(struct nd_opt_hdr),
+	       &ifr.ifr_hwaddr.sa_data, HWADDR_LEN);
+
+	/* sending an unsolicited neighbor advertisement to all */
+	memset(&dst_sin6, 0, sizeof(dst_sin6));
+	dst_sin6.sin6_family = AF_INET6;
+	inet_pton(AF_INET6, BCAST_ADDR, &dst_sin6.sin6_addr); /* should not fail */
+
+	if (sendto(fd, payload, payload_size, 0,
+		   (struct sockaddr *)&dst_sin6, sizeof(dst_sin6))
+	    != payload_size) {
+		printf("ERROR: sendto(%s) failed: %s",
+		       if_name, strerror(errno));
+		goto err;
+	}
+
+	status = 0;
+
+err:
+	close(fd);
+	free(payload);
+	return status;
+}

--- a/heartbeat/Makefile.am
+++ b/heartbeat/Makefile.am
@@ -32,19 +32,23 @@ ocfdir		        = $(OCF_RA_DIR_PREFIX)/heartbeat
 dtddir			= $(datadir)/$(PACKAGE_NAME)
 dtd_DATA		= ra-api-1.dtd
 
-if USE_IPV6ADDR
+if USE_IPV6ADDR_AGENT
 ocf_PROGRAMS           = IPv6addr
-halib_PROGRAMS         = send_ua
 else
 ocf_PROGRAMS           =
+endif
+
+if IPV6ADDR_COMPATIBLE
+halib_PROGRAMS         = send_ua
+else
 halib_PROGRAMS         =
 endif
 
-IPv6addr_SOURCES        = IPv6addr.c
-send_ua_SOURCES         = IPv6addr.c
+IPv6addr_SOURCES        = IPv6addr.c IPv6addr_utils.c
+send_ua_SOURCES         = send_ua.c IPv6addr_utils.c
 
 IPv6addr_LDADD          = -lplumb $(LIBNETLIBS)
-send_ua_LDADD           = -lplumb $(LIBNETLIBS)
+send_ua_LDADD           = $(LIBNETLIBS)
 
 ocf_SCRIPTS	     =  ClusterMon		\
 			CTDB			\

--- a/heartbeat/send_ua.c
+++ b/heartbeat/send_ua.c
@@ -1,0 +1,127 @@
+
+/*
+ * This program manages IPv6 address with OCF Resource Agent standard.
+ *
+ * Author: Huang Zhen <zhenh@cn.ibm.com>
+ * Copyright (c) 2004 International Business Machines
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <IPv6addr.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h> /* for inet_pton */
+#include <net/if.h> /* for if_nametoindex */
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <errno.h>
+
+static void usage_send_ua(const char* self);
+static void byebye(int nsig);
+
+int
+main(int argc, char* argv[])
+{
+	char*		ipv6addr;
+	int		count = UA_REPEAT_COUNT;
+	int		interval = 1000;	/* default 1000 msec */
+	int		ch;
+	int		i;
+	char*		cp;
+	char*		prov_ifname = NULL;
+	struct in6_addr	addr6;
+
+	/* Check binary name */
+	if (argc < 4) {
+		usage_send_ua(argv[0]);
+		return OCF_ERR_ARGS;
+	}
+	while ((ch = getopt(argc, argv, "h?c:i:")) != EOF) {
+		switch(ch) {
+		case 'c': /* count option */
+			count = atoi(optarg);
+		    break;
+		case 'i': /* interval option */
+			interval = atoi(optarg);
+		    break;
+		case 'h':
+		case '?':
+		default:
+			usage_send_ua(argv[0]);
+			return OCF_ERR_ARGS;
+		}
+	}
+
+	/* set termination signal */
+	siginterrupt(SIGTERM, 1);
+	signal(SIGTERM, byebye);
+
+	ipv6addr = argv[optind];
+
+	if (ipv6addr == NULL) {
+		printf("ERROR: Please set OCF_RESKEY_ipv6addr to the IPv6 address you want to manage.");
+		usage_send_ua(argv[0]);
+		return OCF_ERR_ARGS;
+	}
+
+	/* legacy option */
+	if ((cp = strchr(ipv6addr, '/'))) {
+		*cp=0;
+	}
+
+	prov_ifname = argv[optind+2];
+
+	if (inet_pton(AF_INET6, ipv6addr, &addr6) <= 0) {
+		printf("ERROR: Invalid IPv6 address [%s]", ipv6addr);
+		usage_send_ua(argv[0]);
+		return OCF_ERR_ARGS;
+	}
+
+	/* Check whether this system supports IPv6 */
+	if (access(IF_INET6, R_OK)) {
+		printf("ERROR: No support for INET6 on this system.");
+		return OCF_ERR_GENERIC;
+	}
+
+	/* Send unsolicited advertisement packet to neighbor */
+	for (i = 0; i < count; i++) {
+		send_ua(&addr6, prov_ifname);
+		usleep(interval * 1000);
+	}
+
+	return OCF_SUCCESS;
+}
+
+static void usage_send_ua(const char* self)
+{
+	printf("usage: %s [-i[=Interval]] [-c[=Count]] [-h] IPv6-Address Prefix Interface\n",self);
+	return;
+}
+
+/* Following code is copied from send_arp.c, linux-HA project. */
+void
+byebye(int nsig)
+{
+	(void)nsig;
+	/* Avoid an "error exit" log message if we're killed */
+	exit(0);
+}
+

--- a/include/IPv6addr.h
+++ b/include/IPv6addr.h
@@ -1,0 +1,58 @@
+/*
+ * This program manages IPv6 address with OCF Resource Agent standard.
+ *
+ * Author: Huang Zhen <zhenh@cn.ibm.com>
+ * Copyright (c) 2004 International Business Machines
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#ifndef OCF_IPV6_HELPER_H
+#define OCF_IPV6_HELPER_H
+#include <netinet/icmp6.h>
+#include <config.h>
+/*
+0	No error, action succeeded completely
+1 	generic or unspecified error (current practice)
+	The "monitor" operation shall return this for a crashed, hung or
+	otherwise non-functional resource.
+2 	invalid or excess argument(s)
+	Likely error code for validate-all, if the instance parameters
+	do not validate. Any other action is free to also return this
+	exit status code for this case.
+3 	unimplemented feature (for example, "reload")
+4 	user had insufficient privilege
+5 	program is not installed
+6 	program is not configured
+7 	program is not running
+8	resource is running in "master" mode and fully operational
+9	resource is in "master" mode but in a failed state
+*/
+#define	OCF_SUCCESS		0
+#define	OCF_ERR_GENERIC		1
+#define	OCF_ERR_ARGS		2
+#define	OCF_ERR_UNIMPLEMENTED	3
+#define	OCF_ERR_PERM		4
+#define	OCF_ERR_INSTALLED	5
+#define	OCF_ERR_CONFIGURED	6
+#define	OCF_NOT_RUNNING		7
+
+#define	HWADDR_LEN 6 /* mac address length */
+#define UA_REPEAT_COUNT	5
+#define  BCAST_ADDR "ff02::1"
+#define IF_INET6 "/proc/net/if_inet6"
+
+int send_ua(struct in6_addr* src_ip, char* if_name);
+#endif

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -21,4 +21,4 @@ MAINTAINERCLEANFILES    = Makefile.in config.h.in config.h.in~
 idir=$(includedir)/heartbeat
 i_HEADERS = agent_config.h
 
-noinst_HEADERS = config.h
+noinst_HEADERS = config.h IPv6addr.h


### PR DESCRIPTION
We need the 'send_arp' tool in the latest fedora so we can support IPaddr2 with ipv4 addresses. Right now send_arp is literally the IPv6addr agent, which depends on cluster-glue libs that are no longer supported in fedora.  We need that send_ua logic, so I split that util out of the IPv6addr.c file into it's own file.  By doing that, I could remove send_ua's dependency on cluster-glue without affecting IPv6addr.
