### PR TITLE
Medium: VirtualDomain: Add support for qemu-dm as emulator (bnc#885292)

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -248,9 +248,9 @@ pid_status()
 	local emulator=$(get_emulator)
 
 	case "$emulator" in
-		qemu-kvm|qemu-system-*)
+		qemu-kvm|qemu-dm|qemu-system-*)
 			rc=$OCF_NOT_RUNNING
-			ps awx | grep -E "[q]emu-(kvm|system).*-name $DOMAIN_NAME " > /dev/null 2>&1
+			ps awx | grep -E "[q]emu-(kvm|dm|system).*-name $DOMAIN_NAME " > /dev/null 2>&1
 			if [ $? -eq 0 ]; then
 				rc=$OCF_SUCCESS
 			fi


### PR DESCRIPTION
When using Xen, qemu-dm is the emulator name. This patch ensures that
pid_status returns sensible information when this is the case.
