### PR TITLE
Low: VirtualDomain: downgrade error msg during probe

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -226,6 +226,11 @@ update_utilization() {
 get_emulator()
 {
 	local emulator=""
+	local loglevel="error"
+
+	if ocf_is_probe; then
+		loglevel="notice"
+	fi
 
 	emulator=$(virsh $VIRSH_OPTIONS dumpxml $DOMAIN_NAME 2>/dev/null | sed -n -e 's/^.*<emulator>\(.*\)<\/emulator>.*$/\1/p')
 	if [ -z "$emulator" ] && [ -a "$EMULATOR_STATE" ]; then
@@ -238,7 +243,7 @@ get_emulator()
 	if [ -n "$emulator" ]; then
 		basename $emulator
 	else 
-		ocf_log error "Unable to determine emulator for $DOMAIN_NAME" 
+		ocf_log $loglevel "Unable to determine emulator for $DOMAIN_NAME"
 	fi
 }
 


### PR DESCRIPTION
An error to find a domain's emulator does not indicate an error
during the probe operation. This situation is only an issue
if it occurs during a recurring monitor operation after a successful
start has occurred.
