### PR TITLE
High: VirtualDomain: Fixes parsing domain name from xml file.

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -565,7 +565,7 @@ if [ ! -r $OCF_RESKEY_config ]; then
 fi
 
 # Retrieve the domain name from the xml file.
-DOMAIN_NAME=`egrep '.*<name>.*</name>$' ${OCF_RESKEY_config} | sed -e 's/.*<name>\(.*\)<\/name>$/\1/' 2>/dev/null`
+DOMAIN_NAME=`egrep '[[:space:]]*<name>.*</name>[[:space:]]*$' ${OCF_RESKEY_config} | sed -e 's/[[:space:]]*<name>\(.*\)<\/name>[[:space:]]*$/\1/' 2>/dev/null`
 if [ -z $DOMAIN_NAME ]; then
 	ocf_log err "This is unexpected. Cannot determine domain name."
 	exit $OCF_ERR_GENERIC


### PR DESCRIPTION
If the domain xml is not generated by virsh, it is possible
VirtualDomain will not be able to detect the domain's name
from the xml file.  This is a result of the parsing command
not taking into account trailing whitespace characters.
