### PR TITLE
Fix nginx agent

### DIFF
--- a/heartbeat/nginx
+++ b/heartbeat/nginx
@@ -745,7 +745,7 @@ Case insensitive.
 <content type="string" />
 </parameter>
 
-<parameter name="testconffile">
+<parameter name="test20conffile">
 <longdesc lang="en">
 A file which contains a more complex test configuration. Could be useful if
 you have to check more than one web application or in case sensitive


### PR DESCRIPTION
When use the nginx agent with OCF_CHECK_LEVEL=20, we can specify the
parameter 'testconffile'. But now the agent file of nginx read
'test20conffile'. So change the name of parameter to 'test20conffile'.

Signed-off-by: KATOH Yasufumi karma@jazz.email.ne.jp
