### PR TITLE
Low: rgmanager: drop unused shutdown_wait in postgres-8.metadata

### DIFF
--- a/rgmanager/src/resources/postgres-8.metadata
+++ b/rgmanager/src/resources/postgres-8.metadata
@@ -51,18 +51,6 @@
 		<content type="string" default="-D /var/lib/pgsql/data"/>
 	</parameter>
 
-	<parameter name="shutdown_wait">
-		<longdesc lang="en">
-			Wait X seconds for correct end of service shutdown. 
-			This option is ignored in current release.
-		</longdesc>
-		<shortdesc lang="en">
-			Wait X seconds for correct end of service shutdown
-			This option is ignored in current release.
-		</shortdesc>
-		<content type="integer" />
-	</parameter>
-
         <parameter name="startup_wait">
                 <longdesc lang="en">
                         Wait X seconds for correct end of service startup


### PR DESCRIPTION
Signed-off-by: Jan Pokorný <jpokorny@redhat.com>