### PR TITLE
help various RA create state directory

### DIFF
--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -593,6 +593,7 @@ apache_validate_all() {
 		ocf_exit_reason "Configuration file $CONFIGFILE not found!"
 		return $OCF_ERR_INSTALLED
 	fi
+	ocf_mkstatedir root 755 `dirname $PidFile` || return $OCF_ERR_INSTALLED
 	return $OCF_SUCCESS
 }
 

--- a/heartbeat/named
+++ b/heartbeat/named
@@ -229,6 +229,9 @@ named_validate_all() {
         return $OCF_ERR_CONFIGURED
     fi                            
          
+    # make sure that the pidfile directory exists
+    ocf_mkstatedir $OCF_RESKEY_named_user 755 `dirname $OCF_RESKEY_named_pidfile` || return $OCF_ERR_INSTALLED
+
     return $OCF_SUCCESS
 }
 
@@ -487,3 +490,5 @@ case "$1" in
     *)
                 exit $OCF_ERR_UNIMPLEMENTED;;
 esac
+
+# vim:ts=4:sw=4:et:

--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -748,6 +748,87 @@ ocf_stop_processes() {
 }
 
 #
+# create a given status directory
+# if the directory path doesn't start with $HA_VARRUN, then
+# we return with error (most of the calls would be with the user
+# supplied configuration, hence we need to do necessary
+# protection)
+# used mostly for PID files
+#
+# usage: ocf_mkstatedir owner permissions path
+#
+# owner: user.group
+# permissions: permissions
+# path: directory path
+#
+# example:
+#	ocf_mkstatedir named 755 `dirname $pidfile`
+#
+ocf_mkstatedir()
+{
+	local owner
+	local perms
+	local path
+
+	owner=$1
+	perms=$2
+	path=$3
+
+	test -d $path && return 0
+	[ $(id -u) = 0 ] || return 1
+
+	case $path in
+	$HA_VARRUN/*) : this path is ok ;;
+	*) ocf_log err "cannot create $path (does not start with $HA_VARRUN)"
+		return 1
+	;;
+	esac
+
+	mkdir -p $path &&
+	chown $owner $path &&
+	chmod $perms $path
+}
+
+#
+# create a unique status directory in $HA_VARRUN
+# used mostly for PID files
+# the directory is by default set to
+#   $HA_VARRUN/$OCF_RESOURCE_INSTANCE
+# the directory name is printed to stdout
+#
+# usage: ocf_unique_rundir owner permissions name
+#
+# owner: user.group (default: "root")
+# permissions: permissions (default: "755")
+# name: some unique string (default: "$OCF_RESOURCE_INSTANCE")
+#
+# to use the default either don't set the parameter or set it to
+# empty string ("")
+# example:
+#
+#	STATEDIR=`ocf_unique_rundir named "" myownstatedir`
+#
+ocf_unique_rundir()
+{
+	local path
+	local owner
+	local perms
+	local name
+
+	owner=${1:-"root"}
+	perms=${2:-"755"}
+	name=${3:-"$OCF_RESOURCE_INSTANCE"}
+	path=$HA_VARRUN/$name
+	if [ ! -d $path ]; then
+		[ $(id -u) = 0 ] || return 1
+		mkdir -p $path &&
+		chown $owner $path &&
+		chmod $perms $path || return 1
+	fi
+	echo $path
+}
+
+#
 # RA tracing may be turned on by setting OCF_TRACE_RA
 # the trace output will be saved to OCF_TRACE_FILE, if set, or
 # by default to

--- a/heartbeat/zabbixserver
+++ b/heartbeat/zabbixserver
@@ -130,26 +130,6 @@ getpid() {
 }
 
 #
-# Check if PID directory exists
-#
-check_piddir() {
-    local piddir
-    local severity
-
-    # lower severity to info during probe
-    severity=err
-    ocf_is_probe && severity=info
-
-    piddir=`dirname ${OCF_RESKEY_pid}`
-    if [ ! -d $piddir ]; then
-        ocf_log $severity "PID directory ${piddir} doesn't exist"
-        return 1
-    fi
-
-    return 0
-}
-
-#
 # Check for the server configuration file
 #
 check_config() {
@@ -322,9 +302,8 @@ zabbixserver_monitor() {
 # validate configuration
 #
 zabbixserver_validate_all() {
-    check_piddir || return $OCF_ERR_INSTALLED
     check_config $OCF_RESKEY_config || return $OCF_ERR_INSTALLED
-
+    ocf_mkstatedir root 755 `dirname $OCF_RESKEY_pid` || return $OCF_ERR_INSTALLED
     return $OCF_SUCCESS
 }
 


### PR DESCRIPTION
This should help agents that manage daemons running as non-root to create a state directory (for say PID files) which is unique and writeable by the daemon process. Should help fix #350 and #351.