### PR TITLE
Calculate not specified bradcast address from IP address and netmask

### DIFF
--- a/heartbeat/findif.sh
+++ b/heartbeat/findif.sh
@@ -165,8 +165,8 @@ findif()
   if [ $family = "inet" ] ; then
     if [ -z "$brdcast" ] ; then
       if [ -n "$7" ] ; then
-        set -- `ip -o -f $family addr show | grep $7`
-        [ "$5" = brd ] && brdcast=$6
+        eval $(ipcalc -b ${match%*/}/$netmask)
+        brdcast=$BROADCAST
       fi
     fi
   else


### PR DESCRIPTION
It is valid for a secondary interface to be out of another subnet with different netmask than the primary interface.
In this case using the broadcast address from the first assigned IP address to the same nic is wrong.
If no broadcast address specified and the interface supports it, it must always be calculated out of the IP address and netmask.
As IP broadcast communication is not widely used and using different subnets on one interface also rarely used, this error was most likely not seen by anybody else.
