### PR TITLE
Update default value for best_netmask

### DIFF
--- a/tools/findif.c
+++ b/tools/findif.c
@@ -568,7 +568,7 @@ main(int argc, char ** argv) {
 	char	best_if[MAXSTR];
 	char *	if_specified = NULL;
 	struct ifreq	ifr;
-	unsigned long	best_netmask = INT_MAX;
+	unsigned long	best_netmask = UINT_MAX;
 	int		argerrs	= 0;
 	int		nmbits;
 


### PR DESCRIPTION
When best_netmask is set to INT_MAX the netmask and broadcast
address is calculated incorrectly.

Closes: #380
