### PR TITLE
added config save to Migrate_To and Migrate_From

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -564,6 +564,11 @@ VirtualDomain_Migrate_To() {
 		# Scared of that sed expression? So am I. :-)
 		remoteuri=$(echo ${OCF_RESKEY_hypervisor} | sed -e "s,\(.*\)://[^/:]*\(:\?[0-9]*\)/\(.*\),\1${transport_suffix}://${target_node}\2/\3,")
 
+		# save config if needed
+		if ocf_is_true "$OCF_RESKEY_save_config_on_stop"; then	
+			save_config
+		fi
+
 		# OK, we know where to connect to. Now do the actual migration.
 		ocf_log info "$DOMAIN_NAME: Starting live migration to ${target_node} (using remote hypervisor URI ${remoteuri} ${migrateuri})."
 		virsh ${VIRSH_OPTIONS} migrate --live $DOMAIN_NAME ${remoteuri} ${migrateuri}
@@ -586,6 +591,10 @@ VirtualDomain_Migrate_From() {
 		sleep 1
 	done
 	ocf_log info "$DOMAIN_NAME: live migration from ${OCF_RESKEY_CRM_meta_migrate_source} succeeded."
+	# save config if needed
+	if ocf_is_true "$OCF_RESKEY_save_config_on_stop"; then	
+		save_config
+	fi
 	return $OCF_SUCCESS
 }
 
@@ -721,3 +730,4 @@ case $1 in
 		;;
 esac
 exit $?
+


### PR DESCRIPTION
config changes will not be preserved on migration without this change.
Consider the following scenario:
1. user modifies config with virsh edit on node1
2. migrates the VM to node2
Result:
machine is running on node2 with mismatched runtime and saved config. Node1 has an outdated config xml stored as well. If node2 crashes, the machine will start up with the original config somewhere in the cluster. 2+ node clusters are still a problem - if the VM starts on a node where it's not been stopped, migrated to since the config edit, it will start with the outdated config, hence the message in the log (line 432).
