### PR TITLE
fix output redirection of 'anything' resource

### DIFF
--- a/heartbeat/anything
+++ b/heartbeat/anything
@@ -76,14 +76,9 @@ anything_start() {
 		then
 			# We have logfile and errlogfile, so redirect STDOUT und STDERR to different files
 			cmd="su - $user -c \"cd $workdir; nohup $binfile $cmdline_options >> $logfile 2>> $errlogfile & \"'echo \$!' "
-		else if [ -n "$logfile" ]
-			then
-				# We only have logfile so redirect STDOUT and STDERR to the same file
-				cmd="su - $user -c \"cd $workdir; nohup $binfile $cmdline_options >> $logfile 2>&1 & \"'echo \$!' "
-			else
-				# We have neither logfile nor errlogfile, so we're not going to redirect anything
-				cmd="su - $user -c \"cd $workdir; nohup $binfile $cmdline_options & \"'echo \$!'"
-			fi
+		else
+			# We only have logfile so redirect STDOUT and STDERR to the same file
+			cmd="su - $user -c \"cd $workdir; nohup $binfile $cmdline_options >> $logfile 2>&1 & \"'echo \$!' "
 		fi
 		ocf_log debug "Starting $process: $cmd"
 		# Execute the command as created above
@@ -173,7 +168,7 @@ cmdline_options="$OCF_RESKEY_cmdline_options"
 workdir="$OCF_RESKEY_workdir"
 pidfile="$OCF_RESKEY_pidfile"
 [ -z "$pidfile" ] && pidfile=${HA_VARRUN}/anything_${process}.pid
-logfile="$OCF_RESKEY_logfile"
+logfile="${OCF_RESKEY_logfile:-/dev/null}"
 errlogfile="$OCF_RESKEY_errlogfile"
 user="$OCF_RESKEY_user"
 [ -z "$user" ] && user=root
@@ -250,7 +245,7 @@ File to read/write the PID from/to.
 File to write STDOUT to
 </longdesc>
 <shortdesc lang="en">File to write STDOUT to</shortdesc>
-<content type="string" />
+<content type="string" default="/dev/null" />
 </parameter>
 <parameter name="errlogfile" required="0">
 <longdesc lang="en">


### PR DESCRIPTION
This fixes #496 by making the `logfile` parameter default to `/dev/null`.

This has the added benefit of also fixing potential SIGPIPE errors. Previously, if no `logfile` parameter were provided, once the shell that started the process stops listening for output (when [line 85](https://github.com/ClusterLabs/resource-agents/blob/d1b1ed9c9793bdf384c72553267ee3e1f66f555f/heartbeat/anything#L85) ends), if the process tries to write to STDOUT, it'll get a SIGPIPE as there's no longer anything listening on the other end.
