### PR TITLE
Parameter to save running VM's configuration

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -22,7 +22,7 @@ OCF_RESKEY_autoset_utilization_cpu_default="true"
 OCF_RESKEY_autoset_utilization_hv_memory_default="true"
 OCF_RESKEY_migrateport_default=$(( 49152 + $(ocf_maybe_random) % 64 ))
 OCF_RESKEY_CRM_meta_timeout_default=90000
-OCF_RESKEY_save_config_on_stop_default=0
+OCF_RESKEY_save_config_on_stop_default=false
 
 : ${OCF_RESKEY_force_stop=${OCF_RESKEY_force_stop_default}}
 : ${OCF_RESKEY_autoset_utilization_cpu=${OCF_RESKEY_autoset_utilization_cpu_default}}
@@ -158,7 +158,7 @@ Changes to a running VM's config are normally lost on stop.
 This parameter instructs the RA to save the configuration back to the xml file provided in the "config" parameter.
 </longdesc>
 <shortdesc lang="en">Save running VM's config back to its config file</shortdesc>
-<content type="integer" />
+<content type="boolean" />
 </parameter>
 
 <parameter name="snapshot">
@@ -424,6 +424,26 @@ force_stop()
 	return $OCF_SUCCESS
 }
 
+save_config(){
+	CFGTMP=$(mktemp -t vmcfgsave.XXX)
+	virsh $VIRSH_OPTIONS dumpxml ${DOMAIN_NAME} > ${CFGTMP}
+	if [ -s ${CFGTMP} ]; then
+		if virt-xml-validate ${CFGTMP} domain 2>/dev/null ;	then
+			ocf_log info "Saving domain $DOMAIN_NAME to ${OCF_RESKEY_config}. Please make sure it's present on all nodes."
+			if mv ${CFGTMP} ${OCF_RESKEY_config} ; then
+				ocf_log info "Saved $DOMAIN_NAME domain's configuration to ${OCF_RESKEY_config}."
+			else	
+				ocf_log warn "Moving ${CFGTMP} to ${OCF_RESKEY_config} failed."
+			fi
+		else
+			ocf_log warn "Domain $DOMAIN_NAME config failed to validate after dump. Skipping config update."
+		fi
+	else
+		ocf_log warn "Domain $DOMAIN_NAME config has 0 size. Skipping config update."
+	fi
+	rm -f ${CFGTMP}
+}
+
 VirtualDomain_Stop() {
 	local i
 	local status
@@ -453,22 +473,8 @@ VirtualDomain_Stop() {
 			fi
 
 			# save config if needed
-			if [ "$OCF_RESKEY_save_config_on_stop" = 1 ]; then	
-				CFGTMP=$(mktemp -t vmcfgsave.XXX)
-				virsh $VIRSH_OPTIONS dumpxml ${DOMAIN_NAME} > ${CFGTMP}
-				if [ -s ${CFGTMP} ]; then	
-					if virt-xml-validate ${CFGTMP} domain 2>/dev/null ;	then
-						ocf_log info "Saving domain $DOMAIN_NAME to ${OCF_RESKEY_config}. Please make sure it's present on all nodes."
-						if ! mv ${CFGTMP} ${OCF_RESKEY_config} ; then	
-							ocf_log warn "Moving ${CFGTMP} to ${OCF_RESKEY_config} failed."
-						fi
-					else
-						ocf_log warn "Domain $DOMAIN_NAME config failed to validate after dump. Skipping config update."
-					fi
-				else
-					ocf_log warn "Domain $DOMAIN_NAME config has 0 size. Skipping config update."
-				fi
-				rm -f ${CFGTMP}
+			if ocf_is_true "$OCF_RESKEY_save_config_on_stop"; then	
+				save_config
 			fi
 
 			# issue the shutdown if save state didn't shutdown for us
@@ -715,4 +721,3 @@ case $1 in
 		;;
 esac
 exit $?
-


### PR DESCRIPTION
When save_config_on_stop is set to 1 the RA will dump the running VM's config to "config" during resource stop.
