### PR TITLE
Medium: mysql: fix unexpected operation error that caused by MySQL client timeout.

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -45,6 +45,7 @@
 #   OCF_RESKEY_max_slave_lag
 #   OCF_RESKEY_evict_outdated_slaves
 #   OCF_RESKEY_reader_attribute
+#   OCF_RESKEY_client_timeout
 
 #######################################################################
 # Initialization:
@@ -277,6 +278,19 @@ This parameter is only meaningful in master/slave set configurations.
 <shortdesc lang="en">Sets the node attribute that determines
 whether a node is usable for clients to read from.</shortdesc>
 <content type="string" default="${OCF_RESKEY_reader_attribute_default}" />
+</parameter>
+
+<parameter name="client_timeout" unique="0" required="0">
+<longdesc lang="en">
+This parameter specify a timeout for the MySQL client.
+
+The default value is 0(second).
+It means that timeout is disabled, the MySQL client waits for response from the MySQL server until the operation timeout is occurred.
+
+It is recommended that you do not change this parameter from the default value unless you have a explicit timeout requirement to understand the MySQL server as a failure.
+</longdesc>
+<shortdesc lang="en">A timeout for the MySQL client</shortdesc>
+<content type="integer" default="${OCF_RESKEY_client_timeout_default}" />
 </parameter>
 </parameters>
 

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -43,6 +43,7 @@ OCF_RESKEY_replication_port_default="3306"
 OCF_RESKEY_max_slave_lag_default="3600"
 OCF_RESKEY_evict_outdated_slaves_default="false"
 OCF_RESKEY_reader_attribute_default="readable"
+OCF_RESKEY_client_timeout_default="0"
 
 : ${OCF_RESKEY_binary=${OCF_RESKEY_binary_default}}
 MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
@@ -75,11 +76,13 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 
 : ${OCF_RESKEY_reader_attribute=${OCF_RESKEY_reader_attribute_default}}
 
+: ${OCF_RESKEY_client_timeout=${OCF_RESKEY_client_timeout_default}}
+
 #######################################################################
 # Convenience variables
 
 MYSQL=$OCF_RESKEY_client_binary
-MYSQL_OPTIONS_LOCAL="-S $OCF_RESKEY_socket --connect_timeout=10"
+MYSQL_OPTIONS_LOCAL="-S $OCF_RESKEY_socket --connect_timeout=$OCF_RESKEY_client_timeout"
 MYSQL_OPTIONS_REPL="$MYSQL_OPTIONS_LOCAL --user=$OCF_RESKEY_replication_user --password=$OCF_RESKEY_replication_passwd"
 MYSQL_OPTIONS_TEST="$MYSQL_OPTIONS_LOCAL --user=$OCF_RESKEY_test_user --password=$OCF_RESKEY_test_passwd"
 MYSQL_TOO_MANY_CONN_ERR=1040


### PR DESCRIPTION
Currently, a timeout for the MySQL client is hard coded(10 seconds) and operation error is occured when the MySQL server does not respond to the MySQL client in 10 seconds whatever user set a long timeout for operation.

To resolve this problem, I add a new parameter "client_timeout" and the default value is 0(timeout is disabled, the MySQL client waits for response from the MySQL server until the operation timeout is occurred).

If you have a explicit timeout requirement to understand the MySQL server as a failure, then set your timeout value to "client_timeout" parameter.
