### PR TITLE
VirtualDomain: add some polish for libvirtd-less functionality

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -211,8 +211,8 @@ pid_status()
 	emulator=$(basename $(egrep '[[:space:]]*<emulator>.*</emulator>[[:space:]]*$' ${OCF_RESKEY_config} | sed -e 's/[[:space:]]*<emulator>\(.*\)<\/emulator>[[:space:]]*$/\1/'))
 
 	case "$emulator" in
-		qemu-kvm)
-			ps awx | grep "[q]emu-kvm.*-name $DOMAIN_NAME " > /dev/null 2>&1
+		qemu-kvm|qemu-system-*)
+			ps awx | grep -E "[q]emu-(kvm|system).*-name $DOMAIN_NAME " > /dev/null 2>&1
 			if [ $? -eq 0 ]; then
 				# domain exists and is running
 				ocf_log debug "Virtual domain $DOMAIN_NAME is currently running."


### PR DESCRIPTION
The recent changes to make VirtualDomain perform `monitor`actions without a running libvirtd missed a couple of bits:
- `virsh uri` would still be called unconditionally, even when `OCF_RESKEY_hypervisor` was set. This would fail against a non-running libvirtd. Since the `OCF_RESKEY_hypervisor_default` variable is actually no longer used, this call be simplified, avoiding the superfluous `virsh uri` call.
- The check for a running Qemu/KVM process without a running libvirtd would only work if the emulator binary is called `qemu-kvm`, which is true for CentOS 6 but no longer applies to current Ubuntu and possibly other platforms. Now, this tests for `qemu-system-*` as well.
