### PR TITLE
Medium: ldirectord: Fix can not remove virtualservice when stopping ldirectord via systemctl

### DIFF
--- a/ldirectord/systemd/ldirectord.service.in
+++ b/ldirectord/systemd/ldirectord.service.in
@@ -9,3 +9,4 @@ ExecStopPost=/usr/bin/rm -f /var/lock/subsys/ldirectord
 ExecReload=@sbindir@/ldirectord reload
 PIDFile=/var/run/ldirectord.ldirectord.pid
 Type=forking
+KillMode=none


### PR DESCRIPTION
Can not remove virtualservice when stopping ldirectord via systemctl.

```
# cat /etc/ha.d/ldirectord.cf
checktimeout=3
checkinterval=1
autoreload=yes
quiescent=no

virtual=192.168.6.240:80
        real=192.168.6.2:80 gate
        real=192.168.6.3:80 gate
        real=192.168.6.6:80 gate
        fallback=127.0.0.1:80 gate
        checktype=on


# systemctl start ldirectord

# ps -ef | grep ldirector[d]
root      1406     1  0 15:13 ?        00:00:00 /usr/bin/perl -w /usr/sbin/ldirectord start

# ipvsadm -ln
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
TCP  192.168.6.240:80 wrr
  -> 192.168.6.2:80               Route   1      0          0
  -> 192.168.6.3:80               Route   1      0          0
  -> 192.168.6.6:80               Route   1      0          0



# systemctl stop ldirectord

# ps -ef | grep ldirector[d]
<no process>

# ipvsadm -ln
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
TCP  192.168.6.240:80 wrr
  -> 192.168.6.6:80               Route   1      0          0

```

Maybe ldirectord process killed by systemd 
in the middle of ExecStop (/usr/sbin/ldirectord stop).

Apply a patch to systemd unit file, virtualservice is removed correctly.

```
# systemctl start ldirectord

# ps -ef | grep ldirector[d]
root      2954     1  0 15:20 ?        00:00:00 /usr/bin/perl -w /usr/sbin/ldirectord start

# ipvsadm -ln
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
TCP  192.168.6.240:80 wrr
  -> 192.168.6.2:80               Route   1      0          0
  -> 192.168.6.3:80               Route   1      0          0
  -> 192.168.6.6:80               Route   1      0          0



# systemctl stop ldirectord

# ps -ef | grep ldirector[d]
<no process>

# ipvsadm -ln
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn

```

