### PR TITLE
Feature: portblock: reset_tcp_on_unblock_stop

### DIFF
--- a/heartbeat/portblock
+++ b/heartbeat/portblock
@@ -24,8 +24,10 @@
 
 # Defaults
 OCF_RESKEY_ip_default="0.0.0.0/0"
+OCF_RESKEY_reset_local_on_unblock_stop_default="false"
 
 : ${OCF_RESKEY_ip=${OCF_RESKEY_ip_default}}
+: ${OCF_RESKEY_reset_local_on_unblock_stop=${OCF_RESKEY_reset_local_on_unblock_stop_default}}
 #######################################################################
 CMD=`basename $0`
 TICKLETCP=$HA_BIN/tickle_tcp
@@ -149,6 +151,26 @@ The action (block/unblock) to be done on the protocol::portno.
 <content type="string" default="" />
 </parameter>
 
+<parameter name="reset_local_on_unblock_stop" unique="0" required="0">
+<content type="boolean" default="${OCF_RESKEY_reset_local_on_unblock_stop_default}" />
+<shortdesc lang="en">(try to) reset server TCP sessions when unblock stops</shortdesc>
+<longdesc>
+If for some reason the long lived server side TCP sessions won't be cleaned up
+by a reconfiguration/flush/stop of whatever services this portblock protects,
+they would linger in the connection table, even after the IP is gone
+and services have been switched over to an other node.
+
+An example would be the default NFS kernel server.
+
+These "known" connections may seriously confuse and delay a later switchback.
+
+Enabling this option will cause this agent to try to get rid of these connections
+by injecting a temporary iptables rule to TCP-reset outgoing packets from the
+blocked ports, and additionally tickle them locally,
+just before it starts to DROP incoming packets on "unblock stop".
+</longdesc>
+</parameter>
+
 <parameter name="ip" unique="0" required="0">
 <longdesc lang="en">
 The IP address used to be blocked/unblocked.
@@ -233,12 +255,34 @@ save_tcp_connections()
 	fi
 }
 
-run_tickle_tcp()
+tickle_remote()
 {
 	[ -z "$OCF_RESKEY_tickle_dir" ] && return
 	echo 1 > /proc/sys/net/ipv4/tcp_tw_recycle
 	f=$OCF_RESKEY_tickle_dir/$OCF_RESKEY_ip
-	[ -f $f ] && cat $f | $TICKLETCP -n 3
+	[ -r $f ] || return
+	$TICKLETCP -n 3 < $f
+}
+
+tickle_local()
+{
+	[ -z "$OCF_RESKEY_tickle_dir" ] && return
+	f=$OCF_RESKEY_tickle_dir/$OCF_RESKEY_ip
+	[ -r $f ] || return
+	# swap "local" and "remote" address,
+	# so we tickle ourselves.
+	# We set up a REJECT with tcp-reset before we do so, so we get rid of
+	# the no longer wanted potentially long lived "ESTABLISHED" connection
+	# entries on the IP we are going to delet in a sec.  These would get in
+	# the way if we switch-over and then switch-back in quick succession.
+	local i
+	awk '{ print $2, $1; }' $f | $TICKLETCP
+	netstat -tn | grep -Fw $OCF_RESKEY_ip || return
+	for i in 0.1 0.5 1 2 4 ; do
+		sleep $i
+		awk '{ print $2, $1; }' $f | $TICKLETCP
+		netstat -tn | grep -Fw $OCF_RESKEY_ip || break
+	done
 }
 
 SayActive()
@@ -304,15 +348,30 @@ IptablesStatus() {
 #IptablesBLOCK  {udp|tcp} portno,portno ip
 IptablesBLOCK()
 {
+  local rc=0
+  local try_reset=false
+  if	[ "$1/$4/$__OCF_ACTION" = tcp/unblock/stop ] &&
+	ocf_is_true $reset_local_on_unblock_stop
+  then
+	try_reset=true
+  fi
   if
     chain_isactive "$1" "$2" "$3"
   then
     : OK -- chain already active
   else
+    if $try_reset ; then
+      $IPTABLES -I OUTPUT -p "$1" -s "$3" -m multiport --sports "$2" -j REJECT --reject-with tcp-reset
+      tickle_local
+    fi
     $IPTABLES -I INPUT -p "$1" -d "$3" -m multiport --dports "$2" -j DROP
+    rc=$?
+    if $try_reset ; then
+      $IPTABLES -D OUTPUT -p "$1" -s "$3" -m multiport --sports "$2" -j REJECT --reject-with tcp-reset
+    fi
   fi
 
-  return $?
+  return $rc
 }
 
 #IptablesUNBLOCK  {udp|tcp} portno,portno ip
@@ -338,7 +397,7 @@ IptablesStart()
     unblock)
 		IptablesUNBLOCK "$@"
 		rc=$?
-		run_tickle_tcp
+		tickle_remote
 		#ignore run_tickle_tcp exit code!
 		return $rc
 		;;
@@ -411,6 +470,17 @@ IptablesValidateAll()
 	exit $OCF_ERR_CONFIGURED
 	;; 
   esac
+
+  if ocf_is_true $reset_local_on_unblock_stop; then
+	if [ $action != unblock ] ; then
+		ocf_log err "reset_local_on_unblock_stop is only relevant with action=unblock"
+		exit $OCF_ERR_CONFIGURED
+	fi
+	if [ -z $OCF_RESKEY_tickle_dir ] ; then
+		ocf_log warn "reset_local_on_unblock_stop works best with tickle_dir enabled as well"
+	fi
+  fi
+
   return $OCF_SUCCESS
 }
 
@@ -451,6 +521,7 @@ protocol=$OCF_RESKEY_protocol
 portno=$OCF_RESKEY_portno
 action=$OCF_RESKEY_action
 ip=$OCF_RESKEY_ip
+reset_local_on_unblock_stop=$OCF_RESKEY_reset_local_on_unblock_stop
 
 case $1 in
   start)	


### PR DESCRIPTION
If for some reason the long lived server side TCP sessions won't be
cleaned up by a reconfiguration/flush/stop of whatever services this
portblock protects, they would linger in the connection table, even
after the IP is gone and services have been switched over to an other node.

An example would be the default NFS kernel server.

These "known" connections may seriously confuse and delay a later switchback.

Enabling this option will cause this agent to try to get rid of these
connections by injecting a temporary iptables rule to TCP-reset outgoing
packets from the blocked ports, and additionally tickle them locally,
just before it starts to DROP incoming packets on "unblock stop".
