### PR TITLE
Medium: ldirectord: Revised fix for Socket and Socket6 module functions conflict.

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -844,7 +844,12 @@ use Pod::Usage;
 #use English;
 #use Time::HiRes qw( gettimeofday tv_interval );
 use Socket;
-use Socket6 qw(NI_NUMERICHOST NI_NUMERICSERV NI_NAMEREQD getaddrinfo getnameinfo inet_pton);
+use Socket6 qw(NI_NUMERICHOST NI_NUMERICSERV NI_NAMEREQD getaddrinfo getnameinfo inet_pton inet_ntop);
+# Workaround warnning messages : Three "_in6" symbols redefined.
+eval "use Socket6 qw(pack_sockaddr_in6)" unless defined &pack_sockaddr_in6;
+eval "use Socket6 qw(sockaddr_in6)" unless defined &sockaddr_in6;
+eval "use Socket6 qw(unpack_sockaddr_in6)" unless defined &unpack_sockaddr_in6;
+
 use Sys::Hostname;
 use POSIX qw(setsid :sys_wait_h);
 use Sys::Syslog qw(:DEFAULT setlogsock);


### PR DESCRIPTION
Previous fix #365 was incomplete.
RHEL6 not have pack_sockaddr_in6/sockaddr_in6/unpack_sockaddr_in6 in
Perl Socket module.
But those "_in6" symbols used by check_connect or check_sip.
So import those "_in6" symbols only if not implement in Socket module.
Also modify lack inet_ntop module.
