### PR TITLE
Med: rgmanager/fs: typo preventing passing some mount opts

### DIFF
--- a/rgmanager/src/resources/fs.sh.in
+++ b/rgmanager/src/resources/fs.sh.in
@@ -293,7 +293,7 @@ verify_options()
 
 			if [ "$OCF_RESKEY_fstype" = "ext3" ] ||
 			   [ "$OCF_RESKEY_fstype" = "ext4" ]; then
-				case $0 in
+				case $o in
 				noload|data=*)
 					continue
 					;;


### PR DESCRIPTION
...which seems to be the original intention;
specifically: ext{3,4} + noload/data=...

Signed-off-by: Jan Pokorný jpokorny@redhat.com
