### PR TITLE
findif.sh: Use the most specific matching route

### DIFF
--- a/heartbeat/findif.sh
+++ b/heartbeat/findif.sh
@@ -137,9 +137,9 @@ findif()
   fi
   if [ -n "$nic" ] ; then
     # NIC supports more than two.
-    set -- `ip -o -f $family route list match $match $scope | grep "dev $nic"`
+    set -- $(ip -o -f $family route list match $match $scope | grep "dev $nic " | awk 'BEGIN{best=0} { mask=$1; sub(".*/", "", mask); if( int(mask)>=best ) { best=int(mask); best_ln=$0; } } END{print best_ln}')
   else
-    set -- `ip -o -f $family route list match $match $scope`
+    set -- $(ip -o -f $family route list match $match $scope | awk 'BEGIN{best=0} { mask=$1; sub(".*/", "", mask); if( int(mask)>=best ) { best=int(mask); best_ln=$0; } } END{print best_ln}')
   fi
   if [ $# = 0 ] ; then
     case $OCF_RESKEY_ip in


### PR DESCRIPTION
When more than one interface is configured with a network that matches
the IP address we're looking for, but with different networks, the "ip
route" command we're using returns more than one line:

ip -o -f inet route list match 10.122.24.59 scope link
10.122.0.0/18 dev eth1.12  proto kernel  src 10.122.24.159
10.122.24.0/25 dev eth0  proto kernel  src 10.122.24.53

The code assumed that only one line would be returned, and so it's
parsing only the first line, without trying to find out which line is
the best match. What we want is the route with the bigger netmask. It
turns out that it also means that it's the route with the bigger network
IP.

https://bugzilla.novell.com/show_bug.cgi?id=892755