### PR TITLE
Medium: ldirectord: Add Install section for systemd unit file

### DIFF
--- a/ldirectord/systemd/ldirectord.service.in
+++ b/ldirectord/systemd/ldirectord.service.in
@@ -10,3 +10,6 @@ ExecReload=@sbindir@/ldirectord reload
 PIDFile=/var/run/ldirectord.ldirectord.pid
 Type=forking
 KillMode=none
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
ldirectord failed to systemctl enable, with following error:

```
# systemctl enable ldirectord
The unit files have no [Install] section. They are not meant to be enabled
using systemctl.
Possible reasons for having this kind of units are:
1) A unit may be statically enabled by being symlinked from another unit's
   .wants/ or .requires/ directory.
2) A unit's purpose may be to act as a helper for some other unit which has
   a requirement dependency on it.
3) A unit may be started when needed via activation (socket, path, timer,
   D-Bus, udev, scripted systemctl call, ...).
```

This commit enable to work "systemctl enable ldirectord".
