### PR TITLE
VirtualDomain: Try xenstore-ls if no emulator is set (bnc#885292)

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -264,6 +264,14 @@ pid_status()
 			;;
 		# This can be expanded to check for additional emulators
 		*)
+			# We may be running xen with PV domains, they don't
+			# have an emulator set. try xenstore-ls in this case
+			if have_binary xenstore-ls; then
+				xenstore-ls -f /vm | grep -E "/vm.*name = \"$DOMAIN_NAME\"" > /dev/null 2>&1
+				if [ $? -eq 0 ]; then
+					rc=$OCF_SUCCESS
+				fi
+			fi
 			;;
 	esac
 


### PR DESCRIPTION
If libvirt is running a xen PV, there is no emulator set at all. In this case, we might be able to query xen. If the domain is running, there will be an entry for it under /vm.
