### PR TITLE
Medium: ocf-shellfuncs: set HA_LOGD depending on HA_use_logd

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -62,6 +62,11 @@ fi
 # to make sure that ocf_is_probe() always works
 : ${OCF_RESKEY_CRM_meta_interval=0}
 
+# pacemaker sets HA_use_logd, some others use HA_LOGD :/
+if ocf_is_true "$HA_use_logd"; then
+	: ${HA_LOGD:=yes}
+fi
+
 ocf_is_root() {
 	if [ X`id -u` = X0 ]; then
 		true


### PR DESCRIPTION
The retired lrmd used HA_LOGD, the latter development in
pacemaker dropped that variable. This ensures compatibility with
heartbeat and older installations.
