### PR TITLE
Low: nfsserver.sh: for rgmanager nfs agent, strip off trailing '/' from ...

### DIFF
--- a/rgmanager/src/resources/nfsserver.sh
+++ b/rgmanager/src/resources/nfsserver.sh
@@ -23,6 +23,11 @@ if [ $SELINUX_ENABLED ]; then
 	export SELINUX_LABEL="$(ls -ldZ /var/lib/nfs/statd | cut -f4 -d' ')"
 fi
 
+# strip trailing / off so pattern matching will work consistently.
+while [ "${OCF_RESKEY_path#${OCF_RESKEY_path%?}}" = "/" ]
+do
+	OCF_RESKEY_path="${OCF_RESKEY_path%/}"
+done
 
 log_do()
 {


### PR DESCRIPTION
...path option

There's nothing technically wrong with the trailing '/' other
than it prevented some pattern matching from working as expected.
This was the least invasive fix.