### PR TITLE
Fix simple transposition of options for TESTURL

### DIFF
--- a/heartbeat/nginx
+++ b/heartbeat/nginx
@@ -31,7 +31,7 @@
 #  OCF_RESKEY_status10regex
 #  OCF_RESKEY_status10url
 #  OCF_RESKEY_client
-#  OCF_RESKEY_testurl
+#  OCF_RESKEY_test20url
 #  OCF_RESKEY_test20regex
 #  OCF_RESKEY_test20conffile
 #  OCF_RESKEY_test20name
@@ -727,18 +727,18 @@ For example, you can set this paramter to "wget" if you prefer that to curl.
 <content type="string" />
 </parameter>
 
-<parameter name="testurl">
+<parameter name="test20url">
 <longdesc lang="en">
 URL to test. If it does not start with "http", then it's
 considered to be relative to the document root address.
 </longdesc>
-<shortdesc lang="en">Level 10 monitor url</shortdesc>
+<shortdesc lang="en">Level 20 monitor url</shortdesc>
 <content type="string" />
 </parameter>
 
 <parameter name="test20regex">
 <longdesc lang="en">
-Regular expression to match in the output of testurl.
+Regular expression to match in the output of test20url.
 Case insensitive.
 </longdesc>
 <shortdesc lang="en">Level 20 monitor regular expression</shortdesc>
@@ -859,7 +859,7 @@ then
   OPTIONS="$OCF_RESKEY_options"
   CLIENT=${OCF_RESKEY_client}
   TESTREGEX=${OCF_RESKEY_status10regex:-'Reading: [0-9]+ Writing: [0-9]+ Waiting: [0-9]+'}
-  TESTURL="$OCF_RESKEY_status10url"
+  TESTURL="$OCF_RESKEY_test20url"
   TESTREGEX20=${OCF_RESKEY_test20regex}
   TESTCONFFILE="$OCF_RESKEY_test20conffile"
   TESTNAME="$OCF_RESKEY_test20name"


### PR DESCRIPTION
The current script will use `status10url` for both level 10 and level 20 monitor operations, but the documentation indicates that `testurl` will be used for a level 20 monitor.

This patch restores the documented behavior.