### PR TITLE
let $((CURRENT_FSID++)) breaks in the dash shell

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -181,7 +181,7 @@ reset_fsid() {
 	CURRENT_FSID=$OCF_RESKEY_fsid
 }
 bump_fsid() {
-	let $((CURRENT_FSID++))
+	CURRENT_FSID=$((CURRENT_FSID+1))
 }
 get_fsid() {
 	echo $CURRENT_FSID


### PR DESCRIPTION
Syntax change to make exportfs script DASH-compliant, without breaking BASH compatibility.  
