### PR TITLE
Start the nfs.target before nfs-lock and nfs-server for RHEL7

### DIFF
--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -261,6 +261,17 @@ v3locking_exec()
 	fi
 }
 
+nfs_target_exec()
+{
+	local cmd=$1
+	set_exec_mode
+
+	# This is only a systemd target that needs to be started before nfs-server.service
+	case $EXEC_MODE in 
+		2) systemctl $cmd nfs.target
+	esac
+}
+
 nfsserver_monitor ()
 {
 	fn=`mktemp`
@@ -505,6 +516,19 @@ nfsserver_start ()
 	cp -rpf $STATD_PATH/sm $STATD_PATH/sm.bak /var/lib/nfs/state $STATD_PATH/sm.ha > /dev/null 2>&1
 
 	ocf_log info "Starting NFS server ..."
+
+	# check to see if we need to start the nfs.target
+	nfs_target_exec "status"
+	if [ $? -ne $OCF_SUCCESS ]; then
+		nfs_target_exec "start"
+		rc=$?
+		if [ $rc -ne 0 ]; then
+			ocf_log error "Failed to start nfs.target"
+			return $rc
+		fi
+	else
+		ocf_log info "nfs.target already up"
+	fi
 
 	# check to see if we need to start rpc.statd
 	v3locking_exec "status"


### PR DESCRIPTION
Per https://bugzilla.redhat.com/show_bug.cgi?id=1051052 and https://bugzilla.redhat.com/show_bug.cgi?id=970595, nfs.target should be enabled to allow nfs-server to start successfully on systemd based Fedora/RHEL installs. In the resource-agent's case we want to start the nfs.target before nfs-lock and nfs-server are started. Otherwise nfs-server will fail to start after a reboot with:

```
systemd: Dependency failed for NFS Remote Quota Server.
systemd: Dependency failed for NFSv4 ID-name mapping daemon.
```

This fix should be safely ignored by non-systemd systems, as nfs_target_exec will return 0 if EXEC_MODE is not 2. I've tested this fix on RHEL7.

Thanks,

Ben
