### PR TITLE
fs-lib.sh: Fix missed detection of write failure

### DIFF
--- a/rgmanager/src/resources/utils/fs-lib.sh
+++ b/rgmanager/src/resources/utils/fs-lib.sh
@@ -583,7 +583,7 @@ is_alive()
 	done
 	if [ $rw -eq $YES ]; then
 		file=$(mktemp "$mount_point/.check_writable.$(hostname).XXXXXX")
-		if [ ! -e $file ]; then
+		if [ ! -e "$file" ]; then
 			ocf_log err "${OCF_RESOURCE_INSTANCE}: is_alive: failed write test on [$mount_point]. Return code: $errcode"
 			return $NO
 		fi


### PR DESCRIPTION
Improper quoting when checking the mktemp result causes a false positive when that command failed to create the file, such as from a file-system being read-only.  