### PR TITLE
Low: use bash in rgmanager/src/clusterfs.sh rather than clunky sed/awk

### DIFF
--- a/rgmanager/src/resources/clusterfs.sh
+++ b/rgmanager/src/resources/clusterfs.sh
@@ -326,9 +326,9 @@ do_force_unmount() {
 		service nfslock start
 		echo "$nfsexports" | { while read line; do
 			nfsexp=${line%% *}
-			parop=${line//*\(}
+			parop=${line##*\(}
 			nfsopts=${parop%%\)*}
-			op=${line/* }
+			op=${line#* }
 			nfsacl=${op%%\(*}
 			if [ -n "$nfsopts" ]; then
 				exportfs -i -o "$nfsopts" "$nfsacl":$nfsexp


### PR DESCRIPTION
since bash can do find and replace and variable extraction  lets use it.
