### PR TITLE
Filesystem: Fail early when no device is found (bnc#870923)

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -671,7 +671,8 @@ set_blockdevice_var() {
 		;;
 	*)
 		if [ ! -b "$DEVICE"  -a ! -d "$DEVICE" -a "X$OP" != Xstart ] ; then
-			ocf_log warn "Couldn't find device [$DEVICE]. Expected /dev/??? to exist"
+			ocf_log err "Couldn't find device [$DEVICE]. Expected /dev/??? to exist"
+			exit $OCF_ERR_INSTALLED
 		fi
 		if [ ! -d "$DEVICE" ]; then
 			blockdevice=yes


### PR DESCRIPTION
The function set_blockdevice_var checks if the blockdevice exists
but if it doesn't, the function continues. Once the 'start' action
is called, the same problem is reported as an error and the start
action fails.

This patch makes the agent fail immediately.
