### PR TITLE
Low: galera: report when check_user is unable to retrieve status

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -316,7 +316,12 @@ is_primary()
     if [ "$cluster_status" = "Primary" ]; then
         return 0
     fi
-    ocf_log info "Galera instance wsrep_cluster_status=${cluster_status}"
+
+    if [ -z "$cluster_status" ]; then
+        ocf_log err "Unable to retrieve wsrep_cluster_status, verify check_user '$OCF_RESKEY_check_user' has permissions to view status"
+    else
+        ocf_log info "Galera instance wsrep_cluster_status=${cluster_status}"
+    fi
     return 1
 }
 


### PR DESCRIPTION
This is an important piece of data as it reflects that the check_user
does not have permissions to view status. Otherwise this error would
appear to signify that the galera instance did not start properly in
Primary mode, which could result in the user investigating the wrong
problem.
