### PR TITLE
Medium: exportfs: Make unlock_on_stop_default=1 (bnc#864263)

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -97,7 +97,10 @@ stops. Enabling this parameter is highly recommended unless the path exported
 by this ${__SCRIPT_NAME} resource is also exported by a different resource.
 
 Note: Unlocking is only possible on Linux systems where
-/proc/fs/nfsd/unlock_filesystem exists and is writable.
+/proc/fs/nfsd/unlock_filesystem exists and is writable. If your system does
+not fulfill this requirement (on account of having an nonrecent kernel,
+for example), you may set this parameter to 0 to silence the associated
+warning.
 </longdesc>
 <shortdesc lang="en">
 Unlock filesystem on stop?


### PR DESCRIPTION
The resource agent should really release all locks which the NFS server
holds when stopping the resource. When this option was introduced, the
default was kept as 0 for compatibility reasons with legacy kernels,
existing users and non-Linux systems.

This is a proposal to make 1 the default. In most cases, this is the
desired behavior, and not setting this option can lead to unexpected
failures.

Original changeset that introduced this parameter: 612559c9
