### PR TITLE
kamailio: Combined udptcp check can produce wrong test result, if tcp fails.

### DIFF
--- a/heartbeat/kamailio
+++ b/heartbeat/kamailio
@@ -433,11 +433,6 @@ kamailio_status() {
             if [ $result -eq 0 ]; then
                 output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport udp>/dev/null 2>>$errorfile`
                 result=$?
-            else
-                error=`cat $errorfile`
-                rm -f $errorfile
-                ocf_log $not_running_log_level "Kamailio is running, but not functional as sipsak TCP check failed with $(kamailio_format_result $result "$output" "$error")"
-                result=$?
             fi
             ;;
     *)  output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport udp>/dev/null 2>>$errorfile`


### PR DESCRIPTION
There is always room for error.
During simulation of partial packet loss with kamailio process monitor operation is not always able to detect this.
In case the tcp check fails, result shell variable is overwritten by the result of the last command executes which is not sipsak.
Anyhow, this part of error output is not necessary, as it is irrelevant which part of the combined tcp/udp check fails.
