### PR TITLE
High: VirtualDomain: restore advertised start and stop timeout values to...

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -167,8 +167,8 @@ Restore state on start/stop
 </parameters>
 
 <actions>
-<action name="start" timeout="$OCF_RESKEY_CRM_meta_timeout_default" />
-<action name="stop" timeout="$OCF_RESKEY_CRM_meta_timeout_default" />
+<action name="start" timeout="90" />
+<action name="stop" timeout="90" />
 <action name="status" depth="0" timeout="30" interval="10" />
 <action name="monitor" depth="0" timeout="30" interval="10" />
 <action name="migrate_from" timeout="60" />


### PR DESCRIPTION
... a sane value.

The meta_timeout default value is 90000 milliseconds. That value
was used in the xml output to represent the default start and stop
timeout which is reflected in seconds... not milliseconds. A
90000 second timeout doesn't make sense as a default.

oops... Someone even told me it was a bad idea to dynamically generate the xml like this. My fault, fixed!
