### PR TITLE
Build: add --compat-habindir option for HA_BIN backward compatibility

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,12 @@ else
 LINUX_HA = with
 endif
 
+if WITH_COMPAT_HABINDIR
+COMPAT_HABINDIR = without
+else
+COMPAT_HABINDIR = with
+endif
+
 EXTRA_DIST		= autogen.sh .version make/release.mk \
 			  make/git-version-gen make/gitlog-to-changelog \
 			  AUTHORS COPYING COPYING.GPLv3 COPYING.LGPL ChangeLog \
@@ -142,6 +148,7 @@ $(SPEC): $(SPEC).in
 		-e "s#@rcver@#$$rcver#g" \
 		-e "s#@rgmanager@#$(RGMANAGER)#g" \
 		-e "s#@linux-ha@#$(LINUX_HA)#g" \
+		-e "s#@compat-habindir@#$(COMPAT_HABINDIR)#g" \
 	$< > $@-t; \
 	if [ -z "$$dirty" ]; then sed -i -e "s#%glo.*dirty.*##g" $@-t; fi; \
 	if [ -z "$$alphatag" ]; then sed -i -e "s#%glo.*alphatag.*##g" $@-t; fi; \

--- a/configure.ac
+++ b/configure.ac
@@ -233,6 +233,13 @@ fi
 AM_CONDITIONAL(BUILD_LINUX_HA, test $BUILD_LINUX_HA -eq 1)
 AM_CONDITIONAL(BUILD_RGMANAGER, test $BUILD_RGMANAGER -eq 1)
 
+AC_ARG_WITH(compat-habindir,
+    [  --with-compat-habindir      use HA_BIN directory with compatibility for the Heartbeat stack [${libexecdir}]],
+    [],
+    [with_compat_habindir=no])
+AM_CONDITIONAL(WITH_COMPAT_HABINDIR, test "x$with_compat_habindir" != "xno")
+
+
 dnl ===============================================
 dnl General Processing
 dnl ===============================================
@@ -296,6 +303,10 @@ case $libdir in
     AC_MSG_RESULT($libdir);
     ;;
 esac
+
+if test "x$with_compat_habindir" != "xno" ; then
+  libexecdir=${libdir}
+fi
 
 dnl Expand autoconf variables so that we dont end up with '${prefix}' 
 dnl in #defines and python scripts
@@ -917,6 +928,7 @@ AC_MSG_RESULT([  Arch-independent files   = ${datadir}])
 AC_MSG_RESULT([  Documentation            = ${docdir}])
 AC_MSG_RESULT([  State information        = ${localstatedir}])
 AC_MSG_RESULT([  System configuration     = ${sysconfdir}])
+AC_MSG_RESULT([  HA_BIN directory prefix  = ${libexecdir}])
 AC_MSG_RESULT([  RA state files           = ${HA_RSCTMPDIR}])
 AC_MSG_RESULT([  AIS Plugins              = ${LCRSODIR}])
 AC_MSG_RESULT([])

--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -30,6 +30,12 @@
 %bcond_@rgmanager@ rgmanager
 %bcond_@linux-ha@ linuxha
 
+# build with HA_BIN compatibility for the existing Heartbeat stack
+%bcond_@compat-habindir@ compat_habindir
+%if %{with compat_habindir}
+%global _libexecdir %{_libdir}
+%endif
+
 Name:		resource-agents
 Summary:	Open Source HA Reusable Cluster Resource Scripts
 Version:	@version@


### PR DESCRIPTION
I would suggest this option to address the issue #330.
The default behavior retains as the latest revision.

---

This configure option is to be used when the package is used
for the existing Heartbeat stack.

As of the commit below, HA_BIN directory has been changed to
more appropriate location but it introduces an incompatibility
so the Heartbeat stack would fail to start.
  https://github.com/ClusterLabs/resource-agents/pull/285

See also:
 https://github.com/ClusterLabs/resource-agents/issues/330
