### PR TITLE
Low: Filesystem: kill kludge for linux-ha's BasicSanityCheck

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -353,7 +353,7 @@ Filesystem_start()
 	#       accordingly
 
 	if [ $blockdevice = "yes" ]; then
-		if [ "$DEVICE" != "/dev/null" -a ! -b "$DEVICE" ] ; then
+		if [ ! -b "$DEVICE" ] ; then
 			ocf_log err "Couldn't find device [$DEVICE]. Expected /dev/??? to exist"
 			exit $OCF_ERR_INSTALLED
 		fi
@@ -665,9 +665,6 @@ set_blockdevice_var() {
 
 	case $DEVICE in
 	-*) # Oh... An option to mount instead...  Typically -U or -L
-		;;
-	/dev/null) # Special case for BSC
-		blockdevice=yes
 		;;
 	*)
 		if [ ! -b "$DEVICE"  -a ! -d "$DEVICE" -a "X$OP" != Xstart ] ; then


### PR DESCRIPTION
Special-casing for /dev/null is not a systemic approach, nor should be
relevant nowadays.

Signed-off-by: Jan Pokorný jpokorny@redhat.com
