### PR TITLE
Stateful: Make master/slave scores configurable (bnc#867372)

### DIFF
--- a/heartbeat/Stateful
+++ b/heartbeat/Stateful
@@ -56,6 +56,38 @@ Location to store the resource state in
 <content type="string" default="${HA_RSCTMP}/Stateful-{OCF_RESOURCE_INSTANCE}.state" />
 </parameter>
 
+<parameter name="master_score">
+<longdesc lang="en">
+Score set when promoted
+</longdesc>
+<shortdesc lang="en">Master score</shortdesc>
+<content type="integer" default="10" />
+</parameter>
+
+<parameter name="slave_score">
+<longdesc lang="en">
+Score set when demoted
+</longdesc>
+<shortdesc lang="en">Slave score</shortdesc>
+<content type="integer" default="5" />
+</parameter>
+
+<parameter name="slave_score_low">
+<longdesc lang="en">
+Score set while starting as slave
+</longdesc>
+<shortdesc lang="en">Slave score (low)</shortdesc>
+<content type="integer" default="1" />
+</parameter>
+
+<parameter name="master_failed_score">
+<longdesc lang="en">
+Score set when master fails
+</longdesc>
+<shortdesc lang="en">Master failed score</shortdesc>
+<content type="integer" default="0" />
+</parameter>
+
 </parameters>
 
 <actions>
@@ -63,7 +95,8 @@ Location to store the resource state in
 <action name="stop"    timeout="20s" />
 <action name="promote"    timeout="20s" />
 <action name="demote"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20" interval="10"/>
+<action name="monitor" depth="0"  timeout="20" interval="10" role="Master" />
+<action name="monitor" depth="0"  timeout="20" interval="10" role="Slave" />
 <action name="meta-data"  timeout="5" />
 <action name="validate-all"  timeout="20s" />
 </actions>
@@ -111,7 +144,7 @@ stateful_start() {
 	return $OCF_RUNNING_MASTER
     fi
     stateful_update slave
-    $CRM_MASTER -v 5
+    $CRM_MASTER -v ${OCF_RESKEY_slave_score_low}
     return $OCF_SUCCESS
 }
 
@@ -122,7 +155,7 @@ stateful_demote() {
 	return $OCF_NOT_RUNNING
     fi
     stateful_update slave
-    $CRM_MASTER -v 5
+    $CRM_MASTER -v ${OCF_RESKEY_slave_score}
     return $OCF_SUCCESS
 }
 
@@ -132,7 +165,7 @@ stateful_promote() {
 	return $OCF_NOT_RUNNING
     fi
     stateful_update master
-    $CRM_MASTER -v 10
+    $CRM_MASTER -v ${OCF_RESKEY_master_score}
     return $OCF_SUCCESS
 }
 
@@ -152,11 +185,22 @@ stateful_stop() {
 stateful_monitor() {
     stateful_check_state "master"
     if [ $? = 0 ]; then
+	if [ $OCF_RESKEY_CRM_meta_interval = 0 ]; then
+		# Restore the master setting during probes
+		$CRM_MASTER -v ${OCF_RESKEY_master_score}
+	fi
 	return $OCF_RUNNING_MASTER
+    fi
+
+    stateful_check_state "failed master"
+    if [ $? = 0 ]; then
+	$CRM_MASTER -v ${OCF_RESKEY_master_failed_score}
+	return $OCF_SUCCESS
     fi
 
     stateful_check_state "slave"
     if [ $? = 0 ]; then
+	$CRM_MASTER -v ${OCF_RESKEY_slave_score}
 	return $OCF_SUCCESS
     fi
 
@@ -173,6 +217,10 @@ stateful_validate() {
 }
 
 : ${OCF_RESKEY_state=${HA_RSCTMP}/Stateful-${OCF_RESOURCE_INSTANCE}.state}
+: ${OCF_RESKEY_master_score=10}
+: ${OCF_RESKEY_slave_score=5}
+: ${OCF_RESKEY_slave_score_low=1}
+: ${OCF_RESKEY_master_failed_score=0}
 
 case $__OCF_ACTION in
 meta-data)	meta_data;;


### PR DESCRIPTION
This patch makes the slave/master scores set configurable, in order
to enable the simulation of resources that should promote the other
clone if the current master fails.