### PR TITLE
Medium: mysql: fix unexpected operation error that caused by MySQL client timeout.

### DIFF
--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -79,7 +79,7 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 # Convenience variables
 
 MYSQL=$OCF_RESKEY_client_binary
-MYSQL_OPTIONS_LOCAL="-S $OCF_RESKEY_socket --connect_timeout=10"
+MYSQL_OPTIONS_LOCAL="-S $OCF_RESKEY_socket"
 MYSQL_OPTIONS_REPL="$MYSQL_OPTIONS_LOCAL --user=$OCF_RESKEY_replication_user --password=$OCF_RESKEY_replication_passwd"
 MYSQL_OPTIONS_TEST="$MYSQL_OPTIONS_LOCAL --user=$OCF_RESKEY_test_user --password=$OCF_RESKEY_test_passwd"
 MYSQL_TOO_MANY_CONN_ERR=1040


### PR DESCRIPTION
Currently, a timeout for MySQL client is hard coded(10 seconds) and operation error is occured when MySQL server does not respond to MySQL client in 10 seconds whatever user set a long timeout for operation.

This patch disable a timeout for MySQL client to resolve above problem.
