### PR TITLE
High: galera: do not ignore specified check_password

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -671,7 +671,7 @@ fi
 
 MYSQL_OPTIONS_CHECK="-nNE --user=${OCF_RESKEY_check_user}"
 if [ -n "${OCF_RESKEY_check_passwd}" ]; then
-    MYSQL_OPTIONS_CHECK="$MYSQL_OPTIONS_CHECK --password=${MYSQL_PASSWORD}"
+    MYSQL_OPTIONS_CHECK="$MYSQL_OPTIONS_CHECK --password=${OCF_RESKEY_check_passwd}"
 fi
 
 # What kind of method was invoked?


### PR DESCRIPTION
Hi,

I did a galera cluster setup today and found out that the specified "check_passwd" was ignored. Please accept the proposed fix, thanks!

Best regards,
Andreas
