### PR TITLE
lvm_by_vg.sh: Only strip tag on stop if we are owner

### DIFF
--- a/rgmanager/src/resources/lvm_by_vg.sh
+++ b/rgmanager/src/resources/lvm_by_vg.sh
@@ -509,7 +509,7 @@ function vg_stop_single
 
 	#  Make sure we are the owner before we strip the tags
 	vg_owner
-	if [ $? -ne 0 ]; then
+	if [ $? -eq 1 ]; then
 		strip_tags
 	fi
 


### PR DESCRIPTION
Stripping tags on stop if vg_owner returns 2 allows that after a quorum loss when rgmanager performs an emergency stop, we might strip the tag of a node in the quorate partition that is still running the service.  We should only ever need to strip our own tag on stop, never anyone else's.  
