### PR TITLE
Update Xen RA to use xl instead of the deprecated xm

### DIFF
--- a/heartbeat/Xen
+++ b/heartbeat/Xen
@@ -329,7 +329,7 @@ Xen_Start() {
     $xentool mem-set ${DOMAIN_NAME} ${NEWMEM}
   fi
 
-  $xentool create ${OCF_RESKEY_xmfile} name=$DOMAIN_NAME
+  $xentool create ${OCF_RESKEY_xmfile} name=\"$DOMAIN_NAME\"
   rc=$?
   if [ $rc -ne 0 ]; then
     return $OCF_ERR_GENERIC


### PR DESCRIPTION
First commit replaces the use of the xm command line tool with xl.

For more details, see:
- http://wiki.xen.org/wiki/XL#Upgrading_from_xend
- http://wiki.xen.org/wiki/MigrationGuideToXen4.1

Also comes with a second commit which cleans up trailing whitespace in the RA.
