### PR TITLE
fix for missing lxc-ps/lxc-version command in ocf:heartbeat:lxc with LXC >= 1.0.0

### DIFF
--- a/heartbeat/lxc
+++ b/heartbeat/lxc
@@ -113,6 +113,14 @@ LXC_usage() {
 END
 }
 
+lxc_version() {
+  if have_binary lxc-version ; then
+    lxc-version | cut -d' ' -f 3
+  else # since LXC 1.0.0 all commands knows about --version
+    lxc-info --version
+  fi
+}
+
 cgroup_mounted() {
 # test cgroup_mounted, mount if required
 	# Various possible overrides to cgroup mount point.
@@ -190,32 +198,54 @@ LXC_stop() {
 	# It is 'assumed' that the 'init' system will do an orderly shudown if presented with a 'kill -PWR' signal.
 	# On a 'sysvinit' this would require the container to have an inittab file containing "p0::powerfail:/sbin/init 0"
 	declare -i PID=0
-	PID=$(lxc-info --name "${OCF_RESKEY_container}" -p -H)
+	declare CMD=
 
-	# If there is no PID the container seems to be down which
-	# shouldn't happen.
-	if [ $PID -eq 0 ]; then
-		ocf_log err "${OCF_RESKEY_container} seems to run, but has no PID."
-		exit $OCF_ERR_GENERIC
-	fi
+	# LXC prior 1.0.0
+	if ocf_version_cmp "`lxc_version`" 1.0.0 ; then
+		# This should work for traditional 'sysvinit' and 'upstart'
+		lxc-ps --name "${OCF_RESKEY_container}" -- -C init -o pid,comm |while read CN PID CMD ;do
+			[ $PID -gt 1 ] || continue
+			[ "$CMD" = "init" ] || continue
+			ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"sysV init\" or \"upstart\""
+			kill -PWR $PID
+		done
+		# This should work for containers using 'systemd' instead of 'init'
+		lxc-ps --name "${OCF_RESKEY_container}" -- -C systemd -o pid,comm |while read CN PID CMD ;do
+			[ $PID -gt 1 ] || continue
+			[ "$CMD" = "systemd" ] || continue
+			ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"systemd\""
+			kill -PWR $PID
+		done
+	else
+		PID=$(lxc-info --name "${OCF_RESKEY_container}" -p -H)
 
-	# Rescue me.
-	if [ $PID -eq 1 ]; then
-		ocf_log err "${OCF_RESKEY_container} seems to run with PID 1 which cannot be."
-	fi
+		# If there is no PID the container seems to be down which
+		# shouldn't happen.
+		if [ $PID -eq 0 ]; then
+			ocf_log err "${OCF_RESKEY_container} seems to run, but has no PID."
+			exit $OCF_ERR_GENERIC
+		fi
 
-	CMD=$(ps -o comm= -p $PID)
+		# Rescue me.
+		if [ $PID -eq 1 ]; then
+			ocf_log err "${OCF_RESKEY_container} seems to run with PID 1 which cannot be."
+			PID=0
+			CMD=
+		else
+			CMD=$(ps -o comm= -p $PID)
+		fi
 
-	# This should work for traditional 'sysvinit' and 'upstart'
-	if [ "$CMD" = "init" ]; then
-		ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"sysV init\" or \"upstart\""
-		kill -PWR $PID
-	fi
+		# This should work for traditional 'sysvinit' and 'upstart'
+		if [ "$CMD" = "init" ]; then
+			ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"sysV init\" or \"upstart\""
+			kill -PWR $PID
+		fi
 
-	# This should work for containers using 'systemd' instead of 'init'
-	if [ "$CMD" = "systemd" ]; then
-		ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"systemd\""
-		kill -PWR $PID
+		# This should work for containers using 'systemd' instead of 'init'
+		if [ "$CMD" = "systemd" ]; then
+			ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"systemd\""
+			kill -PWR $PID
+		fi
 	fi
 	# The "shutdown_timeout" we use here is the operation
 	# timeout specified in the CIB, minus 5 seconds
@@ -254,7 +284,7 @@ LXC_stop() {
 LXC_status() {
 	# run lxc-info with -s option for LXC-0.7.5 or later
 	local lxc_info_opt="-s"
-	ocf_version_cmp "`lxc-version | cut -d' ' -f 3`" 0.7.5 && lxc_info_opt=""
+	ocf_version_cmp "`lxc_version`" 0.7.5 && lxc_info_opt=""
 	S=`lxc-info $lxc_info_opt -n ${OCF_RESKEY_container}`
 	ocf_log debug "State of ${OCF_RESKEY_container}: $S"
 	if [[ "${S##* }" = "RUNNING" ]] ; then 
@@ -297,6 +327,9 @@ LXC_validate() {
 
 	    check_binary lxc-start
 	    check_binary lxc-stop
+	    if ocf_version_cmp "`lxc_version`" 1.0.0 ; then
+	        check_binary lxc-ps
+	    fi
 	    check_binary lxc-info
 	fi
 	return $OCF_SUCCESS


### PR DESCRIPTION
since beginning of 2014 the lxc-ps command isn't available anymore
(see:
 https://lists.linuxcontainers.org/pipermail/lxc-devel/2014-January/007433.html)
so it is using now lxc-info to determine the PID of a container and "ps"
to get the command name of it.

This works with lxc version 1.0.0.alpha3 and newer (2013-11-15).
The command and output formatting were added/changed in commit 5444216b7ee04a65679d9999d3933450bf817536
