### PR TITLE
Make use of /etc/init.d/apache2 conditional in SUSE-specific configuration

### DIFF
--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -157,12 +157,13 @@ validate_default_config() {
 # that include, we run "/etc/init.d/apache2 configtest" to ensure
 # the relevant config is generated and valid.  We're also taking
 # this opportunity to enable mod_status if it's not present.
+# Note: no longer necessary with systemd
 validate_default_suse_config() {
 	if [ "$CONFIGFILE" = "$DEFAULT_SUSECONFIG" ] && \
 		grep -Eq '^Include[[:space:]]+/etc/apache2/sysconfig.d/include.conf' "$CONFIGFILE"
 	then
 		[ -x "/usr/sbin/a2enmod" ] && ocf_run -q /usr/sbin/a2enmod status
-		ocf_run -q /etc/init.d/apache2 configtest
+		[ -e "/etc/init.d/apache2" ] && ocf_run -q /etc/init.d/apache2 configtest
 		return
 	else
 		return 0


### PR DESCRIPTION
SUSE has switched to systemd, so /etc/init.d/apache2 is going away. This checks if the file exists and only performs the configtest if this is the case.
