### PR TITLE
Medium: oracle: Log if creating $MONUSR fails (bnc#850589)

### DIFF
--- a/heartbeat/oracle
+++ b/heartbeat/oracle
@@ -543,6 +543,7 @@ oracle_start() {
 
 	# check/create the monitor user
 	if ! check_mon_user; then
+		ocf_log err "Could not create monitor user $MONUSR: $output"
 		return $OCF_ERR_GENERIC
 	fi
 


### PR DESCRIPTION
Write error message to log if creating the OCFMON user fails.

Related commit: 989430c4
