### PR TITLE
Low: bash can do find and replace

### DIFF
--- a/rgmanager/src/resources/apache.sh
+++ b/rgmanager/src/resources/apache.sh
@@ -265,7 +265,7 @@ fi;
 		
 case $1 in
 	meta-data)
-		cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'`
+		cat ${0/.sh/.metadata}
 		exit 0
 		;;
 	validate-all|verify-all)

--- a/rgmanager/src/resources/drbd.sh
+++ b/rgmanager/src/resources/drbd.sh
@@ -94,7 +94,7 @@ fi
 # This one doesn't need to pass the verify check
 case $1 in
     meta-data)
-	cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'` && exit 0
+	cat ${0/.sh/.metadata}
 	exit $OCF_ERR_GENERIC
 	;;
 esac

--- a/rgmanager/src/resources/lvm.sh
+++ b/rgmanager/src/resources/lvm.sh
@@ -161,7 +161,7 @@ recover|restart)
 	;;
 
 meta-data)
-	cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'`
+	cat ${0/.sh/.metadata}
 	;;
 
 validate-all|verify-all)

--- a/rgmanager/src/resources/mysql.sh
+++ b/rgmanager/src/resources/mysql.sh
@@ -180,7 +180,7 @@ status()
 
 case $1 in
 	meta-data)
-		cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'`
+		cat ${0/.sh/.metadata}
 		exit 0
 		;;
 	validate-all)

--- a/rgmanager/src/resources/named.sh
+++ b/rgmanager/src/resources/named.sh
@@ -191,7 +191,7 @@ status()
 
 case $1 in
 	meta-data)
-		cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'`
+		cat ${0/.sh/.metadata}
 		exit 0
 		;;
 	validate-all)

--- a/rgmanager/src/resources/openldap.sh
+++ b/rgmanager/src/resources/openldap.sh
@@ -194,7 +194,7 @@ status()
 
 case $1 in
 	meta-data)
-		cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'`
+		cat ${0/.sh/.metadata}
 		exit 0
 		;;
 	validate-all)

--- a/rgmanager/src/resources/orainstance.sh
+++ b/rgmanager/src/resources/orainstance.sh
@@ -545,7 +545,7 @@ status_oracle() {
 
 case $1 in
 	meta-data)
-		cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'`
+		cat ${0/.sh/.metadata}
 		exit 0
 		;;
 	start)

--- a/rgmanager/src/resources/oralistener.sh
+++ b/rgmanager/src/resources/oralistener.sh
@@ -166,7 +166,7 @@ recover() {
 
 case $1 in
 	meta-data)
-		cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'`
+		cat ${0/.sh/.metadata}
 		exit 0
 		;;
 	verify-all)

--- a/rgmanager/src/resources/postgres-8.sh
+++ b/rgmanager/src/resources/postgres-8.sh
@@ -208,7 +208,7 @@ status()
 
 case $1 in
 	meta-data)
-		cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'`
+		cat ${0/.sh/.metadata}
 		exit 0
 		;;
 	validate-all)

--- a/rgmanager/src/resources/samba.sh
+++ b/rgmanager/src/resources/samba.sh
@@ -208,7 +208,7 @@ status()
 
 case $1 in
 	meta-data)
-		cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'`
+		cat ${0/.sh/.metadata}
 		exit 0
 		;;
 	validate-all)

--- a/rgmanager/src/resources/tomcat-5.sh
+++ b/rgmanager/src/resources/tomcat-5.sh
@@ -241,7 +241,7 @@ status()
 
 case $1 in
 	meta-data)
-		cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'`
+		cat ${0/.sh/.metadata}
 		exit 0
 		;;
 	validate-all)

--- a/rgmanager/src/resources/tomcat-6.sh
+++ b/rgmanager/src/resources/tomcat-6.sh
@@ -216,7 +216,7 @@ status()
 
 case $1 in
 	meta-data)
-		cat `echo $0 | sed 's/^\(.*\)\.sh$/\1.metadata/'`
+		cat ${0/.sh/.metadata}
 		exit 0
 		;;
 	validate-all)


### PR DESCRIPTION
Ok, shelling out to do find and replace when sh does it so easily urked me enough to write a patch.

tested with ./lvm.sh  meta-data
