### PR TITLE
Medium: ldirectord: Revised IPv6 workaround code #379

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -2852,11 +2852,12 @@ sub check_http
 		. "virtualhost=\"$virtualhost\"");
 
 	if (inet_pton(AF_INET6,&ld_strip_brackets($host))) {
+		no warnings 'once';
 		require Net::INET6Glue::INET_is_INET6;
 		# Workaround for Net-HTTP IPv6 Address URLs Broken
-		push(@LWP::Protocol::http::EXTRA_SOCK_OPTS, "PeerAddr" => $host);
-		push(@LWP::Protocol::http::EXTRA_SOCK_OPTS, "PeerHost" => &ld_strip_brackets($host));
-		push(@LWP::Protocol::http::EXTRA_SOCK_OPTS, "Host" => &ld_strip_brackets($host));
+		@LWP::Protocol::http::EXTRA_SOCK_OPTS = (PeerAddr => $host,
+							 PeerHost => &ld_strip_brackets($host),
+							 Host => &ld_strip_brackets($host));
 	}
 
 	my $ua = new LWP::UserAgent(ssl_opts => { verify_hostname => 0 });


### PR DESCRIPTION
Previous patch #379 was incorrect.
IPv6 workaround code use push function, but push is
appending value whenever execute check_http.(That's a waste...)
So rewrite workaround code use substitution.
