### PR TITLE
Low: use bash in rgmanager/src/netfs.sh rather than clunky sed/grep/cut

### DIFF
--- a/rgmanager/src/resources/netfs.sh
+++ b/rgmanager/src/resources/netfs.sh
@@ -383,10 +383,10 @@ do_nfs_rpc_check() {
 	# we find something.
 
 	for o in ${OCF_RESKEY_options//,/ }; do
-		if [[ $o =~ ^proto= ]]; then
+		if [ ${o%%=*} == proto ]; then
 			nfsproto="${o/*=}}"
 		fi
-		if [[ $o =~ ^mountproto= ]]; then
+		if [ ${o%%=*} == mountproto ]; then
 			nfsmountproto="${o/*=}"
 		fi
 		case $o in


### PR DESCRIPTION
since bash can do find and replace, regex matches and variable extraction  lets use it.
