### PR TITLE
High: CTDB: do not fail monitor operation when ctdb socket does not exist

### DIFF
--- a/heartbeat/CTDB
+++ b/heartbeat/CTDB
@@ -660,6 +660,8 @@ ctdb_monitor() {
 	if [ $? -ne 0 ]; then
 		if echo $status | grep -qs 'Connection refused'; then
 			return $OCF_NOT_RUNNING
+		elif echo $status | grep -qs 'No such file or directory'; then
+			return $OCF_NOT_RUNNING
 		else
 			ocf_log err "CTDB status call failed: $status"
 			return $OCF_ERR_GENERIC


### PR DESCRIPTION
When starting CTDB with a custom socket location for the first
time, pacemaker's probe operation (monitor_0) fails because
the custom socket does not exist. This patch detects this failure
and returns "not running" instead of a "generic error" return code.
