### PR TITLE
Medium: ldirectord: Get correct user for sending email (bnc#910497)

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -4469,13 +4469,14 @@ sub ld_emailalert_net_smtp
 	my $smtp = Net::SMTP->new($smtp_server);
 
 	if ($smtp) {
-		$smtp->mail("$ENV{USER}\@$hostname");
+		my $myusername = getpwuid( $< );
+		$smtp->mail("$myusername\@$hostname");
 		$smtp->to($to_addr);
 		$smtp->data();
 		if($EMAILALERTFROM) {
 			$smtp->datasend("From: $EMAILALERTFROM\n");
 		} else {
-			$smtp->datasend("From: $ENV{USER}\@$hostname\n");
+			$smtp->datasend("From: $myusername\@$hostname\n");
 		}
 		$smtp->datasend("To: $to_addr\n");
 		$smtp->datasend("Subject: $subject\n\n");


### PR DESCRIPTION
On sending email alert the "local part" of the sending mailaddress
(before @) is the "user" who start ldirectord.
This however does only work if you start /usr/sbin/ldirectord on a bash
shell.
Starting it via resource agent `ocf:heartbeat:ldirectord` seems not
forward the bash environment `"$ENV{USER}"`.

/var/log/mail shows like this:

```
Dec 12 12:30:41 sles11sp301 postfix/qmgr[15049]: 06B94103B9D:
from=<@sles11sp301.vmhamming.suse.de>, size=608, nrcpt=1 (queue active)
```

The following change (using "getpwuid( $< )" instead) will fix that problem.