### PR TITLE
Xen: Only add quotes when using the xl toolset

### DIFF
--- a/heartbeat/Xen
+++ b/heartbeat/Xen
@@ -328,8 +328,13 @@ Xen_Start() {
 		$xentool mem-set ${DOMAIN_NAME} ${NEWMEM}
 	fi
 
-	$xentool create ${OCF_RESKEY_xmfile} name=\"$DOMAIN_NAME\"
-	rc=$?
+	if expr "x$xentool" : "x.*xl" >/dev/null; then
+		$xentool create ${OCF_RESKEY_xmfile} name=\"$DOMAIN_NAME\"
+		rc=$?
+	else
+		$xentool create ${OCF_RESKEY_xmfile} name=$DOMAIN_NAME
+		rc=$?
+	fi
 	if [ $rc -ne 0 ]; then
 		return $OCF_ERR_GENERIC
 	else


### PR DESCRIPTION
The quotes cause problems when using the xm toolset.
