### PR TITLE
Middle: anything: Prevent stop failure, even if the job takes time to st...

### DIFF
--- a/heartbeat/anything
+++ b/heartbeat/anything
@@ -133,14 +133,17 @@ anything_stop() {
                 done
                 ocf_log warn "Stop with SIGTERM failed/timed out, now sending SIGKILL."
                 kill -s 9 $pid
-                if ! anything_status
-                then
-                        ocf_log warn "SIGKILL did the job."
-                        rc=$OCF_SUCCESS
-                else
-                        ocf_log err "Failed to stop - even with SIGKILL."
-                        rc=$OCF_ERR_GENERIC
-                fi
+                while :
+                do
+                        if ! anything_status
+                        then
+                                ocf_log warn "SIGKILL did the job."
+                                rc=$OCF_SUCCESS
+                                break
+                        fi
+                        ocf_log info "The job still hasn't stopped yet. Waiting..."
+                        sleep 1
+                done
 	fi
 	rm -f $pidfile 
 	return $rc


### PR DESCRIPTION
...op.

Currentry, in the anything_stop() method, immediately monitor the job and return a value(SUCCESS or ERR) after sending SIGKILL.
But, I'm concerned about some job may not stop immediately. For example, because of Time-consuming due to the kernel inside.
So, I change the stop method to wait forever to stop the job.
This is like the stop method of pgsql RA or apache RA.
