### PR TITLE
Medium: oracle: oracledb.sh always executes a forced stop

### DIFF
--- a/rgmanager/src/resources/oracledb.sh
+++ b/rgmanager/src/resources/oracledb.sh
@@ -362,7 +362,7 @@ force_cleanup()
 	declare pid
 
 	# Patch from Shane Bradley to fix 471266
-	pids=`ps ax | grep $ORACLE_HOME | grep "ora_.*_${ORACLE_SID}" | grep -v grep | awk '{print $1} '`
+	pids=`ps ax | grep $ORACLE_HOME | grep "ora_.*_${ORACLE_SID}" | grep -v grep | awk '{print $1}'`
 
 	ocf_log error "Not all Oracle processes for $ORACLE_SID exited cleanly, killing"
 


### PR DESCRIPTION
exit_idle() ps |grep  if all oracle processes are correctly stopped.

expected behavior:
- ps | grep should return 0 if oracle is not stopped, 1 if stopped

actual behavior:
- ps | grep always return 0, even if no oracle processes linger around. So stopping an oracle instance always takes at least 90 seconds

This is because there's an ps | grep | awk; but awk always return 0 even if it prints no output.

A simpler (but logically different) solution could be to just remove the awk...your choiche!

Peace,
R.
