### PR TITLE
More fixes for monitoring VirtualDomain without libvirtd

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -185,9 +185,17 @@ set_util_attr() {
 	local cval outp
 
 	cval=$(crm_resource -Q -r $OCF_RESOURCE_INSTANCE -z -g $attr 2>/dev/null)
+	if [ $? -ne 0 ] && [ -z "$cval" ]; then
+		crm_resource -Q -r $OCF_RESOURCE_INSTANCE -z -g $attr 2>&1 | grep -e "not connected" > /dev/null 2>&1
+		if [ $? -eq 0 ]; then
+			ocf_log debug "Unable to set utilization attribute, cib is not available"
+			return
+		fi
+	fi
+
 	if [ "$cval" != "$val" ]; then
-	   outp=`crm_resource -r $OCF_RESOURCE_INSTANCE -z -p $attr -v $val 2>&1` ||
-	   ocf_log warn "crm_resource failed to set utilization attribute $attr: $outp"
+		outp=$(crm_resource -r $OCF_RESOURCE_INSTANCE -z -p $attr -v $val 2>&1) ||
+		ocf_log warn "crm_resource failed to set utilization attribute $attr: $outp"
 	fi
 }
 
@@ -195,11 +203,11 @@ update_utilization() {
 	local dom_cpu dom_mem
 
 	if ocf_is_true "$OCF_RESKEY_autoset_utilization_cpu"; then
-	   dom_cpu=$(LANG=C virsh $VIRSH_OPTIONS dominfo ${DOMAIN_NAME} | awk '/CPU\(s\)/{print $2}')
+	   dom_cpu=$(LANG=C virsh $VIRSH_OPTIONS dominfo ${DOMAIN_NAME} 2>/dev/null | awk '/CPU\(s\)/{print $2}')
 	   test -n "$dom_cpu" && set_util_attr cpu $dom_cpu
 	fi
 	if ocf_is_true "$OCF_RESKEY_autoset_utilization_hv_memory"; then
-	   dom_mem=$(LANG=C virsh $VIRSH_OPTIONS dominfo ${DOMAIN_NAME} | awk '/Max memory/{printf("%d", $3/1024)}')
+	   dom_mem=$(LANG=C virsh $VIRSH_OPTIONS dominfo ${DOMAIN_NAME} 2>/dev/null | awk '/Max memory/{printf("%d", $3/1024)}')
 	   test -n "$dom_mem" && set_util_attr hv_memory "$dom_mem"
 	fi
 }
@@ -266,13 +274,13 @@ VirtualDomain_Status() {
 	status="no state"
 	while [ "$status" = "no state" ]; do
 		try=$(($try + 1 ))
-		status=$(virsh $VIRSH_OPTIONS domstate $DOMAIN_NAME 2>&1|tr 'A-Z' 'a-z')
+		status=$(virsh $VIRSH_OPTIONS domstate $DOMAIN_NAME 2>&1 | tr 'A-Z' 'a-z')
 		case "$status" in
 			*"error:"*"domain not found"*|"shut off")
 				# shut off: domain is defined, but not started, will not happen if
 				#   domain is created but not defined
 				# Domain not found: domain is not defined and thus not started
-				ocf_log debug "Virtual domain $DOMAIN_NAME is currently $status."
+				ocf_log debug "Virtual domain $DOMAIN_NAME is not running: $(echo $status | sed s/error://g)"
 				rc=$OCF_NOT_RUNNING
 				;;
 			running|paused|idle|blocked|"in shutdown")
@@ -325,7 +333,7 @@ VirtualDomain_Status() {
 }
 
 verify_undefined() {
-	for dom in `virsh --connect=${OCF_RESKEY_hypervisor} list --all --name`; do
+	for dom in `virsh --connect=${OCF_RESKEY_hypervisor} list --all --name 2>/dev/null`; do
 		if [ "$dom" = "$DOMAIN_NAME" ]; then
 			virsh $VIRSH_OPTIONS undefine $DOMAIN_NAME > /dev/null 2>&1
 			return
@@ -614,7 +622,7 @@ case $1 in
 esac
 
 # Grab the virsh uri default, but only if hypervisor isn't set
-: ${OCF_RESKEY_hypervisor=$(virsh --quiet uri)}
+: ${OCF_RESKEY_hypervisor=$(virsh --quiet uri 2>/dev/null)}
 
 # Set options to be passed to virsh:
 VIRSH_OPTIONS="--connect=${OCF_RESKEY_hypervisor} --quiet"


### PR DESCRIPTION
We recently added the ability for VirtualDomain to monitor a vm even if libvirtd has gone down.  The monitor is performed by inspecting the pid associated with the emulator that launched the vm.  We determine the emulator binary that is in use by searching for it in the vm's config.

It turns out the emulator is not required to be in the config, but will be assigned after the vm domain is created in libvirt. Because of this, we must cache the domain's emulator after it is created in order to be able to monitor the vm if libvirt later goes down and the vm's config does not contain the emulator binary.

I've also included some fixes to how we perform logging without pacemaker or libvirtd being present. 
