### PR TITLE
Medium: Xinetd: refine exit codes when xinetd is stopped

### DIFF
--- a/heartbeat/Xinetd
+++ b/heartbeat/Xinetd
@@ -195,10 +195,20 @@ fi
 
 # Is xinetd running at all
 if [ -z "`get_xinetd_pid`" ]; then
-    ocf_log err "xinetd not running, we manage just xinetd services, not the daemon itself"
     case "$1" in
     stop) exit $OCF_SUCCESS;;
-    start|monitor|status) exit $OCF_ERR_INSTALLED;;
+    start)
+	ocf_log err "xinetd not running, we manage just xinetd services, not the daemon itself"
+	exit $OCF_ERR_INSTALLED
+	;;
+    status|monitor)
+	if ocf_is_probe; then
+	    exit $OCF_NOT_RUNNING
+	else
+	    ocf_log err "xinetd stopped"
+	    exit $OCF_ERR_GENERIC
+	fi
+	;;
     esac
 fi
 


### PR DESCRIPTION
Spotted by @bubble666:

https://github.com/ClusterLabs/resource-agents/commit/e9c03c15bdfa49a6bfce784ab922dd0ece546561#commitcomment-4983265
