### PR TITLE
Medium: iscsi: iscsi status fails with open-iscsi with support for flash...

### DIFF
--- a/heartbeat/iscsi
+++ b/heartbeat/iscsi
@@ -268,7 +268,8 @@ open_iscsi_add() {
 }
 open_iscsi_get_session_id() {
 	local target="$1"
-	$iscsiadm -m session 2>/dev/null | grep "$target$" |
+	$iscsiadm -m session 2>/dev/null |
+		grep -E "$target($|[[:space:]])" |
 		awk '{print $2}' | tr -d '[]'
 }
 open_iscsi_remove() {


### PR DESCRIPTION
... (bnc#878039)

iscsiadm -m session has additional output:

> iscsiadm -m session
> tcp: [4] 10.2.12.1:3260,1 iqn.2011-03.de.suse.hex-10:disk0 (non-flash)

The flash/non-flash breaks the status. The regular expression
needs update.

The change is compatible with the old output too.
