### PR TITLE
mysql: Pull out the correct variable when setting read-only mode

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -411,7 +411,7 @@ get_read_only() {
     local read_only_state
 
     read_only_state=`$MYSQL $MYSQL_OPTIONS_REPL \
-        -e "SHOW VARIABLES" | grep read_only | awk '{print $2}'`
+        -ss -e "SHOW VARIABLES LIKE 'read_only'" | awk '{print $2}'`
 
     if [ "$read_only_state" = "ON" ]; then
         return 0

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -411,9 +411,9 @@ get_read_only() {
     local read_only_state
 
     read_only_state=`$MYSQL $MYSQL_OPTIONS_REPL \
-        -ss -e "SHOW VARIABLES LIKE 'read_only'" | awk '{print $2}'`
+        -ss -e "SHOW GLOBAL VARIABLES LIKE 'read_only'"
 
-    if [ "$read_only_state" = "ON" ]; then
+    if [ $read_only_state =~ '*ON' ]; then
         return 0
     else
         return 1


### PR DESCRIPTION
MariaDB10 has 3 variables that include read_only. Pull out the correct variable instead of grep'ing for it.
