### PR TITLE
low: ldirectord: modify manual and sample for Radius check

### DIFF
--- a/ldirectord/ldirectord.cf
+++ b/ldirectord/ldirectord.cf
@@ -295,9 +295,9 @@ virtual=192.168.6.240:80
 # Note that using checktype=connect and protocol=udp
 # will also effect ping checks
 #virtual=192.168.6.240:1812
-#	real=192.168.6.2::1812 gate
-#	real=192.168.6.3::1812 gate
-#	real=192.168.6.6::1812 gate
+#	real=192.168.6.2:1812 gate
+#	real=192.168.6.3:1812 gate
+#	real=192.168.6.6:1812 gate
 #	fallback=127.0.0.1:1812 gate
 #	scheduler=rr
 #	#persistent=600
@@ -305,7 +305,7 @@ virtual=192.168.6.240:80
 #	protocol=udp
 #	checktype=negotiate
 #	service=radius
-#	password="readuser"
+#	login="readuser"
 #	passwd="genericpassword"
 #	secret="somesecret"
 #	checktimeout=1

--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -597,7 +597,7 @@ B<login = ">I<username>B<">
 For FTP, IMAP, LDAP, MySQL, Oracle, POP and PostgreSQL, the username
 used to log in.
 
-For Radius the passwd is used for the attribute User-Name.
+For Radius the username is used for the attribute User-Name.
 
 For SIP, the username is used as both the to and from address for an
 OPTIONS query.


### PR DESCRIPTION
"password" option is not implemented.
"login" option is used for the attribute User-Name.

By the way, modify typo "::"->":"