### PR TITLE
Fix to the correct the URL described in the spec.

### DIFF
--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -35,7 +35,7 @@ Summary:	Open Source HA Reusable Cluster Resource Scripts
 Version:	@version@
 Release:	@specver@%{?rcver:%{rcver}}%{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}%{?dist}
 License:	GPLv2+ and LGPLv2+
-URL:		http://to.be.defined.com/
+URL:		https://github.com/ClusterLabs/resource-agents
 %if 0%{?fedora} || 0%{?centos_version} || 0%{?rhel}
 Group:		System Environment/Base
 %else


### PR DESCRIPTION
URL described by resource-agents.spec.in now is not right.
I think that I should change this to https://github.com/ClusterLabs/resource-agents.
