### PR TITLE
Fix: Problem that a state of domain cannot evaluate by LANG of libvirtd

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -331,12 +331,13 @@ VirtualDomain_Status() {
 	status="no state"
 	while [ "$status" = "no state" ]; do
 		try=$(($try + 1 ))
-		status=$(virsh $VIRSH_OPTIONS domstate $DOMAIN_NAME 2>&1 | tr 'A-Z' 'a-z')
+		status=$(LANG=C virsh $VIRSH_OPTIONS domstate $DOMAIN_NAME 2>&1 | tr 'A-Z' 'a-z')
 		case "$status" in
-			*"error:"*"failed to get domain"*|"shut off")
+			*"error:"*"domain not found"|*"error:"*"failed to get domain"*|"shut off")
 				# shut off: domain is defined, but not started, will not happen if
 				#   domain is created but not defined
-				# failed to get domain: domain is not defined and thus not started
+				# "Domain not found" or "failed to get domain": domain is not defined
+				#   and thus not started
 				ocf_log debug "Virtual domain $DOMAIN_NAME is not running: $(echo $status | sed s/error://g)"
 				rc=$OCF_NOT_RUNNING
 				;;

--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -333,10 +333,10 @@ VirtualDomain_Status() {
 		try=$(($try + 1 ))
 		status=$(virsh $VIRSH_OPTIONS domstate $DOMAIN_NAME 2>&1 | tr 'A-Z' 'a-z')
 		case "$status" in
-			*"error:"*"domain not found"*|"shut off")
+			*"error:"*"failed to get domain"*|"shut off")
 				# shut off: domain is defined, but not started, will not happen if
 				#   domain is created but not defined
-				# Domain not found: domain is not defined and thus not started
+				# failed to get domain: domain is not defined and thus not started
 				ocf_log debug "Virtual domain $DOMAIN_NAME is not running: $(echo $status | sed s/error://g)"
 				rc=$OCF_NOT_RUNNING
 				;;


### PR DESCRIPTION
If libvirtd of LANG is set to other than English, I fail to start the domain.
It occurs when there is not defined of domain in libvirtd.
Modify to use the output that does not depend on the language environment.

 * in case of LANG=ja_JP.UTF-8

```
# cat /proc/`pidof libvirtd`/environ | tr '\0' '\n'                                                                                                                                         
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
LANG=ja_JP.UTF-8
NOTIFY_SOCKET=@/org/freedesktop/systemd1/notify
# virsh domstate guest-4                                                                                                                                                                    
error: failed to get domain 'guest-4'
error: ドメインは見つかりませんでした: 'guest-4' と一致する名前を持つドメインがありません 
```

 * in case of LANG=en_US.UTF-8

```
# cat /proc/`pidof libvirtd`/environ | tr '\0' '\n'
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
LANG=en_US.UTF-8
NOTIFY_SOCKET=@/org/freedesktop/systemd1/notify
# virsh domstate guest-4
error: failed to get domain 'guest-4'
error: Domain not found: no domain with matching name 'guest-4'
```