### PR TITLE
VirtualDomain: add option to sync vm config via csync2

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -22,12 +22,20 @@ OCF_RESKEY_autoset_utilization_cpu_default="true"
 OCF_RESKEY_autoset_utilization_hv_memory_default="true"
 OCF_RESKEY_migrateport_default=$(( 49152 + $(ocf_maybe_random) % 64 ))
 OCF_RESKEY_CRM_meta_timeout_default=90000
+OCF_RESKEY_save_config_on_stop_default=false
+OCF_RESKEY_sync_config_on_stop_default=false
 
 : ${OCF_RESKEY_force_stop=${OCF_RESKEY_force_stop_default}}
 : ${OCF_RESKEY_autoset_utilization_cpu=${OCF_RESKEY_autoset_utilization_cpu_default}}
 : ${OCF_RESKEY_autoset_utilization_hv_memory=${OCF_RESKEY_autoset_utilization_hv_memory_default}}
 : ${OCF_RESKEY_migrateport=${OCF_RESKEY_migrateport_default}}
 : ${OCF_RESKEY_CRM_meta_timeout=${OCF_RESKEY_CRM_meta_timeout_default}}
+: ${OCF_RESKEY_save_config_on_stop=${OCF_RESKEY_save_config_on_stop_default}}
+: ${OCF_RESKEY_sync_config_on_stop=${OCF_RESKEY_sync_config_on_stop_default}}
+
+if ocf_is_true ${OCF_RESKEY_sync_config_on_stop}; then
+	OCF_RESKEY_save_config_on_stop="true"
+fi
 #######################################################################
 
 ## I'd very much suggest to make this RA use bash,
@@ -148,6 +156,26 @@ This port will be used in the qemu migrateuri. If unset, the port will be a rand
 </longdesc>
 <shortdesc lang="en">Port for migrateuri</shortdesc>
 <content type="integer" />
+</parameter>
+
+<parameter name="save_config_on_stop" unique="0" required="0">
+<longdesc lang="en">
+Changes to a running VM's config are normally lost on stop. 
+This parameter instructs the RA to save the configuration back to the xml file provided in the "config" parameter.
+</longdesc>
+<shortdesc lang="en">Save running VM's config back to its config file</shortdesc>
+<content type="boolean" />
+</parameter>
+
+<parameter name="sync_config_on_stop" unique="0" required="0">
+<longdesc lang="en">
+Setting this automatically enables save_config_on_stop. 
+When enabled this parameter instructs the RA to 
+call csync2 -x to synchronize the file to all nodes.
+csync2 must be properly set up for this to work.
+</longdesc>
+<shortdesc lang="en">Save running VM's config back to its config file</shortdesc>
+<content type="boolean" />
 </parameter>
 
 <parameter name="snapshot">
@@ -413,6 +441,38 @@ force_stop()
 	return $OCF_SUCCESS
 }
 
+sync_config(){
+	ocf_log info "Syncing $DOMAIN_NAME config file with csync2 -x ${OCF_RESKEY_config}"
+	if ! csync2 -x ${OCF_RESKEY_config}; then
+		ocf_log warn "Syncing ${OCF_RESKEY_config} failed."; 
+	fi
+}
+
+save_config(){
+	CFGTMP=$(mktemp -t vmcfgsave.XXX)
+	virsh $VIRSH_OPTIONS dumpxml --inactive --security-info ${DOMAIN_NAME} > ${CFGTMP}
+	if [ -s ${CFGTMP} ]; then
+		if ! cmp -s ${CFGTMP} ${OCF_RESKEY_config}; then
+			if virt-xml-validate ${CFGTMP} domain 2>/dev/null ;	then
+				ocf_log info "Saving domain $DOMAIN_NAME to ${OCF_RESKEY_config}. Please make sure it's present on all nodes or sync_config_on_stop is on."
+				if cat ${CFGTMP} > ${OCF_RESKEY_config} ; then
+					ocf_log info "Saved $DOMAIN_NAME domain's configuration to ${OCF_RESKEY_config}."
+					if ocf_is_true "$OCF_RESKEY_sync_config_on_stop"; then	
+						sync_config
+					fi
+				else	
+					ocf_log warn "Moving ${CFGTMP} to ${OCF_RESKEY_config} failed."
+				fi
+			else
+				ocf_log warn "Domain $DOMAIN_NAME config failed to validate after dump. Skipping config update."
+			fi
+		fi
+	else
+		ocf_log warn "Domain $DOMAIN_NAME config has 0 size. Skipping config update."
+	fi
+	rm -f ${CFGTMP}
+}
+
 VirtualDomain_Stop() {
 	local i
 	local status
@@ -439,6 +499,11 @@ VirtualDomain_Stop() {
 				else
 					ocf_log error "Failed to save snapshot state of ${DOMAIN_NAME} on stop"
 				fi
+			fi
+
+			# save config if needed
+			if ocf_is_true "$OCF_RESKEY_save_config_on_stop"; then	
+				save_config
 			fi
 
 			# issue the shutdown if save state didn't shutdown for us
@@ -528,6 +593,11 @@ VirtualDomain_Migrate_To() {
 		# Scared of that sed expression? So am I. :-)
 		remoteuri=$(echo ${OCF_RESKEY_hypervisor} | sed -e "s,\(.*\)://[^/:]*\(:\?[0-9]*\)/\(.*\),\1${transport_suffix}://${target_node}\2/\3,")
 
+		# save config if needed
+		if ocf_is_true "$OCF_RESKEY_save_config_on_stop"; then	
+			save_config
+		fi
+
 		# OK, we know where to connect to. Now do the actual migration.
 		ocf_log info "$DOMAIN_NAME: Starting live migration to ${target_node} (using remote hypervisor URI ${remoteuri} ${migrateuri})."
 		virsh ${VIRSH_OPTIONS} migrate --live $DOMAIN_NAME ${remoteuri} ${migrateuri}
@@ -550,6 +620,10 @@ VirtualDomain_Migrate_From() {
 		sleep 1
 	done
 	ocf_log info "$DOMAIN_NAME: live migration from ${OCF_RESKEY_CRM_meta_migrate_source} succeeded."
+	# save config if needed
+	if ocf_is_true "$OCF_RESKEY_save_config_on_stop"; then	
+		save_config
+	fi
 	return $OCF_SUCCESS
 }
 
@@ -579,6 +653,11 @@ VirtualDomain_Monitor() {
 
 	update_emulator_cache
 	update_utilization
+   # Save configuration on monitor as well, so we will have a better chance of 
+	# having fresh and up to date config files on all nodes.
+	if ocf_is_true "$OCF_RESKEY_save_config_on_stop"; then	
+		save_config
+	fi
 
 	return ${rc}
 }
@@ -612,6 +691,11 @@ VirtualDomain_Validate_All() {
 			ocf_log error "Configuration file $OCF_RESKEY_config does not exist or is not readable."
 			return $OCF_ERR_INSTALLED
 		fi
+	fi
+
+	# Check if csync2 is available when config tells us we might need it.
+	if ocf_is_true $OCF_RESKEY_sync_config_on_stop; then
+		check_binary csync2; 
 	fi
 }
 


### PR DESCRIPTION
When save_config_on_stop AND sync_config_on_save is enabled the config gets synced with csync2 -x vm.conf to all nodes configured in csync2. This will make sure that wherever the VM starts it will inherit the config changes.
