### PR TITLE
High: Exit reason string support updates

### DIFF
--- a/heartbeat/CTDB
+++ b/heartbeat/CTDB
@@ -544,7 +544,7 @@ ctdb_start() {
 	mkdir -p $persistent_db_dir 2>/dev/null
 	for pdbase in $(ls $persistent_db_dir/*.tdb.[0-9] 2>/dev/null$) ; do
 		/usr/bin/tdbdump $pdbase >/dev/null 2>/dev/null || {
-			ocf_log err "Persistent database $pdbase is corrupted!  CTDB will not start."
+			ocf_exit_reason "Persistent database $pdbase is corrupted!  CTDB will not start."
 			return $OCF_ERR_GENERIC
 		}
 	done
@@ -552,7 +552,7 @@ ctdb_start() {
 	# Add necessary configuration to smb.conf
 	init_smb_conf
 	if [ $? -ne 0 ]; then
-		ocf_log err "Failed to update $OCF_RESKEY_smb_conf."
+		ocf_exit_reason "Failed to update $OCF_RESKEY_smb_conf."
 		return $OCF_ERR_GENERIC
 	fi
 
@@ -596,7 +596,7 @@ ctdb_start() {
 		# cleanup smb.conf
 		cleanup_smb_conf
 		
-		ocf_log err "Failed to execute $OCF_RESKEY_ctdbd_binary."
+		ocf_exit_reason "Failed to execute $OCF_RESKEY_ctdbd_binary."
 		return $OCF_ERR_GENERIC
 	else
 		# Wait a bit for CTDB to stabilize
@@ -610,7 +610,7 @@ ctdb_start() {
 			if [ $? -ne 0 ]; then
 				# CTDB will be running, kill it before returning
 				ctdb_stop
-				ocf_log err "Can't invoke $OCF_RESKEY_ctdb_binary --socket=$OCF_RESKEY_ctdb_socket status"
+				ocf_exit_reason "Can't invoke $OCF_RESKEY_ctdb_binary --socket=$OCF_RESKEY_ctdb_socket status"
 				return $OCF_ERR_GENERIC
 			fi
 			if ! echo $status | grep -qs 'UNHEALTHY (THIS'; then
@@ -626,7 +626,7 @@ ctdb_start() {
 	# ctdbd will (or can) actually still be running at this point, so kill it
 	ctdb_stop
 	
-	ocf_log err "Timeout waiting for CTDB to stabilize"
+	ocf_exit_reason "Timeout waiting for CTDB to stabilize"
 	return $OCF_ERR_GENERIC
 }
 
@@ -681,7 +681,7 @@ ctdb_monitor() {
 		elif echo $status | grep -qs 'No such file or directory'; then
 			return $OCF_NOT_RUNNING
 		else
-			ocf_log err "CTDB status call failed: $status"
+			ocf_exit_reason "CTDB status call failed: $status"
 			return $OCF_ERR_GENERIC
 		fi
 	fi
@@ -689,7 +689,7 @@ ctdb_monitor() {
 		return $OCF_SUCCESS
 	fi
 
-	ocf_log err "CTDB status is bad: $status"
+	ocf_exit_reason "CTDB status is bad: $status"
 	return $OCF_ERR_GENERIC
 }
 
@@ -702,12 +702,12 @@ ctdb_validate() {
 	done
 
 	if [ -z "$CTDB_SYSCONFIG" ]; then
-		ocf_log err "Can't find CTDB config file (expecting /etc/sysconfig/ctdb, /etc/default/ctdb or similar)"
+		ocf_exit_reason "Can't find CTDB config file (expecting /etc/sysconfig/ctdb, /etc/default/ctdb or similar)"
 		return $OCF_ERR_INSTALLED
 	fi
 
 	if ocf_is_true "$OCF_RESKEY_ctdb_manages_samba" && [ ! -f "$OCF_RESKEY_smb_conf" ]; then
-		ocf_log err "Samba config file '$OCF_RESKEY_smb_conf' does not exist."
+		ocf_exit_reason "Samba config file '$OCF_RESKEY_smb_conf' does not exist."
 		return $OCF_ERR_INSTALLED
 	fi
 
@@ -716,19 +716,19 @@ ctdb_validate() {
 	fi
 
 	if [ ! -f "$OCF_RESKEY_ctdb_config_dir/nodes" ]; then
-		ocf_log err "$OCF_RESKEY_ctdb_config_dir/nodes does not exist."
+		ocf_exit_reason "$OCF_RESKEY_ctdb_config_dir/nodes does not exist."
 		return $OCF_ERR_ARGS
 	fi
 
 	if [ -z "$OCF_RESKEY_ctdb_recovery_lock" ]; then
-		ocf_log err "ctdb_recovery_lock not specified."
+		ocf_exit_reason "ctdb_recovery_lock not specified."
 		return $OCF_ERR_CONFIGURED
 	fi
 
 	lock_dir=$(dirname "$OCF_RESKEY_ctdb_recovery_lock")
 	touch "$lock_dir/$$" 2>/dev/null
 	if [ $? != 0 ]; then
-		ocf_log err "Directory for lock file '$OCF_RESKEY_ctdb_recovery_lock' does not exist, or is not writable."
+		ocf_exit_reason "Directory for lock file '$OCF_RESKEY_ctdb_recovery_lock' does not exist, or is not writable."
 		return $OCF_ERR_ARGS
 	fi
 	rm "$lock_dir/$$"

--- a/heartbeat/Delay
+++ b/heartbeat/Delay
@@ -184,7 +184,7 @@ Delay_Validate_All() {
 # _Return_ on validation success
 	return $OCF_SUCCESS
   else
-	echo "Some of the instance parameters are invalid"
+	ocf_exit_reason "Some of the instance parameters are invalid"
 # _Exit_ on validation failure
 	exit $OCF_ERR_ARGS
   fi

--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -368,7 +368,7 @@ fstype_supported()
 	# check the if the filesystem support exists again.
 	$MODPROBE $support >/dev/null
 	if [ $? -ne 0 ]; then
-		ocf_log err "Couldn't find filesystem $FSTYPE in /proc/filesystems and failed to load kernal module"
+		ocf_exit_reason "Couldn't find filesystem $FSTYPE in /proc/filesystems and failed to load kernal module"
 		return $OCF_ERR_INSTALLED
 	fi
 
@@ -385,7 +385,7 @@ fstype_supported()
 		sleep 1
 	done
 
-	ocf_log err "Couldn't find filesystem $FSTYPE in /proc/filesystems"
+	ocf_exit_reason "Couldn't find filesystem $FSTYPE in /proc/filesystems"
 	return $OCF_ERR_INSTALLED
 }
 
@@ -409,7 +409,7 @@ Filesystem_start()
 
 	if [ $blockdevice = "yes" ]; then
 		if [ "$DEVICE" != "/dev/null" -a ! -b "$DEVICE" ] ; then
-			ocf_log err "Couldn't find device [$DEVICE]. Expected /dev/??? to exist"
+			ocf_exit_reason "Couldn't find device [$DEVICE]. Expected /dev/??? to exist"
 			exit $OCF_ERR_INSTALLED
 		fi
 
@@ -424,7 +424,7 @@ Filesystem_start()
 			# NOTE: if any errors at all are detected, it returns non-zero
 			# if the error is >= 4 then there is a big problem
 			if [ $? -ge 4 ]; then
-				ocf_log err "Couldn't sucessfully fsck filesystem for $DEVICE"
+				ocf_exit_reason "Couldn't sucessfully fsck filesystem for $DEVICE"
 				return $OCF_ERR_GENERIC
 			fi
 		fi
@@ -433,7 +433,7 @@ Filesystem_start()
 	[ -d "$MOUNTPOINT" ] ||
 		ocf_run mkdir -p $MOUNTPOINT
 	if [ ! -d "$MOUNTPOINT" ] ; then
-		ocf_log err "Couldn't find directory  [$MOUNTPOINT] to use as a mount point"
+		ocf_exit_reason "Couldn't find directory  [$MOUNTPOINT] to use as a mount point"
 		exit $OCF_ERR_INSTALLED
 	fi
 
@@ -448,7 +448,7 @@ Filesystem_start()
 	esac
 
 	if [ $? -ne 0 ]; then
-		ocf_log err "Couldn't mount filesystem $DEVICE on $MOUNTPOINT"
+		ocf_exit_reason "Couldn't mount filesystem $DEVICE on $MOUNTPOINT"
 		return $OCF_ERR_GENERIC
 	fi
 	return $OCF_SUCCESS
@@ -507,7 +507,7 @@ fs_stop() {
 		while [ $cnt -gt 0 ]; do
 			try_umount $SUB &&
 				return $OCF_SUCCESS
-			ocf_log err "Couldn't unmount $SUB; trying cleanup with $sig"
+			ocf_exit_reason "Couldn't unmount $SUB; trying cleanup with $sig"
 			signal_processes $SUB $sig
 			cnt=$((cnt-1))
 			sleep 1
@@ -558,7 +558,7 @@ Filesystem_stop()
 			fs_stop $SUB $timeout
 			rc=$?
 			if [ $rc -ne $OCF_SUCCESS ]; then
-				ocf_log err "Couldn't unmount $SUB, giving up!"
+				ocf_exit_reason "Couldn't unmount $SUB, giving up!"
 			fi
 		done
 	fi
@@ -611,7 +611,7 @@ Filesystem_monitor_10()
 	dd_opts="iflag=direct bs=4k count=1"
 	err_output=`dd if=$DEVICE $dd_opts 2>&1 >/dev/null`
 	if [ $? -ne 0 ]; then
-		ocf_log err "Failed to read device $DEVICE"
+		ocf_exit_reason "Failed to read device $DEVICE"
 		ocf_log err "dd said: $err_output"
 		return $OCF_ERR_GENERIC
 	fi
@@ -634,18 +634,18 @@ Filesystem_monitor_20()
 	[ -d "$status_dir" ] || mkdir -p "$status_dir"
 	err_output=`echo "${OCF_RESOURCE_INSTANCE}" | dd of=${STATUSFILE} $dd_opts 2>&1`
 	if [ $? -ne 0 ]; then
-		ocf_log err "Failed to write status file ${STATUSFILE}"
+		ocf_exit_reason "Failed to write status file ${STATUSFILE}"
 		ocf_log err "dd said: $err_output"
 		return $OCF_ERR_GENERIC
 	fi
 	test -f ${STATUSFILE}
 	if [ $? -ne 0 ]; then
-		ocf_log err "Cannot stat the status file ${STATUSFILE}"
+		ocf_exit_reason "Cannot stat the status file ${STATUSFILE}"
 		return $OCF_ERR_GENERIC
 	fi
 	cat ${STATUSFILE} > /dev/null
 	if [ $? -ne 0 ]; then
-		ocf_log err "Cannot read the status file ${STATUSFILE}"
+		ocf_exit_reason "Cannot read the status file ${STATUSFILE}"
 		return $OCF_ERR_GENERIC
 	fi
 	return $OCF_SUCCESS
@@ -663,7 +663,7 @@ Filesystem_monitor()
 		10) Filesystem_monitor_10; rc=$?;;
 		20) Filesystem_monitor_20; rc=$?;;
 		*)
-			ocf_log err "unsupported monitor level $OCF_CHECK_LEVEL"
+			ocf_exit_reason "unsupported monitor level $OCF_CHECK_LEVEL"
 			rc=$OCF_ERR_CONFIGURED
 		;;
 		esac
@@ -780,7 +780,7 @@ case $OP in
 esac
 
 if [ x = x"$DEVICE" ]; then
-	ocf_log err "Please set OCF_RESKEY_device to the device to be managed"
+	ocf_exit_reason "Please set OCF_RESKEY_device to the device to be managed"
 	exit $OCF_ERR_CONFIGURED
 fi
 
@@ -792,7 +792,7 @@ set_blockdevice_var
 # But the output of `mount` and /proc/mounts do not.
 if [ -z "$OCF_RESKEY_directory" ]; then
 	if [ X$OP = "Xstart" -o $blockdevice = "no" ]; then
-		ocf_log err "Please specify the directory"
+		ocf_exit_reason "Please specify the directory"
 		exit $OCF_ERR_CONFIGURED 
 	fi
 else
@@ -854,7 +854,7 @@ esac
 if ocf_is_clone; then
 	case $CLUSTERSAFE in
 	0)
-		ocf_log err "DANGER! $FSTYPE on $DEVICE is NOT cluster-aware!"
+		ocf_exit_reason "DANGER! $FSTYPE on $DEVICE is NOT cluster-aware!"
 		ocf_log err "DO NOT RUN IT AS A CLONE!"
 		ocf_log err "Politely refusing to proceed to avoid data corruption."
 		exit $OCF_ERR_CONFIGURED

--- a/heartbeat/IPsrcaddr
+++ b/heartbeat/IPsrcaddr
@@ -111,7 +111,7 @@ END
 }
 
 errorexit() {
-	ocf_log err "$*"
+	ocf_exit_reason "$*"
 	exit $OCF_ERR_GENERIC
 }
 
@@ -253,7 +253,7 @@ CheckIP() {
 	    ( [ $1 -le 254 ] && [ $2 -le 254 ] && [ $3 -le 254 ] && [ $4 -le 254 ] )
 	then
 	    if [ $1 -eq 127 ]; then
-		ocf_log err "IP address [$ip] is a loopback address, thus can not be preferred source address"
+		ocf_exit_reason "IP address [$ip] is a loopback address, thus can not be preferred source address"
 		exit $OCF_ERR_CONFIGURED
 	    fi
 	else
@@ -368,7 +368,7 @@ ip_status() {
 
 	  case $IF in
 	  	lo*)  
-		    ocf_log err "IP address [$BASEIP] is served by loopback, thus can not be preferred source address"
+		    ocf_exit_reason "IP address [$BASEIP] is served by loopback, thus can not be preferred source address"
 		    exit $OCF_ERR_CONFIGURED
 		    ;;
 		*)return $OCF_SUCCESS;;
@@ -394,7 +394,7 @@ srca_validate_all() {
 	if CheckIP "$ipaddress"; then
 	  : 
 	else
-	  ocf_log err "Invalid IP address [$ipaddress]"
+	  ocf_exit_reason "Invalid IP address [$ipaddress]"
 	  exit $OCF_ERR_CONFIGURED
 	fi
 
@@ -406,7 +406,7 @@ srca_validate_all() {
 	if ip_status "$ipaddress"; then
 	  :
 	else
-	  ocf_log err "We are not serving [$ipaddress], hence can not make it a preferred source address"
+	  ocf_exit_reason "We are not serving [$ipaddress], hence can not make it a preferred source address"
 	  exit $OCF_ERR_INSTALLED
 	fi
 }
@@ -434,7 +434,7 @@ if
   [ -z "$OCF_RESKEY_ipaddress" ]
 then
 #  usage
-  ocf_log err "Please set OCF_RESKEY_ipaddress to the preferred source IP address!"
+  ocf_exit_reason "Please set OCF_RESKEY_ipaddress to the preferred source IP address!"
   exit $OCF_ERR_CONFIGURED
 fi
 
@@ -447,7 +447,7 @@ fi
 findif_out=`$FINDIF -C`
 rc=$?
 [ $rc -ne 0 ] && {
-    ocf_log err "[$FINDIF -C] failed"
+    ocf_exit_reason "[$FINDIF -C] failed"
     exit $rc
 }
 

--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -175,8 +175,8 @@ verify_tags_environment()
 	# guarantee our tag will be filtered on startup
 	##
 	if ! lvm dumpconfig activation/volume_list; then
-		ocf_log err "LVM: Improper setup detected"
-		ocf_log err "The volume_list filter must be initialized in lvm.conf for exclusive activation without clvmd"
+		ocf_log err  "LVM: Improper setup detected"
+		ocf_exit_reason "The volume_list filter must be initialized in lvm.conf for exclusive activation without clvmd"
 		return $OCF_ERR_GENERIC
 	fi
 
@@ -187,7 +187,7 @@ verify_tags_environment()
 	##
 	if lvm dumpconfig activation/volume_list | grep -e "\"@$OUR_TAG\"" -e "\"${OCF_RESKEY_volgrpname}\""; then
 		ocf_log err "LVM:  Improper setup detected"
-		ocf_log err "The volume_list in lvm.conf must not contain the cluster tag, \"$OUR_TAG\", or volume group, $OCF_RESKEY_volgrpname"
+		ocf_exit_reason "The volume_list in lvm.conf must not contain the cluster tag, \"$OUR_TAG\", or volume group, $OCF_RESKEY_volgrpname"
 		return $OCF_ERR_GENERIC
 	fi
 
@@ -257,7 +257,7 @@ strip_tags()
 	done
 
 	if [ ! -z `vgs -o tags --noheadings $OCF_RESKEY_volgrpname | tr -d ' '` ]; then
-		ocf_log err "Failed to remove ownership tags from $OCF_RESKEY_volgrpname"
+		ocf_exit_reason "Failed to remove ownership tags from $OCF_RESKEY_volgrpname"
 		return $OCF_ERR_GENERIC
 	fi
 
@@ -284,7 +284,7 @@ set_tags()
 
 	vgchange --addtag $OUR_TAG $OCF_RESKEY_volgrpname
 	if [ $? -ne 0 ]; then
-		ocf_log err "Failed to add ownership tag to $OCF_RESKEY_volgrpname"
+		ocf_exit_reason "Failed to add ownership tag to $OCF_RESKEY_volgrpname"
 		return $OCF_ERR_GENERIC
 	fi
 
@@ -315,7 +315,7 @@ LVM_status() {
 		test "`cd /dev/$1 && ls`" != ""
 		rc=$?
 		if [ $rc -ne 0 ]; then
-			ocf_log err "VG $1 with no logical volumes is not supported by this RA!"
+			ocf_exit_reason "VG $1 with no logical volumes is not supported by this RA!"
 		fi
 	fi
 
@@ -328,7 +328,7 @@ LVM_status() {
 			# If vg is running, make sure the correct tag is present. Otherwise we
 			# can not guarantee exclusive activation.
 			if ! check_tags; then
-				ocf_log err "WARNING: $OCF_RESKEY_volgrpname is active without the cluster tag, \"$OUR_TAG\""
+				ocf_exit_reason "WARNING: $OCF_RESKEY_volgrpname is active without the cluster tag, \"$OUR_TAG\""
 				rc=$OCF_ERR_GENERIC
 			fi
 
@@ -397,7 +397,7 @@ retry_exclusive_start()
 			return $OCF_ERR_GENERIC;;
 		*)
 			if ! lvchange -an $OCF_RESKEY_volgrpname/$1; then
-				ocf_log err "Unable to perform required deactivation of $OCF_RESKEY_volgrpname/$1 before starting"
+				ocf_exit_reason "Unable to perform required deactivation of $OCF_RESKEY_volgrpname/$1 before starting"
 				return $OCF_ERR_GENERIC
 			fi
 			;;
@@ -456,7 +456,7 @@ LVM_start() {
 		: OK Volume $vg activated just fine!
 		return $OCF_SUCCESS 
 	else
-		ocf_log err "LVM: $vg did not activate correctly"
+		ocf_exit_reason "LVM: $vg did not activate correctly"
 		return $OCF_NOT_RUNNING
 	fi
 }
@@ -485,7 +485,7 @@ LVM_stop() {
 		ocf_run vgchange $vgchange_options $vg
 		res=$?
 		if LVM_status $vg; then
-			ocf_log err "LVM: $vg did not stop correctly"
+			ocf_exit_reason "LVM: $vg did not stop correctly"
 			res=1
 		fi
 
@@ -542,7 +542,7 @@ LVM_validate_all() {
 	##
 	VGOUT=`vgck ${VOLUME} 2>&1`
 	if [ $? -ne 0 ]; then
-		ocf_log err "Volume group [$VOLUME] does not exist or contains error! ${VGOUT}"
+		ocf_exit_reason "Volume group [$VOLUME] does not exist or contains error! ${VGOUT}"
 		exit $OCF_ERR_GENERIC
 	fi
 
@@ -555,7 +555,7 @@ LVM_validate_all() {
 		VGOUT=`vgdisplay -v ${VOLUME} 2>&1`
 	fi
 	if [ $? -ne 0 ]; then
-		ocf_log err "Volume group [$VOLUME] does not exist or contains error! ${VGOUT}"
+		ocf_exit_reason "Volume group [$VOLUME] does not exist or contains error! ${VGOUT}"
 		exit $OCF_ERR_GENERIC
 	fi
 
@@ -571,7 +571,7 @@ LVM_validate_all() {
 	# Having cloned lvm resources with exclusive vg activation makes no sense at all.
 	##
 	if ocf_is_clone; then
-		ocf_log err "cloned lvm resources can not be activated exclusively"
+		ocf_exit_reason "cloned lvm resources can not be activated exclusively"
 		exit $OCF_ERR_CONFIGURED
 	fi
 
@@ -590,7 +590,7 @@ LVM_validate_all() {
 		# verify is clvmd running
 		##
 		if ! ps -C clvmd > /dev/null 2>&1; then
-			ocf_log err "$OCF_RESKEY_volgrpname has the cluster attribute set, but 'clvmd' is not running"
+			ocf_exit_reason "$OCF_RESKEY_volgrpname has the cluster attribute set, but 'clvmd' is not running"
 			exit $OCF_ERR_GENERIC
 		fi
 		;;
@@ -627,7 +627,7 @@ esac
 if 
 	[ -z "$OCF_RESKEY_volgrpname" ]
 then
-	ocf_log err "You must identify the volume group name!"
+	ocf_exit_reason "You must identify the volume group name!"
 	exit $OCF_ERR_CONFIGURED 
 fi
 
@@ -654,7 +654,7 @@ rc=$?
 if
 	( [ $rc -ne 0 ] || [ -z "$LVM_VERSION" ] )
 then
-	ocf_log err "LVM: $1 could not determine LVM version. Try 'vgchange --version' manually and modify $0 ?"
+	ocf_exit_reason "LVM: $1 could not determine LVM version. Try 'vgchange --version' manually and modify $0 ?"
 	exit $OCF_ERR_INSTALLED
 fi
 LVM_MAJOR="${LVM_VERSION%%.*}"

--- a/heartbeat/MailTo
+++ b/heartbeat/MailTo
@@ -131,7 +131,7 @@ MailToStatus () {
 
 MailToValidateAll () {
 	if [ -z "$MAILCMD" ]; then
-		ocf_log err "MAILCMD not set: complain to the packager"
+		ocf_exit_reason "MAILCMD not set: complain to the packager"
 		exit $OCF_ERR_INSTALLED
 	fi
 	check_binary "$MAILCMD"
@@ -169,7 +169,7 @@ esac
 if 
   [ -z "$OCF_RESKEY_email" ]
 then
-  ocf_log err "At least 1 Email address has to be given!"
+  ocf_exit_reason "At least 1 Email address has to be given!"
   exit $OCF_ERR_CONFIGURED
 fi
 

--- a/heartbeat/Route
+++ b/heartbeat/Route
@@ -174,7 +174,7 @@ route_start() {
 	ocf_log info "${OCF_RESOURCE_INSTANCE} Added network route: $route_spec"
 	return $OCF_SUCCESS
     else
-	ocf_log error "${OCF_RESOURCE_INSTANCE} Failed to add network route: $route_spec"
+	ocf_exit_reason "${OCF_RESOURCE_INSTANCE} Failed to add network route: $route_spec"
     fi
     return $OCF_ERR_GENERIC
 }
@@ -189,7 +189,7 @@ route_stop() {
 		ocf_log info "${OCF_RESOURCE_INSTANCE} Removed network route: $route_spec"
 		return $OCF_SUCCESS
 	    else
-		ocf_log error "${OCF_RESOURCE_INSTANCE} Failed to remove network route: $route_spec"
+		ocf_exit_reason "${OCF_RESOURCE_INSTANCE} Failed to remove network route: $route_spec"
 	    fi
 	    ;;
 	$OCF_NOT_RUNNING)
@@ -224,24 +224,24 @@ route_validate() {
     # If we're running as a clone, are the clone meta attrs OK?
     if [ "${OCF_RESKEY_CRM_meta_clone}" ]; then
 	if [ "${OCF_RESKEY_CRM_meta_clone_node_max}" != 1 ]; then
-	    ocf_log error "Misconfigured clone parameters. Must set meta attribute \"clone_node_max\" to 1, got ${OCF_RESKEY_CRM_meta_clone_node_max}."
+	    ocf_exit_reason "Misconfigured clone parameters. Must set meta attribute \"clone_node_max\" to 1, got ${OCF_RESKEY_CRM_meta_clone_node_max}."
 	    return $OCF_ERR_ARGS
 	fi
     fi
     # Did we get a destination?
     if [ -z "${OCF_RESKEY_destination}" ]; then
-	ocf_log error "Missing required parameter \"destination\"."
+	ocf_exit_reason "Missing required parameter \"destination\"."
 	return $OCF_ERR_ARGS
     fi
     # Did we get either a device or a gateway address?
     if [ -z "${OCF_RESKEY_device}" -a -z "${OCF_RESKEY_gateway}" ]; then
-	ocf_log error "Must specifiy either \"device\", or \"gateway\", or both."
+	ocf_exit_reason "Must specifiy either \"device\", or \"gateway\", or both."
 	return $OCF_ERR_ARGS
     fi
     # If a device has been configured, is it available on this system?
     if [ -n "${OCF_RESKEY_device}" ]; then
 	if ! ip link show ${OCF_RESKEY_device} >/dev/null 2>&1; then
-	    ocf_log error "Network device ${OCF_RESKEY_device} appears not to be available on this system."
+	    ocf_exit_reason "Network device ${OCF_RESKEY_device} appears not to be available on this system."
 	    # OCF_ERR_ARGS prevents the resource from running anywhere at all,
 	    # maybe another node has the interface?
             # OCF_ERR_INSTALLED just prevents starting on this particular node.
@@ -256,7 +256,7 @@ route_validate() {
         # this system?
 	if [ -n "${OCF_RESKEY_source}" ]; then
 	    if ! ip address show | grep -w ${OCF_RESKEY_source} >/dev/null 2>&1; then
-		ocf_log error "Source address ${OCF_RESKEY_source} appears not to be available on this system."
+		ocf_exit_reason "Source address ${OCF_RESKEY_source} appears not to be available on this system."
 	    # same reason as with _device:
 		return $OCF_ERR_INSTALLED
 	    fi
@@ -264,7 +264,7 @@ route_validate() {
         # If a gateway address has been configured, is it reachable?
 	if [ -n "${OCF_RESKEY_gateway}" ]; then
 	    if ! ip route get ${OCF_RESKEY_gateway} >/dev/null 2>&1; then
-		ocf_log error "Gateway address ${OCF_RESKEY_gateway} is unreachable."
+		ocf_exit_reason "Gateway address ${OCF_RESKEY_gateway} is unreachable."
 	    # same reason as with _device:
 		return $OCF_ERR_INSTALLED
 	    fi

--- a/heartbeat/SendArp
+++ b/heartbeat/SendArp
@@ -166,10 +166,10 @@ sendarp_start() {
 	# and wait-ing would be equal to not running in
 	# background
 	($SENDARP $ARGS ||
-	    ocf_log err "Could not send gratuitous arps") &
+	    ocf_exit_reason "Could not send gratuitous arps") &
     else
 	$SENDARP $ARGS || {
-	    ocf_log err "Could not send gratuitous arps"
+	    ocf_exit_reason "Could not send gratuitous arps"
 	    rc=$OCF_ERR_GENERIC
 	}
     fi

--- a/heartbeat/Squid
+++ b/heartbeat/Squid
@@ -216,7 +216,7 @@ are_pids_sane()
 	if [[ "${SQUID_PIDS[1]}" = "${SQUID_PIDS[2]}" ]]; then
 		return $OCF_SUCCESS
 	else
-		ocf_log err "$SQUID_NAME:Pid unmatch"
+		ocf_exit_reason "$SQUID_NAME:Pid unmatch"
 		return $OCF_ERR_GENERIC
 	fi
 }
@@ -253,7 +253,7 @@ monitor_squid()
 			"${SQUID_PIDS[0]},${SQUID_PIDS[1]},${SQUID_PIDS[2]}"
 		(( trialcount = trialcount + 1 ))
 		if (( trialcount > SQUID_CONFIRM_TRIALCOUNT )); then
-			ocf_log err "$SQUID_NAME:Inconsistency of processes remains unsolved"
+			ocf_exit_reason "$SQUID_NAME:Inconsistency of processes remains unsolved"
 			return $OCF_ERR_GENERIC
 		fi
 		sleep 1
@@ -348,7 +348,7 @@ fi
 
 SQUID_CONF="${OCF_RESKEY_squid_conf}"
 if [[ -z "$SQUID_CONF" ]]; then
-	ocf_log err "SQUID_CONF is not defined"
+	ocf_exit_reason "SQUID_CONF is not defined"
 	exit $OCF_ERR_CONFIGURED
 fi
 
@@ -374,23 +374,23 @@ fi
 
 SQUID_EXE="${OCF_RESKEY_squid_exe}"
 if [[ -z "$SQUID_EXE" ]]; then
-	ocf_log err "SQUID_EXE is not defined"
+	ocf_exit_reason "SQUID_EXE is not defined"
 	exit $OCF_ERR_CONFIGURED
 fi
 if [[ ! -x "$SQUID_EXE" ]]; then
-	ocf_log err "$SQUID_EXE is not found"
+	ocf_exit_reason "$SQUID_EXE is not found"
 	exit $OCF_ERR_CONFIGURED
 fi
 
 SQUID_PIDFILE="${OCF_RESKEY_squid_pidfile}"
 if [[ -z "$SQUID_PIDFILE" ]]; then
-	ocf_log err "SQUID_PIDFILE is not defined"
+	ocf_exit_reason "SQUID_PIDFILE is not defined"
 	exit $OCF_ERR_CONFIGURED
 fi
 
 SQUID_PORT="${OCF_RESKEY_squid_port}"
 if [[ -z "$SQUID_PORT" ]]; then
-	ocf_log err "SQUID_PORT is not defined"
+	ocf_exit_reason "SQUID_PORT is not defined"
 	exit $OCF_ERR_CONFIGURED
 fi
 

--- a/heartbeat/Xinetd
+++ b/heartbeat/Xinetd
@@ -89,11 +89,11 @@ hup_inetd () {
 	if kill -s HUP $pid; then
             ocf_log info "asked xinetd to reload by sending SIGHUP to process $pid!"
 	else
-            ocf_log err "could not send SIGHUP to process $pid!"
+            ocf_exit_reason "could not send SIGHUP to process $pid!"
             exit $OCF_ERR_GENERIC
 	fi
     else
-	ocf_log err "xinetd process not found!"
+	ocf_exit_reason "xinetd process not found!"
 	exit $OCF_ERR_GENERIC
     fi
 }
@@ -161,7 +161,7 @@ xup_usage () {
 
 xup_validate_all () {
     if [ ! -f "$SVCDEF" ]; then
-        ocf_log err "service $service missing $SVCDEF"
+        ocf_exit_reason "service $service missing $SVCDEF"
 	return $OCF_ERR_INSTALLED
     fi
     return $OCF_SUCCESS
@@ -185,7 +185,7 @@ case "$1" in
 esac
 
 if [ -z "$OCF_RESKEY_service" ]; then
-    ocf_log err "please define \"service\" parameter"
+    ocf_exit_reason "please define \"service\" parameter"
     if [ "$1" = "start" ]; then 
 	exit $OCF_ERR_CONFIGURED
     else
@@ -198,14 +198,14 @@ if [ -z "`get_xinetd_pid`" ]; then
     case "$1" in
     stop) exit $OCF_SUCCESS;;
     start)
-	ocf_log err "xinetd not running, we manage just xinetd services, not the daemon itself"
+	ocf_exit_reason "xinetd not running, we manage just xinetd services, not the daemon itself"
 	exit $OCF_ERR_INSTALLED
 	;;
     status|monitor)
 	if ocf_is_probe; then
 	    exit $OCF_NOT_RUNNING
 	else
-	    ocf_log err "xinetd stopped"
+	    ocf_exit_reason "xinetd stopped"
 	    exit $OCF_ERR_GENERIC
 	fi
 	;;
@@ -214,7 +214,7 @@ fi
 
 # Make sure the OCF_RESKEY_service is a valid xinetd service name
 if [ ! -f $SVCDEF ]; then
-    ocf_log err "service definition $SVCDEF not found!"
+    ocf_exit_reason "service definition $SVCDEF not found!"
     if [ "$1" = "start" ]; then 
 	exit $OCF_ERR_INSTALLED
     else

--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -288,7 +288,7 @@ apache_stop() {
 		kill_stop $pid
 
 		if ProcessRunning $pid; then
-			ocf_log info "$CMD still running ($pid). Killing pid failed."
+			ocf_exit_reason "$CMD still running ($pid). Killing pid failed."
 			ret=$OCF_ERR_GENERIC
 		fi
 	fi
@@ -319,7 +319,7 @@ apache_monitor_10() {
 		return $OCF_SUCCESS
 	else
 		if ! ocf_is_probe; then
-			ocf_log err "Failed to access httpd status page."
+			ocf_exit_reason "Failed to access httpd status page."
 		fi
 		return $OCF_ERR_GENERIC
 	fi
@@ -370,7 +370,7 @@ apache_monitor_basic() {
 	fi
 
 	if ! ocf_is_probe; then
-		ocf_log err "Failed to access httpd status page."
+		ocf_exit_reason "Failed to access httpd status page."
 	fi
 	return $OCF_ERR_GENERIC
 }
@@ -383,7 +383,7 @@ apache_monitor() {
 
 	ourhttpclient=`findhttpclient`  # we'll need one
 	if [ -z "$ourhttpclient" ]; then
-		ocf_log err "could not find a http client; make sure that either wget or curl is available"
+		ocf_exit_reason "could not find a http client; make sure that either wget or curl is available"
 		return $OCF_ERR_INSTALLED
 	fi
 
@@ -582,15 +582,15 @@ END
 
 apache_validate_all() {
 	if [ -z "$HTTPD" ]; then
-		ocf_log err "apache httpd program not found"
+		ocf_exit_reason "apache httpd program not found"
 		return $OCF_ERR_INSTALLED
 	fi
 	if [ ! -x "$HTTPD" ]; then
-		ocf_log err "HTTPD $HTTPD not found or is not an executable!"
+		ocf_exit_reason "HTTPD $HTTPD not found or is not an executable!"
 		return $OCF_ERR_INSTALLED
 	fi
 	if [ ! -f $CONFIGFILE ]; then
-		ocf_log err "Configuration file $CONFIGFILE not found!"
+		ocf_exit_reason "Configuration file $CONFIGFILE not found!"
 		return $OCF_ERR_INSTALLED
 	fi
 	return $OCF_SUCCESS

--- a/heartbeat/clvm
+++ b/heartbeat/clvm
@@ -169,7 +169,7 @@ check_process()
 			return $OCF_NOT_RUNNING;;
 		*)
 			rm -f "$pidfile" > /dev/null 2>&1 
-			ocf_log err "Error encountered detecting pid status of $binary"
+			ocf_exit_reason "Error encountered detecting pid status of $binary"
 			return $OCF_ERR_GENERIC;;
 	esac
 }
@@ -180,7 +180,7 @@ clvmd_status()
 	local mirror_rc
 	clvmd_validate
 	if [ $? -ne $OCF_SUCCESS ]; then
-		ocf_log error "Unable to monitor, Environment validation failed."
+		ocf_exit_reason "Unable to monitor, Environment validation failed."
 		return $?
 	fi
 
@@ -260,7 +260,7 @@ clvmd_stop()
 			ocf_log info "Deactivating clustered VG(s):" 
 			ocf_run ${LVM_VGCHANGE} -anl $LVM_VGS
 			if [ $? -ne 0 ]; then
-				ocf_log error "Failed to deactivate volume groups, cluster vglist = $LVM_VGS" 
+				ocf_exit_reason "Failed to deactivate volume groups, cluster vglist = $LVM_VGS" 
 				return $OCF_ERR_GENERIC
 			fi
 		fi
@@ -268,14 +268,14 @@ clvmd_stop()
 		ocf_log info "Signaling $DAEMON to exit"
 		killall -TERM $DAEMON
 		if [ $? != 0 ]; then
-			ocf_log error "Failed to signal -TERM to $DAEMON"
+			ocf_exit_reason "Failed to signal -TERM to $DAEMON"
 			return $OCF_ERR_GENERIC
 		fi
 
 		wait_for_process $DAEMON $CLVMD_TIMEOUT
 		rc=$?
 		if [ $rc -ne $OCF_SUCCESS ]; then
-			ocf_log error "$DAEMON failed to exit"
+			ocf_exit_reason "$DAEMON failed to exit"
 			return $rc
 		fi
 
@@ -313,7 +313,7 @@ start_process()
 		ocf_run $binary_path $opts
 		rc=$?
 		if [ $rc -ne 0 ]; then
-			ocf_log error "Failed to launch $binary_path, exit code $rc"
+			ocf_exit_reason "Failed to launch $binary_path, exit code $rc"
 			exit $OCF_ERR_GENERIC
 		fi
 	fi
@@ -341,7 +341,7 @@ clvmd_start()
 
 	clvmd_validate
 	if [ $? -ne $OCF_SUCCESS ]; then
-		ocf_log error "Unable to start, Environment validation failed."
+		ocf_exit_reason "Unable to start, Environment validation failed."
 		return $?
 	fi
 

--- a/heartbeat/conntrackd
+++ b/heartbeat/conntrackd
@@ -98,7 +98,7 @@ meta_expect()
                 # [, not [[, or it won't work ;)
                 [ $val $op $expect ] && return
         fi
-        ocf_log err "meta parameter misconfigured, expected $what $op $expect, but found ${val:-unset}."
+        ocf_exit_reason "meta parameter misconfigured, expected $what $op $expect, but found ${val:-unset}."
         exit $OCF_ERR_CONFIGURED
 }
 
@@ -123,7 +123,7 @@ conntrackd_monitor() {
 		# now see if it acceppts queries
 		if ! $OCF_RESKEY_binary -C $OCF_RESKEY_config -s > /dev/null 2>&1; then
 			rc=$OCF_ERR_GENERIC
-			ocf_log err "conntrackd is running but not responding to queries"
+			ocf_exit_reason "conntrackd is running but not responding to queries"
 		fi
 		if conntrackd_is_master; then
 			rc=$OCF_RUNNING_MASTER
@@ -154,7 +154,7 @@ conntrackd_start() {
 			conntrackd_set_master_score $slave_score
 			# -n = request resync from the others
 			if ! $OCF_RESKEY_binary -C $OCF_RESKEY_config -n; then
-				ocf_log err "$OCF_RESKEY_binary -C $OCF_RESKEY_config -n failed during start."
+				ocf_exit_reason "$OCF_RESKEY_binary -C $OCF_RESKEY_config -n failed during start."
 				rc=$OCF_ERR_GENERIC
 			else
 				rc=$OCF_SUCCESS
@@ -170,7 +170,7 @@ conntrackd_start() {
 			ha_pseudo_resource $statefile stop
 			;;
 		$OCF_ERR_GENERIC)
-			ocf_log err "conntrackd start failed"
+			ocf_exit_reason "conntrackd start failed"
 			rc=$OCF_ERR_GENERIC
 			break
 			;;
@@ -208,7 +208,7 @@ conntrackd_stop() {
 conntrackd_validate_all() {
 	check_binary "$OCF_RESKEY_binary"
 	if ! [ -e "$OCF_RESKEY_config" ]; then
-		ocf_log err "Config FILE $OCF_RESKEY_config does not exist"
+		ocf_exit_reason "Config FILE $OCF_RESKEY_config does not exist"
 		return $OCF_ERR_INSTALLED
 	fi
         meta_expect master-node-max = 1
@@ -227,7 +227,7 @@ conntrackd_promote() {
 		# -B = send a bulk update on the line
 		for parm in c f R B; do
 			if ! $OCF_RESKEY_binary -C $OCF_RESKEY_config -$parm; then
-				ocf_log err "$OCF_RESKEY_binary -C $OCF_RESKEY_config -$parm failed during promote."
+				ocf_exit_reason "$OCF_RESKEY_binary -C $OCF_RESKEY_config -$parm failed during promote."
 				rc=$OCF_ERR_GENERIC
 				break
 			fi
@@ -245,7 +245,7 @@ conntrackd_demote() {
 		# -n = request a resync from the others
 		for parm in t n; do
 			if ! $OCF_RESKEY_binary -C $OCF_RESKEY_config -$parm; then
-                        	ocf_log err "$OCF_RESKEY_binary -C $OCF_RESKEY_config -$parm failed during demote."
+                        	ocf_exit_reason "$OCF_RESKEY_binary -C $OCF_RESKEY_config -$parm failed during demote."
                         	rc=$OCF_ERR_GENERIC
                         	break
                 	fi

--- a/heartbeat/dhcpd
+++ b/heartbeat/dhcpd
@@ -189,17 +189,17 @@ dhcpd_validate_all() {
 	# chroot mode is enabled.
 	if ocf_is_true $OCF_RESKEY_chrooted ; then
 	    if ! test -e "$OCF_RESKEY_chrooted_path"; then
-		ocf_log err "Path $OCF_RESKEY_chrooted_path does not exist."
+		ocf_exit_reason "Path $OCF_RESKEY_chrooted_path does not exist."
 		return $OCF_ERR_INSTALLED
 	    fi
 
 	    if test -n "$OCF_RESKEY_chrooted_path/$OCF_RESKEY_config" -a ! -r "$OCF_RESKEY_chrooted_path/$OCF_RESKEY_config"; then
-		ocf_log err "Configuration file $OCF_RESKEY_chrooted_path/$OCF_RESKEY_config doesn't exist"
+		ocf_exit_reason "Configuration file $OCF_RESKEY_chrooted_path/$OCF_RESKEY_config doesn't exist"
 		return $OCF_ERR_INSTALLED
 	    fi
 	else
 	    if test -n "$OCF_RESKEY_config" -a ! -r "$OCF_RESKEY_config"; then
-		ocf_log err "Configuration file $OCF_RESKEY_config doesn't exist"
+		ocf_exit_reason "Configuration file $OCF_RESKEY_config doesn't exist"
 		return $OCF_ERR_INSTALLED
 	    fi
 	fi
@@ -207,7 +207,7 @@ dhcpd_validate_all() {
     fi 
 
     if ! getent passwd $OCF_RESKEY_user >/dev/null 2>&1; then
-        ocf_log err "User $OCF_RESKEY_user doesn't exist"
+        ocf_exit_reason "User $OCF_RESKEY_user doesn't exist"
         return $OCF_ERR_INSTALLED
     fi
 
@@ -264,7 +264,7 @@ dhcpd_initialize_chroot() {
     ## If there is no conf file, we can't initialize the chrooted 
     ## environment, return with "program not configured"
     if ! [ -f $OCF_RESKEY_config ] ; then
-	ocf_log err "dhcpd has not been configured."
+	ocf_exit_reason "dhcpd has not been configured."
 	return $OCF_ERR_CONFIGURED
     fi
 
@@ -283,7 +283,7 @@ dhcpd_initialize_chroot() {
 	if [ -e $i ] ; then
 	    DEFAULT_FILE_LIST="$DEFAULT_FILE_LIST $i"
 	else
-	    ocf_log err "include file $i does not exist"
+	    ocf_exit_reason "include file $i does not exist"
 	    return $OCF_ERR_INSTALLED
 	fi
     done
@@ -299,7 +299,7 @@ dhcpd_initialize_chroot() {
 
 	# Next, we copy the configuration file into place.
 	cp -aL "$i" "$OCF_RESKEY_chrooted_path/${i%/*}/" > /dev/null 2>&1 ||
-	    { ocf_log err "could not copy $i to chroot jail"; return $OCF_ERR_GENERIC; }
+	    { ocf_exit_reason "could not copy $i to chroot jail"; return $OCF_ERR_GENERIC; }
     done
 
     libdir=$(basename $(echo /var/lib/dhcp/lib*))
@@ -328,7 +328,7 @@ dhcpd_initialize_chroot() {
     for i in $cplibs ; do
 	if [ -s "$i" ]; then
 	    cp -pL "$i" "/var/lib/dhcp/$libdir/" ||
-		{ ocf_log err "could not copy $i to chroot jail"; return $OCF_ERR_GENERIC; }
+		{ ocf_exit_reason "could not copy $i to chroot jail"; return $OCF_ERR_GENERIC; }
 	fi
     done
 
@@ -339,7 +339,7 @@ dhcpd_initialize_chroot() {
 dhcpd_initialize() {
     ## If there is no conf file, we can't start a dhcp service.
     if ! [ -f $OCF_RESKEY_config ] ; then
-	ocf_log err "dhcpd has not been configured."
+	ocf_exit_reason "dhcpd has not been configured."
 	return $OCF_ERR_CONFIGURED
     fi
 
@@ -392,10 +392,10 @@ dhcpd_start() {
     # Only initialize the chrooted path(s) if chroot mode is enabled.
     if ocf_is_true $OCF_RESKEY_chrooted ; then
 	dhcpd_initialize_chroot ||
-	    { ocf_log err "Could not fully initialize the chroot environment." ; return $OCF_ERR_INSTALLED; }
+	    { ocf_exit_reason "Could not fully initialize the chroot environment." ; return $OCF_ERR_INSTALLED; }
     else
 	dhcpd_initialize ||
-	    { ocf_log err "Could not fully initialize the runtime environment." ; return $OCF_ERR_INSTALLED; }
+	    { ocf_exit_reason "Could not fully initialize the runtime environment." ; return $OCF_ERR_INSTALLED; }
     fi
 
     dhcpd_validate_all || exit
@@ -501,7 +501,7 @@ dhcpd_stop () {
 
     #If still up
     if dhcpd_monitor 2>&1; then
-        ocf_log err "dhcpd is still up! Trying kill -s KILL"
+        ocf_log notice "dhcpd is still up! Trying kill -s KILL"
 
 	kill -s SIGKILL `cat $PIDF`
     fi

--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -317,7 +317,7 @@ is_primary()
     fi
 
     if [ -z "$cluster_status" ]; then
-        ocf_log err "Unable to retrieve wsrep_cluster_status, verify check_user '$OCF_RESKEY_check_user' has permissions to view status"
+        ocf_exit_reason "Unable to retrieve wsrep_cluster_status, verify check_user '$OCF_RESKEY_check_user' has permissions to view status"
     else
         ocf_log info "Galera instance wsrep_cluster_status=${cluster_status}"
     fi
@@ -440,7 +440,7 @@ galera_promote()
             ocf_log info "Node <${NODENAME}> is bootstrapping the cluster"
             extra_opts="--wsrep-cluster-address=gcomm://"
         else
-            ocf_log err "Failure, Attempted to promote Master instance of $OCF_RESOURCE_INSTANCE before bootstrap node has been detected."
+            ocf_exit_reason "Failure, Attempted to promote Master instance of $OCF_RESOURCE_INSTANCE before bootstrap node has been detected."
             return $OCF_ERR_GENERIC
         fi
 
@@ -450,7 +450,7 @@ galera_promote()
     mysql_common_stop
     rc=$?
     if [ $rc -ne $OCF_SUCCESS ] && [ $rc -ne $OCF_NOT_RUNNING ]; then
-        ocf_log err "Failed to stop read-only galera instance during promotion to Master"
+        ocf_exit_reason "Failed to stop read-only galera instance during promotion to Master"
         return $rc
     fi
 
@@ -466,19 +466,19 @@ galera_promote()
     galera_monitor
     rc=$?
     if [ $rc != $OCF_SUCCESS -a $rc != $OCF_RUNNING_MASTER ]; then
-        ocf_log err "Failed initial monitor action"
+        ocf_exit_reason "Failed initial monitor action"
         return $rc
     fi
 
     is_readonly
     if [ $? -eq 0 ]; then
-        ocf_log err "Failure. Master instance started in read-only mode, check configuration."
+        ocf_exit_reason "Failure. Master instance started in read-only mode, check configuration."
         return $OCF_ERR_GENERIC
     fi
 
     is_primary
     if [ $? -ne 0 ]; then
-        ocf_log err "Failure. Master instance started, but is not in Primary mode."
+        ocf_exit_reason "Failure. Master instance started, but is not in Primary mode."
         return $OCF_ERR_GENERIC
     fi
 
@@ -504,7 +504,7 @@ galera_demote()
     mysql_common_stop
     rc=$?
     if [ $rc -ne $OCF_SUCCESS ] && [ $rc -ne $OCF_NOT_RUNNING ]; then
-        ocf_log err "Failed to stop Master galera instance during demotion to Master"
+        ocf_exit_reason "Failed to stop Master galera instance during demotion to Master"
         return $rc
     fi
 
@@ -522,7 +522,7 @@ galera_start()
 
     echo $OCF_RESKEY_wsrep_cluster_address | grep -q $NODENAME
     if [ $? -ne 0 ]; then
-        ocf_log err "local node <${NODENAME}> must be a member of the wsrep_cluster_address <${OCF_RESKEY_wsrep_cluster_address}>to start this galera instance"
+        ocf_exit_reason "local node <${NODENAME}> must be a member of the wsrep_cluster_address <${OCF_RESKEY_wsrep_cluster_address}>to start this galera instance"
         return $OCF_ERR_CONFIGURED
     fi
 
@@ -531,7 +531,7 @@ galera_start()
 
     is_readonly
     if [ $? -ne 0 ]; then
-        ocf_log err "Failure. Slave instance did not start correctly in read-only mode, Make sure local galera.cnf does not have wsrep_cluster_address set."
+        ocf_exit_reason "Slave instance did not start correctly in read-only mode, Make sure local galera.cnf does not have wsrep_cluster_address set."
         return $OCF_ERR_GENERIC
     fi
 
@@ -578,7 +578,7 @@ galera_monitor()
 
     echo $OCF_RESKEY_wsrep_cluster_address | grep -q $NODENAME
     if [ $? -ne 0 ]; then
-        ocf_log err "local node <${NODENAME}> is started, but is not a member of the wsrep_cluster_address <${OCF_RESKEY_wsrep_cluster_address}>"
+        ocf_exit_reason "local node <${NODENAME}> is started, but is not a member of the wsrep_cluster_address <${OCF_RESKEY_wsrep_cluster_address}>"
         return $OCF_ERR_GENERIC
     fi
 
@@ -586,7 +586,7 @@ galera_monitor()
     if [ $? -ne 0 ]; then
         is_primary
         if [ $? -ne 0 ]; then
-            ocf_log err "local node <${NODENAME}> is neither in primary mode nor in read_only mode. Unknown state."
+            ocf_exit_reason "local node <${NODENAME}> is neither in primary mode nor in read_only mode. Unknown state."
             return $OCF_ERR_GENERIC
         fi
 
@@ -628,12 +628,12 @@ galera_stop()
 galera_validate()
 {
     if ! ocf_is_ms; then
-        ocf_log err "Galera must be configured as a multistate Master/Slave resource."
+        ocf_exit_reason "Galera must be configured as a multistate Master/Slave resource."
         return $OCF_ERR_CONFIGURED
     fi
 
     if [ -z "$OCF_RESKEY_wsrep_cluster_address" ]; then
-        ocf_log err "Galera must be configured with a wsrep_cluster_address value."
+        ocf_exit_reason "Galera must be configured with a wsrep_cluster_address value."
         return $OCF_ERR_CONFIGURED
     fi
 

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -394,7 +394,7 @@ get_slave_info() {
         else
             # Instance produced an empty "SHOW SLAVE STATUS" output --
             # instance is not a slave
-            ocf_log err "check_slave invoked on an instance that is not a replication slave."
+            ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
             return $OCF_ERR_GENERIC
         fi
 
@@ -415,7 +415,7 @@ check_slave() {
             # Whoa. Replication ran into an error. This slave has
             # diverged from its master. Make sure this resource
             # doesn't restart in place.
-            ocf_log err "MySQL instance configured for replication, but replication has failed."
+            ocf_exit_reason "MySQL instance configured for replication, but replication has failed."
             ocf_log err "See $tmpfile for details"
 
             # Just pull the reader VIP away, killing MySQL here would be pretty evil
@@ -454,7 +454,7 @@ check_slave() {
             # We don't have a replication SQL thread running. Not a
             # good thing. Try to recoved by restarting the SQL thread
             # and remove reader vip.  Prevent MySQL restart.
-            ocf_log err "MySQL Slave SQL threads currently not running."
+            ocf_exit_reason "MySQL Slave SQL threads currently not running."
             ocf_log err "See $tmpfile for details"
 
             # Remove reader vip
@@ -472,7 +472,7 @@ check_slave() {
             # We're supposed to bail out if we lag too far
             # behind. Let's check our lag.
             if [ "$secs_behind" = "NULL" ] || [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
-                ocf_log err "MySQL Slave is $secs_behind seconds behind master (allowed maximum: $OCF_RESKEY_max_slave_lag)."
+                ocf_exit_reason "MySQL Slave is $secs_behind seconds behind master (allowed maximum: $OCF_RESKEY_max_slave_lag)."
                 ocf_log err "See $tmpfile for details"
 
                 # Remove reader vip
@@ -507,7 +507,7 @@ check_slave() {
         # instance is not a slave
         # TODO: Needs to handle when get_slave_info will return too many connections error
         rm -f $tmpfile
-        ocf_log err "check_slave invoked on an instance that is not a replication slave."
+        ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
         exit $OCF_ERR_GENERIC
     fi
 }
@@ -596,7 +596,7 @@ unset_master(){
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
         -e "STOP SLAVE IO_THREAD"
     if [ $? -gt 0 ]; then
-        ocf_log err "Error stopping slave IO thread"
+        ocf_exit_reason "Error stopping slave IO thread"
         exit $OCF_ERR_GENERIC
     fi
 
@@ -620,14 +620,14 @@ unset_master(){
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
         -e "STOP SLAVE"
     if [ $? -gt 0 ]; then
-        ocf_log err "Error stopping rest slave threads"
+        ocf_exit_reason "Error stopping rest slave threads"
         exit $OCF_ERR_GENERIC
     fi
 
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
         -e "RESET SLAVE /*!50516 ALL */;"
     if [ $? -gt 0 ]; then
-        ocf_log err "Failed to reset slave"
+        ocf_exit_reason "Failed to reset slave"
         exit $OCF_ERR_GENERIC
     fi
 }
@@ -737,7 +737,7 @@ mysql_monitor() {
         rc=$?
 
         if [ $rc -ne 0 ]; then
-            ocf_log err "Failed to select from $test_table";
+            ocf_exit_reason "Failed to select from $test_table";
             return $OCF_ERR_GENERIC;
         fi
     fi
@@ -800,7 +800,7 @@ mysql_start() {
             set_master
             start_slave
             if [ $? -ne 0 ]; then
-                ocf_log err "Failed to start slave"
+                ocf_exit_reason "Failed to start slave"
                 return $OCF_ERR_GENERIC
             fi
         else
@@ -823,7 +823,7 @@ mysql_start() {
     mysql_monitor
     rc=$?
     if [ $rc != $OCF_SUCCESS -a $rc != $OCF_RUNNING_MASTER ]; then
-        ocf_log err "Failed initial monitor action"
+        ocf_exit_reason "Failed initial monitor action"
         return $rc
     fi
 
@@ -921,7 +921,7 @@ mysql_notify() {
 
                 start_slave
                 if [ $? -ne 0 ]; then
-                    ocf_log err "Failed to start slave"
+                    ocf_exit_reason "Failed to start slave"
                     return $OCF_ERR_GENERIC
                 fi
             fi
@@ -933,7 +933,7 @@ mysql_notify() {
                 ocf_log info "post-demote notification for $demote_host"
                 set_read_only on
                 if [ $? -ne 0 ]; then
-                    ocf_log err "Failed to set read-only";
+                    ocf_exit_reason "Failed to set read-only";
                     return $OCF_ERR_GENERIC;
                 fi
 

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -98,24 +98,24 @@ mysql_common_validate()
     check_binary  $OCF_RESKEY_client_binary
 
     if [ ! -f $OCF_RESKEY_config ]; then
-        ocf_log err "Config $OCF_RESKEY_config doesn't exist";
+        ocf_exit_reason "Config $OCF_RESKEY_config doesn't exist";
         return $OCF_ERR_INSTALLED;
     fi
 
     if [ ! -d $OCF_RESKEY_datadir ]; then
-        ocf_log err "Datadir $OCF_RESKEY_datadir doesn't exist";
+        ocf_exit_reason "Datadir $OCF_RESKEY_datadir doesn't exist";
         return $OCF_ERR_INSTALLED;
     fi
 
     getent passwd $OCF_RESKEY_user >/dev/null 2>&1
     if [ ! $? -eq 0 ]; then
-        ocf_log err "User $OCF_RESKEY_user doesn't exit";
+        ocf_exit_reason "User $OCF_RESKEY_user doesn't exit";
         return $OCF_ERR_INSTALLED;
     fi
 
     getent group $OCF_RESKEY_group >/dev/null 2>&1
     if [ ! $? -eq 0 ]; then
-        ocf_log err "Group $OCF_RESKEY_group doesn't exist";
+        ocf_exit_reason "Group $OCF_RESKEY_group doesn't exist";
         return $OCF_ERR_INSTALLED;
     fi
 
@@ -162,7 +162,7 @@ mysql_common_prepare_dirs()
         $MYSQL_BINDIR/mysql_install_db --datadir=$OCF_RESKEY_datadir
         rc=$?
         if [ $rc -ne 0 ] ; then
-            ocf_log err "Initialization failed: $rc";
+            ocf_exit_reason "Initialization failed: $rc";
             exit $OCF_ERR_GENERIC
         fi
         chown -R $OCF_RESKEY_user:$OCF_RESKEY_group $OCF_RESKEY_datadir
@@ -187,7 +187,7 @@ mysql_common_prepare_dirs()
     # user
     for dir in $pid_dir $socket_dir; do
         if ! su -s /bin/sh - $OCF_RESKEY_user -c "test -w $dir"; then
-            ocf_log err "Directory $dir is not writable by $OCF_RESKEY_user"
+            ocf_exit_reason "Directory $dir is not writable by $OCF_RESKEY_user"
             exit $OCF_ERR_PERM;
         fi
     done
@@ -213,7 +213,7 @@ mysql_common_start()
     while [ $start_wait = 1 ]; do
         if ! ps $pid > /dev/null 2>&1; then
             wait $pid
-            ocf_log err "MySQL server failed to start (pid=$pid) (rc=$?), please check your installation"
+            ocf_exit_reason "MySQL server failed to start (pid=$pid) (rc=$?), please check your installation"
             return $OCF_ERR_GENERIC
         fi
         mysql_common_status info
@@ -244,7 +244,7 @@ mysql_common_stop()
     /bin/kill $pid > /dev/null
     rc=$?
     if [ $rc != 0 ]; then
-        ocf_log err "MySQL couldn't be stopped"
+        ocf_exit_reason "MySQL couldn't be stopped"
         return $OCF_ERR_GENERIC
     fi
     # stop waiting

--- a/heartbeat/named
+++ b/heartbeat/named
@@ -211,21 +211,21 @@ named_validate_all() {
         if ocf_is_probe; then
            ocf_log info "Configuration file ${OCF_RESKEY_named_rootdir}/${OCF_RESKEY_named_config} not readable during probe."
         else
-           ocf_log err "Configuration file ${OCF_RESKEY_named_rootdir}/${OCF_RESKEY_named_config} doesn't exist"
+           ocf_exit_reason "Configuration file ${OCF_RESKEY_named_rootdir}/${OCF_RESKEY_named_config} doesn't exist"
            return $OCF_ERR_INSTALLED
         fi
     fi
 
     getent passwd $OCF_RESKEY_named_user >/dev/null 2>&1
     if [ ! $? -eq 0 ]; then
-        ocf_log err "User $OCF_RESKEY_named_user doesn't exist";
+        ocf_exit_reason "User $OCF_RESKEY_named_user doesn't exist";
         return $OCF_ERR_INSTALLED;
     fi
 
     if [ -z "$OCF_RESKEY_monitor_request" -o \
          -z "$OCF_RESKEY_monitor_response" -o \
          -z "$OCF_RESKEY_monitor_ip" ]; then
-        ocf_log err "None of monitor_request, monitor_response, and monitor_ip can be empty"
+        ocf_exit_reason "None of monitor_request, monitor_response, and monitor_ip can be empty"
         return $OCF_ERR_CONFIGURED
     fi                            
          
@@ -309,7 +309,7 @@ named_monitor() {
 
     if [ $? -ne 0 ] || ! echo $output | grep -q '.* has .*address '"$OCF_RESKEY_monitor_response" 
     then
-       ocf_log err "named didn't answer properly for $OCF_RESKEY_monitor_request."
+       ocf_exit_reason "named didn't answer properly for $OCF_RESKEY_monitor_request."
        ocf_log err "Expected: $OCF_RESKEY_monitor_response."
        ocf_log err "Got: $output"
        return $OCF_ERR_GENERIC
@@ -356,7 +356,7 @@ named_start() {
 
     if ! ${OCF_RESKEY_named} -u ${OCF_RESKEY_named_user} $root_dir_opt ${OCF_RESKEY_named_options}
     then
-        ocf_log err "named failed to start."
+        ocf_exit_reason "named failed to start."
         return $OCF_ERR_GENERIC
     fi
     
@@ -368,7 +368,7 @@ named_start() {
             echo $pid > ${OCF_RESKEY_named_pidfile}
         fi
     else
-        ocf_log err "named failed to start. Probably error in configuration."
+        ocf_exit_reason "named failed to start. Probably error in configuration."
         return $OCF_ERR_GENERIC
     fi
         
@@ -420,7 +420,7 @@ named_stop () {
     
     #If still up    
     if named_status 2>&1; then
-        ocf_log err "named is still up! Killing"
+        ocf_exit_reason "named is still up! Killing"
         kill -9 `cat ${OCF_RESKEY_named_pidfile}`
     fi
     
@@ -460,7 +460,7 @@ then
 fi
 
 if [ `id -u` -ne 0 ]; then
-    ocf_log err "$0 must be run as root"
+    ocf_exit_reason "$0 must be run as root"
     exit $OCF_ERR_GENERIC
 fi
 

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -507,7 +507,7 @@ pgsql_real_start() {
     # Check if we need to create a log file
     if ! check_log_file $OCF_RESKEY_logfile
     then
-        ocf_log err "PostgreSQL can't write to the log file: $OCF_RESKEY_logfile"
+        ocf_exit_reason "PostgreSQL can't write to the log file: $OCF_RESKEY_logfile"
         return $OCF_ERR_PERM
     fi
 
@@ -545,7 +545,7 @@ pgsql_real_start() {
         # Probably started.....
         ocf_log info "PostgreSQL start command sent."
     else
-        ocf_log err "Can't start PostgreSQL."
+        ocf_exit_reason "Can't start PostgreSQL."
         return $OCF_ERR_GENERIC
     fi
 
@@ -577,7 +577,7 @@ pgsql_replication_start() {
     fi
 
     if [ -f $PGSQL_LOCK ]; then
-        ocf_log err "My data may be inconsistent. You have to remove $PGSQL_LOCK file to force start."
+        ocf_exit_reason "My data may be inconsistent. You have to remove $PGSQL_LOCK file to force start."
         return $OCF_ERR_GENERIC
     fi
 
@@ -607,7 +607,7 @@ pgsql_promote() {
     local rc
 
     if ! is_replication; then
-        ocf_log err "Not in a replication mode."
+        ocf_exit_reason "Not in a replication mode."
         return $OCF_ERR_CONFIGURED
     fi
     rm -f ${XLOG_NOTE_FILE}.*
@@ -630,7 +630,7 @@ pgsql_promote() {
         pgsql_real_start
         rc=$?
         if [ $rc -ne $OCF_RUNNING_MASTER ]; then
-            ocf_log err "Can't start PostgreSQL as primary on promote."
+            ocf_exit_reason "Can't start PostgreSQL as primary on promote."
             if [ $rc -ne $OCF_SUCCESS ]; then
                 change_pgsql_status "$NODENAME" "STOP"
             fi
@@ -641,7 +641,7 @@ pgsql_promote() {
         if [ $? -eq 0 ]; then
             ocf_log info "PostgreSQL promote command sent."
         else
-            ocf_log err "Can't promote PostgreSQL."
+            ocf_exit_reason "Can't promote PostgreSQL."
             return $OCF_ERR_GENERIC
         fi
 
@@ -652,7 +652,7 @@ pgsql_promote() {
             if [ $rc -eq $OCF_RUNNING_MASTER ]; then
                 break;
             elif [ $rc -eq $OCF_ERR_GENERIC ]; then
-                ocf_log err "Can't promote PostgreSQL."
+                ocf_exit_reason "Can't promote PostgreSQL."
                 return $rc
             fi
             sleep 1
@@ -672,7 +672,7 @@ pgsql_demote() {
     local rc
 
     if ! is_replication; then
-        ocf_log err "Not in a replication mode."
+        ocf_exit_reason "Not in a replication mode."
         return $OCF_ERR_CONFIGURED
     fi
 
@@ -873,7 +873,7 @@ pgsql_real_monitor() {
             t)  ocf_log debug "PostgreSQL is running as a hot standby."
                 return $OCF_SUCCESS;;
 
-            *)  ocf_log err "$CHECK_MS_SQL output is $output"
+            *)  ocf_exit_reason "$CHECK_MS_SQL output is $output"
                 return $OCF_ERR_GENERIC;;
         esac
     fi
@@ -984,7 +984,7 @@ pgsql_pre_promote() {
             cmp_location=`printf "$master_baseline\n$my_master_baseline\n" |\
                           sort | head -1`
             if [ "$cmp_location" != "$my_master_baseline" ]; then
-                ocf_log err "My data is newer than new master's one. New master's location : $master_baseline"
+                ocf_exit_reason "My data is newer than new master's one. New master's location : $master_baseline"
                 exec_with_retry 0 $CRM_FAILCOUNT -r $OCF_RESOURCE_INSTANCE -U $NODENAME -v INFINITY
                 return $OCF_ERR_GENERIC
             fi
@@ -1160,7 +1160,7 @@ have_master_right() {
 
     show_xlog_location
     if [ $? -ne 0 ]; then
-        ocf_log err "Failed to show my xlog location."
+        ocf_exit_reason "Failed to show my xlog location."
         exit $OCF_ERR_GENERIC
     fi
 
@@ -1292,7 +1292,7 @@ set_async_mode_all() {
     ocf_log info "Set all nodes into async mode."
     runasowner -q err "echo \"synchronous_standby_names = ''\" > \"$REP_MODE_CONF\""
     if [ $? -ne 0 ]; then
-        ocf_log err "Can't set all nodes into async mode."
+        ocf_exit_reason "Can't set all nodes into async mode."
         return 1
     fi
     return 0
@@ -1330,7 +1330,7 @@ reload_conf() {
     if [ $? -eq 0 ]; then
         ocf_log info "Reload configuration file."
     else
-        ocf_log err "Can't reload configuration file."
+        ocf_exit_reason "Can't reload configuration file."
         return 1
     fi
 
@@ -1350,7 +1350,7 @@ user_recovery_conf() {
 make_recovery_conf() {
     runasowner "touch $RECOVERY_CONF"
     if [ $? -ne 0 ]; then
-        ocf_log err "Can't create recovery.conf."
+        ocf_exit_reason "Can't create recovery.conf."
         return 1
     fi
 
@@ -1471,11 +1471,11 @@ report_psql_error()
 
     ocf_log $loglevel "$message rc=$rc"
     if [ $rc -eq 1 ]; then
-        ocf_log err "Fatal error (out of memory, file not found, etc.) occurred while executing the psql command."
+        ocf_exit_reason "Fatal error (out of memory, file not found, etc.) occurred while executing the psql command."
     elif [ $rc -eq 2 ]; then
         ocf_log $loglevel "Connection error (connection to the server went bad and the session was not interactive) occurred while executing the psql command."
     elif [ $rc -eq 3 ]; then
-        ocf_log err "Script error (the variable ON_ERROR_STOP was set) occurred while executing the psql command."
+        ocf_exit_reason "Script error (the variable ON_ERROR_STOP was set) occurred while executing the psql command."
     fi
 }
 
@@ -1502,7 +1502,7 @@ exec_with_timeout() {
         sleep 1
         count=`expr $count - 1`
         if [ $count -le 0 ]; then
-            ocf_log err "\"$*\" (pid=$func_pid) timed out."
+            ocf_exit_reason "\"$*\" (pid=$func_pid) timed out."
             kill -s 9 $func_pid >/dev/null 2>&1
             return 1
         fi
@@ -1537,7 +1537,7 @@ exec_with_retry() {
         fi
     done
 
-    ocf_log err "giving up executing \"$*\""
+    ocf_exit_reason "giving up executing \"$*\""
     return $rc
 }
 
@@ -1551,7 +1551,7 @@ node_exist() {
 
 check_binary2() {
     if ! have_binary "$1"; then
-        ocf_log err "Setup problem: couldn't find command: $1"
+        ocf_exit_reason "Setup problem: couldn't find command: $1"
         return 1
     fi
     return 0
@@ -1565,7 +1565,7 @@ check_config() {
            ocf_log info "Configuration file is $1 not readable during probe."
            rc=1
         else
-           ocf_log err "Configuration file $1 doesn't exist"
+           ocf_exit_reason "Configuration file $1 doesn't exist"
            rc=2
         fi
     fi
@@ -1591,7 +1591,7 @@ pgsql_validate_all() {
 
     getent passwd $OCF_RESKEY_pgdba >/dev/null 2>&1
     if [ ! $? -eq 0 ]; then
-        ocf_log err "User $OCF_RESKEY_pgdba doesn't exist";
+        ocf_exit_reason "User $OCF_RESKEY_pgdba doesn't exist";
         return $OCF_ERR_INSTALLED;
     fi
 
@@ -1599,46 +1599,46 @@ pgsql_validate_all() {
         ocf_log info "Don't check $OCF_RESKEY_pgdata during probe"
     else
         if ! runasowner "test -w $OCF_RESKEY_pgdata"; then
-            ocf_log err "Directory $OCF_RESKEY_pgdata is not writable by $OCF_RESKEY_pgdba"
+            ocf_exit_reason "Directory $OCF_RESKEY_pgdata is not writable by $OCF_RESKEY_pgdba"
             return $OCF_ERR_PERM;
         fi
     fi
 
     if [ -n "$OCF_RESKEY_monitor_user" -a ! -n "$OCF_RESKEY_monitor_password" ]
     then
-        ocf_log err "monitor password can't be empty"
+        ocf_exit_reason "monitor password can't be empty"
         return $OCF_ERR_CONFIGURED
     fi
 
     if [ ! -n "$OCF_RESKEY_monitor_user" -a -n "$OCF_RESKEY_monitor_password" ]
     then
-        ocf_log err "monitor_user has to be set if monitor_password is set"
+        ocf_exit_reason "monitor_user has to be set if monitor_password is set"
         return $OCF_ERR_CONFIGURED
     fi
 
     if is_replication || [ "$OCF_RESKEY_rep_mode" = "slave" ]; then
         version=`cat $OCF_RESKEY_pgdata/PG_VERSION`
         if [ `printf "$version\n9.1" | sort -n | head -1` != "9.1" ]; then
-            ocf_log err "Replication mode needs PostgreSQL 9.1 or higher."
+            ocf_exit_reason "Replication mode needs PostgreSQL 9.1 or higher."
             return $OCF_ERR_INSTALLED
         fi
         if [ ! -n "$OCF_RESKEY_master_ip" ]; then
-            ocf_log err "master_ip can't be empty."
+            ocf_exit_reason "master_ip can't be empty."
             return $OCF_ERR_CONFIGURED
         fi
     fi
 
     if is_replication; then
         if ! ocf_is_ms; then
-            ocf_log err "Replication(rep_mode=async or sync) requires Master/Slave configuration."
+            ocf_exit_reason "Replication(rep_mode=async or sync) requires Master/Slave configuration."
             return $OCF_ERR_CONFIGURED
         fi
         if [ ! "$OCF_RESKEY_rep_mode" = "sync" -a ! "$OCF_RESKEY_rep_mode" = "async" ]; then
-            ocf_log err "Invalid rep_mode : $OCF_RESKEY_rep_mode"
+            ocf_exit_reason "Invalid rep_mode : $OCF_RESKEY_rep_mode"
             return $OCF_ERR_CONFIGURED
         fi
         if [ ! -n "$NODE_LIST" ]; then
-            ocf_log err "node_list can't be empty."
+            ocf_exit_reason "node_list can't be empty."
             return $OCF_ERR_CONFIGURED
         fi
         if [ $check_config_rc -eq 0 ]; then
@@ -1657,14 +1657,14 @@ pgsql_validate_all() {
             fi
         fi
         if ! mkdir -p $OCF_RESKEY_tmpdir || ! chown $OCF_RESKEY_pgdba $OCF_RESKEY_tmpdir || ! chmod 700 $OCF_RESKEY_tmpdir; then
-            ocf_log err "Can't create directory $OCF_RESKEY_tmpdir or it is not readable by $OCF_RESKEY_pgdba"
+            ocf_exit_reason "Can't create directory $OCF_RESKEY_tmpdir or it is not readable by $OCF_RESKEY_pgdba"
             return $OCF_ERR_PERM
         fi
     fi
 
     if [ "$OCF_RESKEY_rep_mode" = "slave" ]; then
         if ocf_is_ms; then
-            ocf_log err "Replication(rep_mode=slave) does not support Master/Slave configuration."
+            ocf_exit_reason "Replication(rep_mode=slave) does not support Master/Slave configuration."
             return $OCF_ERR_CONFIGURED
         fi
     fi
@@ -1699,24 +1699,24 @@ check_log_file() {
 check_socket_dir() {
     if [ ! -d "$OCF_RESKEY_socketdir" ]; then
         if ! mkdir "$OCF_RESKEY_socketdir"; then
-            ocf_log err "Can't create directory $OCF_RESKEY_socketdir"
+            ocf_exit_reason "Can't create directory $OCF_RESKEY_socketdir"
             exit $OCF_ERR_PERM
         fi
 
         if ! chown $OCF_RESKEY_pgdba:`getent passwd \
              $OCF_RESKEY_pgdba | cut -d ":" -f 4` "$OCF_RESKEY_socketdir" 
         then
-            ocf_log err "Can't change ownership for $OCF_RESKEY_socketdir"
+            ocf_exit_reason "Can't change ownership for $OCF_RESKEY_socketdir"
             exit $OCF_ERR_PERM
         fi
 
         if ! chmod 2775 "$OCF_RESKEY_socketdir"; then
-            ocf_log err "Can't change permissions for $OCF_RESKEY_socketdir"
+            ocf_exit_reason "Can't change permissions for $OCF_RESKEY_socketdir"
             exit $OCF_ERR_PERM
         fi
     else
         if ! runasowner "touch $OCF_RESKEY_socketdir/test.$$"; then
-            ocf_log err "$OCF_RESKEY_pgdba can't create files in $OCF_RESKEY_socketdir"
+            ocf_exit_reason "$OCF_RESKEY_pgdba can't create files in $OCF_RESKEY_socketdir"
             exit $OCF_ERR_PERM
         fi
         rm $OCF_RESKEY_socketdir/test.$$
@@ -1806,7 +1806,7 @@ US=`id -u -n`
 
 if [ $US != root -a $US != $OCF_RESKEY_pgdba ]
 then
-    ocf_log err "$0 must be run as root or $OCF_RESKEY_pgdba"
+    ocf_exit_reason "$0 must be run as root or $OCF_RESKEY_pgdba"
     exit $OCF_ERR_GENERIC
 fi
 

--- a/heartbeat/postfix
+++ b/heartbeat/postfix
@@ -134,7 +134,7 @@ postfix_start()
     ret=$?
 
     if [ $ret -ne 0 ]; then
-        ocf_log err "Postfix returned error: " $ret
+        ocf_exit_reason "Postfix returned error: " $ret
         return $OCF_ERR_GENERIC
     fi
 
@@ -165,7 +165,7 @@ postfix_stop()
     ret=$?
 
     if [ $ret -ne 0 ]; then
-        ocf_log err "Postfix returned an error while stopping: " $ret
+        ocf_exit_reason "Postfix returned an error while stopping: " $ret
         return $OCF_ERR_GENERIC
     fi
 
@@ -181,14 +181,14 @@ postfix_stop()
     # escalate to abort if we did not stop by now
     # @TODO shall we loop here too?
     if postfix_running info; then
-        ocf_log err "Postfix failed to stop. Escalating to 'abort'."
+        ocf_exit_reason "Postfix failed to stop. Escalating to 'abort'."
 
         $binary $OPTIONS abort >/dev/null 2>&1; ret=$?
         sleep 5
 
         # postfix abort did not succeed
         if postfix_running; then
-            ocf_log err "Postfix failed to abort."
+            ocf_exit_reason "Postfix failed to abort."
             return $OCF_ERR_GENERIC
         fi
     fi
@@ -238,14 +238,14 @@ postfix_validate_all()
                 # skip in-depth directory checks if config file isn't readable during probe
                 dir_check=false
             else
-                ocf_log err "Postfix configuration directory '$config_dir' does not exist or is not readable."
+                ocf_exit_reason "Postfix configuration directory '$config_dir' does not exist or is not readable."
                 return $OCF_ERR_INSTALLED
             fi
         fi
 
         alternate_config_directories=`postconf -h alternate_config_directories 2>/dev/null | grep "$config_dir/\?"`
         if [ "x$alternate_config_directories" = "x" ]; then
-            ocf_log err "Postfix main configuration must contain correct 'alternate_config_directories' parameter."
+            ocf_exit_reason "Postfix main configuration must contain correct 'alternate_config_directories' parameter."
             return $OCF_ERR_INSTALLED
         fi
     fi
@@ -257,7 +257,7 @@ postfix_validate_all()
             if ocf_is_probe; then
                 ocf_log info "Postfix queue directory '$queue_dir' not readable during probe."
             else
-                ocf_log err "Postfix queue directory '$queue_dir' does not exist or is not readable."
+                ocf_exit_reason "Postfix queue directory '$queue_dir' does not exist or is not readable."
                 return $OCF_ERR_INSTALLED
             fi
         fi
@@ -266,14 +266,14 @@ postfix_validate_all()
             data_dir=`postconf $OPTION_CONFIG_DIR -h data_directory 2>/dev/null`
             data_dir_count=`echo "$data_dir" | tr ',' ' ' | wc -w`
             if [ $data_dir_count -gt 1 ]; then
-            	ocf_log err "Postfix data directory '$orig_data_dir' cannot be set to multiple directories."
+            	ocf_exit_reason "Postfix data directory '$orig_data_dir' cannot be set to multiple directories."
                 return $OCF_ERR_INSTALLED
             fi
             if [ ! -d "$data_dir" ]; then
                 if ocf_is_probe; then
                     ocf_log info "Postfix data directory '$data_dir' not readable during probe."
                 else
-                    ocf_log err "Postfix data directory '$data_dir' does not exist or is not readable."
+                    ocf_exit_reason "Postfix data directory '$data_dir' does not exist or is not readable."
                     return $OCF_ERR_INSTALLED
                 fi
             fi
@@ -287,7 +287,7 @@ postfix_validate_all()
                     if ocf_is_probe; then
                         ocf_log info "Directory '$dir' is not writable by user '$user' during probe."
                     else
-                        ocf_log err "Directory '$dir' is not writable by user '$user'."
+                        ocf_exit_reason "Directory '$dir' is not writable by user '$user'."
                         return $OCF_ERR_PERM;
                     fi
                 fi
@@ -300,7 +300,7 @@ postfix_validate_all()
         $binary $OPTIONS check >/dev/null 2>&1
         ret=$?
         if [ $ret -ne 0 ]; then
-            ocf_log err "Postfix 'check' failed: " $ret
+            ocf_exit_reason "Postfix 'check' failed: " $ret
             return $OCF_ERR_GENERIC
         fi
     fi

--- a/heartbeat/rsyncd
+++ b/heartbeat/rsyncd
@@ -127,7 +127,7 @@ rsyncd_status()
 				return $OCF_ERR_GENERIC
 			fi
 		else
-			ocf_log err "PID file empty!"
+			ocf_exit_reason "PID file empty!"
 			return $OCF_ERR_GENERIC
 		fi
 	fi
@@ -145,7 +145,7 @@ rsyncd_start()
 	if [ $retVal -eq $OCF_SUCCESS ]; then
 		exit $OCF_SUCCESS
 	elif [ $retVal -ne $OCF_NOT_RUNNING ]; then
-		ocf_log err "Error. Unknown status."
+		ocf_exit_reason "Error. Unknown status."
 		exit $OCF_ERR_GENERIC
 	fi
 
@@ -164,11 +164,11 @@ rsyncd_start()
 	if  grep -v "^#" "$CONF_FILE" | grep "pid file" > /dev/null ; then
 		$COMMAND;
 		if [ $? -ne 0 ]; then
-			ocf_log err "Error. rsync daemon returned error $?."
+			ocf_exit_reason "Error. rsync daemon returned error $?."
 			exit $OCF_ERR_GENERIC
 		fi
 	else
-		ocf_log err "Error. \"pid file\" entry required in the rsyncd config file by rsyncd OCF RA."
+		ocf_exit_reason "Error. \"pid file\" entry required in the rsyncd config file by rsyncd OCF RA."
 		return $OCF_ERR_GENERIC
 	fi
 
@@ -186,7 +186,7 @@ rsyncd_stop()
 			if [ $? -ne 0 ]; then
 				kill -s KILL $PID
 				if [ $? -ne 0 ]; then
-					ocf_log err "Error. Could not stop rsync daemon."
+					ocf_exit_reason "Error. Could not stop rsync daemon."
 					return $OCF_ERR_GENERIC
 				fi
 			fi
@@ -205,18 +205,18 @@ rsyncd_monitor()
 rsyncd_validate_all()
 {
 	if [ -n "$OCF_RESKEY_binpath" -a ! -x "$OCF_RESKEY_binpath" ]; then
-		ocf_log err "Binary path $OCF_RESKEY_binpath does not exist."
+		ocf_exit_reason "Binary path $OCF_RESKEY_binpath does not exist."
 		exit $OCF_ERR_ARGS
 	fi
 	if [ -n "$OCF_RESKEY_conffile" -a ! -f "$OCF_RESKEY_conffile" ]; then
-		ocf_log err "Config file $OCF_RESKEY_conffile does not exist."
+		ocf_exit_reason "Config file $OCF_RESKEY_conffile does not exist."
 		exit $OCF_ERR_ARGS
 	fi
 
 	if  grep -v "^#" "$CONF_FILE" | grep "pid file" > /dev/null ; then
 		:
 	else
-		ocf_log err "Error. \"pid file\" entry required in the rsyncd config file by rsyncd OCF RA."
+		ocf_exit_reason "Error. \"pid file\" entry required in the rsyncd config file by rsyncd OCF RA."
 		return $OCF_ERR_GENERIC
 	fi
 

--- a/heartbeat/slapd
+++ b/heartbeat/slapd
@@ -268,7 +268,7 @@ slapd_pid()
       return $OCF_SUCCESS
     fi
 
-    ocf_log err "slapd pid file '$pid_file' empty."
+    ocf_exit_reason "slapd pid file '$pid_file' empty."
     return $OCF_ERR_GENERIC
   fi
 
@@ -316,7 +316,7 @@ slapd_start()
   elif [ -f "$config" ]; then
     options="$options -f $config"
   else
-    ocf_log err "slapd configuration '$config' does not exist."
+    ocf_exit_reason "slapd configuration '$config' does not exist."
     return $OCF_ERR_INSTALLED
   fi
 
@@ -331,7 +331,7 @@ slapd_start()
   fi
 
   if [ $rc -ne 0 ]; then
-    ocf_log err "slapd returned error."
+    ocf_exit_reason "slapd returned error."
 
     return $OCF_ERR_GENERIC
   fi
@@ -366,7 +366,7 @@ slapd_stop()
 
   terminate $pid TERM $OCF_RESKEY_stop_escalate; rc=$?
   if [ $rc -ne 0  ]; then
-    ocf_log err "slapd failed to stop. Escalating to KILL."
+    ocf_exit_reason "slapd failed to stop. Escalating to KILL."
     terminate $pid KILL; rc=$?
   fi
 
@@ -391,12 +391,12 @@ slapd_monitor()
   if [ $state -eq $OCF_NOT_RUNNING ]; then
     if [ -z "$1" ];then
       if ! ocf_is_probe; then
-        ocf_log err "slapd process not found."
+        ocf_exit_reason "slapd process not found."
       fi
     fi
     return $state
   elif [ $state -ne $OCF_SUCCESS ]; then
-    ocf_log err "slapd returned error."
+    ocf_exit_reason "slapd returned error."
     return $state
   fi
 
@@ -427,7 +427,7 @@ slapd_monitor()
     if ocf_is_probe; then
       ocf_log info "slapd configuration '$config' does not exist during probe."
     else
-      ocf_log err "slapd configuration '$config' does not exist."
+      ocf_exit_reason "slapd configuration '$config' does not exist."
       return $OCF_ERR_INSTALLED
     fi
   fi
@@ -447,12 +447,12 @@ slapd_monitor()
         ocf_log debug "slapd database with suffix '$suffix' reachable"
         ;;
       "49")
-        ocf_log err "slapd database with suffix '$suffix' unreachable. Invalid credentials."
+        ocf_exit_reason "slapd database with suffix '$suffix' unreachable. Invalid credentials."
         return $OCF_ERR_CONFIGURED
         ;;
       *)
         if [ -z "$1" ] || [ -n "$1" -a $rc -ne 1 ]; then
-          ocf_log err "slapd database with suffix '$suffix' unreachable. exit code ($rc)"
+          ocf_exit_reason "slapd database with suffix '$suffix' unreachable. exit code ($rc)"
         fi
         state=$OCF_ERR_GENERIC
         ;;
@@ -480,7 +480,7 @@ slapd_validate_all()
       if ocf_is_probe; then
         ocf_log info "slapd configuration '$config' does not exist during probe."
       else
-        ocf_log err "slapd configuration '$config' does not exist."
+        ocf_exit_reason "slapd configuration '$config' does not exist."
         return $OCF_ERR_INSTALLED
       fi
     fi
@@ -489,14 +489,14 @@ slapd_validate_all()
   if [ -z "$user" ]; then
     user=`id -nu 2>/dev/null`
   elif ! id "$user" >/dev/null 2>&1; then
-    ocf_log err "slapd user '$user' does not exist"
+    ocf_exit_reason "slapd user '$user' does not exist"
     return $OCF_ERR_INSTALLED
   fi
 
   if [ -z "$group" ]; then
     group=`id -ng 2>/dev/null`
   elif ! grep "^$group:" /etc/group >/dev/null 2>&1; then
-    ocf_log err "slapd group '$group' does not exist"
+    ocf_exit_reason "slapd group '$group' does not exist"
     return $OCF_ERR_INSTALLED
   fi
 

--- a/heartbeat/symlink
+++ b/heartbeat/symlink
@@ -117,7 +117,7 @@ symlink_monitor() {
         rc=$OCF_NOT_RUNNING
     elif [ ! -L  "$OCF_RESKEY_link" ]; then
         if [ -z "$OCF_RESKEY_backup_suffix" ]; then
-            ocf_log err "$OCF_RESKEY_link exists but is not a symbolic link!"
+            ocf_exit_reason "$OCF_RESKEY_link exists but is not a symbolic link!"
             exit $OCF_ERR_INSTALLED
         else
             ocf_log debug "$OCF_RESKEY_link exists but is not a symbolic link, will be moved to ${OCF_RESKEY_link}${OCF_RESKEY_backup_suffix} on start"
@@ -128,7 +128,7 @@ symlink_monitor() {
         rc=$OCF_SUCCESS
     else
         if [ -z "$OCF_RESKEY_backup_suffix" ]; then
-            ocf_log err "$OCF_RESKEY_link does not point to ${OCF_RESKEY_target}!"
+            ocf_exit_reason "$OCF_RESKEY_link does not point to ${OCF_RESKEY_target}!"
             exit $OCF_ERR_INSTALLED
         else
             ocf_log debug "$OCF_RESKEY_link does not point to ${OCF_RESKEY_target}, will be moved to ${OCF_RESKEY_link}${OCF_RESKEY_backup_suffix} on start"
@@ -146,7 +146,7 @@ symlink_start() {
                 # have errored out. But there is a chance that
                 # something else put that file there after
                 # symlink_monitor ran.
-                ocf_log err "$OCF_RESKEY_link exists and no backup_suffix is set, won't overwrite."
+                ocf_exit_reason "$OCF_RESKEY_link exists and no backup_suffix is set, won't overwrite."
                 exit $OCF_ERR_GENERIC
             else
                 ocf_log debug "Found $OCF_RESKEY_link, moving to ${OCF_RESKEY_link}${OCF_RESKEY_backup_suffix}"
@@ -174,7 +174,7 @@ symlink_stop() {
             fi
             return $OCF_SUCCESS
         else
-            ocf_log err "Removing $OCF_RESKEY_link failed."
+            ocf_exit_reason "Removing $OCF_RESKEY_link failed."
             return $OCF_ERR_GENERIC
         fi
     else
@@ -184,11 +184,11 @@ symlink_stop() {
 
 symlink_validate_all() {
     if [ "x${OCF_RESKEY_link}" = "x" ]; then
-        ocf_log err "Mandatory parameter link is unset"
+        ocf_exit_reason "Mandatory parameter link is unset"
         exit $OCF_ERR_CONFIGURED
     fi
     if [ "x${OCF_RESKEY_target}" = "x" ]; then
-        ocf_log err "Mandatory parameter target is unset"
+        ocf_exit_reason "Mandatory parameter target is unset"
         exit $OCF_ERR_CONFIGURED
     fi
 

--- a/heartbeat/tomcat
+++ b/heartbeat/tomcat
@@ -157,7 +157,7 @@ rotate_catalina_out()
 	su - -s /bin/sh $RESOURCE_TOMCAT_USER \
 		-c "touch \"$CATALINA_BASE/logs/catalina_$CURRENT_ROTATELOG_SUFFIX.log\"" > /dev/null 2>&1
 	if [ $? -ne 0 ]; then
-		ocf_log err "$CATALINA_BASE/logs/catalina_$CURRENT_ROTATELOG_SUFFIX.log is not writable."
+		ocf_exit_reason "$CATALINA_BASE/logs/catalina_$CURRENT_ROTATELOG_SUFFIX.log is not writable."
 		return $OCF_ERR_GENERIC
 	fi
 
@@ -235,7 +235,7 @@ start_tomcat()
 		if [ $? -eq 0 ]; then
 			ocf_log debug "Rotate catalina.out succeeded."
 		else
-			ocf_log err "Rotate catalina.out failed. Avoid starting tomcat without catalina.out rotation."
+			ocf_exit_reason "Rotate catalina.out failed. Avoid starting tomcat without catalina.out rotation."
 			return $OCF_ERR_GENERIC
 		fi
 	fi
@@ -534,12 +534,12 @@ validate_all_tomcat()
 	check_binary $WGET
 
 	if [ -z "${TOMCAT_START_SCRIPT}" ]; then
-		ocf_log err "No default tomcat start script detected. Please specify start script location using the 'tomcat_start_script' option"
+		ocf_exit_reason "No default tomcat start script detected. Please specify start script location using the 'tomcat_start_script' option"
 		rc=$OCF_ERR_CONFIGURED
 	fi
 
 	if [ -n "$MAX_STOP_TIME" ] && [ "$MAX_STOP_TIME" -lt 0 ]; then
-		ocf_log err "max_stop_time must be set to a value greater than 0."
+		ocf_exit_reason "max_stop_time must be set to a value greater than 0."
 		rc=$OCF_ERR_CONFIGURED
 	fi
 
@@ -550,14 +550,14 @@ validate_all_tomcat()
 		ocf_log debug "grep port=\"$port\" $CATALINA_BASE/conf/server.xml"
 		grep "port=\"$port\"" $CATALINA_BASE/conf/server.xml > /dev/null 2>&1
 		if [ $? -ne 0 ]; then
-			ocf_log err "Your configured status URL specifies a port ($port), but the server does not have a connector listening to that port in $CATALINA_BASE/conf/server.xml"
+			ocf_exit_reason "Your configured status URL specifies a port ($port), but the server does not have a connector listening to that port in $CATALINA_BASE/conf/server.xml"
 			rc=$OCF_ERR_INSTALLED
 		fi
 	fi
 
 	if ocf_is_true ${CATALINA_ROTATE_LOG}; then
 		if [ ! -x "$ROTATELOGS" ]; then
-			ocf_log err "rotatelogs command does not exist."
+			ocf_exit_reason "rotatelogs command does not exist."
 			rc=$OCF_ERR_INSTALLED
 		fi
 	fi
@@ -638,7 +638,7 @@ if [ ! -d "$JAVA_HOME" -o ! -d "$CATALINA_HOME" -o ! -d "$CATALINA_BASE" ]; then
 		monitor)	exit	$OCF_NOT_RUNNING;;
 		status)		exit	$LSB_STATUS_STOPPED;;
 	esac
-	ocf_log err "JAVA_HOME or CATALINA_HOME or CATALINA_BASE does not exist."
+	ocf_exit_reason "JAVA_HOME or CATALINA_HOME or CATALINA_BASE does not exist."
 	exit $OCF_ERR_INSTALLED
 fi
 
@@ -652,7 +652,7 @@ if [ ! -x "$JAVA" ]; then
 		monitor)	exit	$OCF_NOT_RUNNING;;
 		status)		exit	$LSB_STATUS_STOPPED;;
 	esac
-	ocf_log err "java command does not exist."
+	ocf_exit_reason "java command does not exist."
 	exit $OCF_ERR_INSTALLED
 fi
 


### PR DESCRIPTION
The following agents have been updated. These were all originally their own commit. I consolidated them into a single commit for this update.

High: apache: exit reason string support
High: clvmd: exit reason support
High: conntrackd: exit reason support
High: CTDB: exit reason support
High: Delay: exit reason string support
High: delay: exit reason support
High: Filesystem: exit reason support
High: galera: exit reason string support
High: IPsrcaddr: exit reason support
High: clvmd: exit reason support
High: MailTo: exit string support
High: mysql: exit string support
High: named: exit reason support
High: pgsql: exit reason support
High: postfix: exit reason support
High: Route: exit reason support
High: rsyncd: exit reason support
High: SendArp: exit string support
High: slapd: exit reason support
High: Squid: exit reason support
High: symlink: exit reason support
High: mysql-common: exit reason support
High: tomcat: exit reason support
High: Xinetd: exit reason support
