### PR TITLE
orainstance.sh: Fix process name grep in exit_idle

### DIFF
--- a/rgmanager/src/resources/orainstance.sh
+++ b/rgmanager/src/resources/orainstance.sh
@@ -216,7 +216,7 @@ exit_idle() {
 	declare -i n=0
 	
 	ocf_log debug "Waiting for Oracle processes for $ORACLE_SID to terminate..."
-	while ps ax | grep $ORACLE_SID | grep -v grep | grep -q -v $LSNR_PROCNAME; do
+	while ps ax | grep ora_.*_${ORACLE_SID} | grep -v grep | grep -q -v $LSNR_PROCNAME; do
 		if [ $n -ge 90 ]; then
 			ocf_log debug "Timed out while waiting for Oracle processes for $ORACLE_SID to terminate"
 			force_cleanup


### PR DESCRIPTION
Fix a bug that can cause the script to pause for 90 seconds.
rhbz#1200639