### PR TITLE
Remove LVM RA limit of not supporting volume group with no logical volum...

### DIFF
--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -293,7 +293,7 @@ set_tags()
 }
 
 get_lv_number() {
-	echo "`vgdisplay $1|sed -n '/Cur LV/p'|awk '{print $3}'`"
+	vgdisplay $1|awk '/Cur LV/{print $3}'
 }
 
 #
@@ -317,7 +317,7 @@ LVM_status() {
 	fi
 	# Here we always return true if the volume grouop is empty
 	lv_nu=$(get_lv_number $1)
-	if [ $lv_nu -eq 0 ]; then
+	if [ "$lv_nu" = "0" ]; then
             return 0
 	fi
 	
@@ -494,7 +494,7 @@ LVM_stop() {
 	do
 		ocf_run vgchange $vgchange_options $vg
 		res=$?
-		if [ $lv_nu -eq 0 ]; then
+		if [ "$lv_nu" = "0" ]; then
 			res=0
 		elif LVM_status $vg; then
 			ocf_exit_reason "LVM: $vg did not stop correctly"

--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -292,8 +292,16 @@ set_tags()
 	return $OCF_SUCCESS
 }
 
-get_lv_number() {
-	vgdisplay $1|awk '/Cur LV/{print $3}'
+#
+#       Return whether volume goup is empth(0:empty; 1: contains lvs)
+#
+vg_is_empty() {
+        grep "logical_volumes" /etc/lvm/backup/$1
+        if [ $? -eq 0 ]; then
+                return 1
+        else
+                return 0
+        fi
 }
 
 #
@@ -301,7 +309,6 @@ get_lv_number() {
 #
 LVM_status() {
 	local rc=1
-	local lv_nu
 	loglevel="debug"
 
 	# Set the log level of the error message
@@ -315,11 +322,11 @@ LVM_status() {
 			fi
 		fi
 	fi
+	
 	# Here we always return true if the volume grouop is empty
-	lv_nu=$(get_lv_number $1)
-	if [ "$lv_nu" = "0" ]; then
-            return 0
-	fi
+        if vg_is_empty $vg; then
+                return 0
+        fi
 	
 	if [ -d /dev/$1 ]; then
 		test "`cd /dev/$1 && ls`" != ""
@@ -484,8 +491,6 @@ LVM_stop() {
 
 	ocf_log info "Deactivating volume group $vg"
 
-	lv_nu=$(get_lv_number $vg)
-
 	case $(get_vg_mode) in
 		1) vgchange_options="-an" ;;
 	esac
@@ -494,7 +499,8 @@ LVM_stop() {
 	do
 		ocf_run vgchange $vgchange_options $vg
 		res=$?
-		if [ "$lv_nu" = "0" ]; then
+
+		if vg_is_empty $vg; then
 			res=0
 		elif LVM_status $vg; then
 			ocf_exit_reason "LVM: $vg did not stop correctly"

--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -482,7 +482,6 @@ LVM_stop() {
 	local res=$OCF_ERR_GENERIC
 	local vgchange_options="-aln"
 	local vg=$1
-	local lv_nu
 
 	if ! vgs $vg > /dev/null 2>&1; then
 		ocf_log info "Volume group $vg not found"

--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -292,11 +292,16 @@ set_tags()
 	return $OCF_SUCCESS
 }
 
+get_lv_number() {
+	echo "`vgdisplay $1|sed -n '/Cur LV/p'|awk '{print $3}'`"
+}
+
 #
 #	Return LVM status (silently)
 #
 LVM_status() {
 	local rc=1
+	local lv_nu
 	loglevel="debug"
 
 	# Set the log level of the error message
@@ -310,13 +315,15 @@ LVM_status() {
 			fi
 		fi
 	fi
+	# Here we always return true if the volume grouop is empty
+	lv_nu=$(get_lv_number $1)
+	if [ $lv_nu -eq 0 ]; then
+            return 0
+	fi
 	
 	if [ -d /dev/$1 ]; then
 		test "`cd /dev/$1 && ls`" != ""
 		rc=$?
-		if [ $rc -ne 0 ]; then
-			ocf_exit_reason "VG $1 with no logical volumes is not supported by this RA!"
-		fi
 	fi
 
 	if [ $rc -ne 0 ]; then
@@ -468,6 +475,7 @@ LVM_stop() {
 	local res=$OCF_ERR_GENERIC
 	local vgchange_options="-aln"
 	local vg=$1
+	local lv_nu
 
 	if ! vgs $vg > /dev/null 2>&1; then
 		ocf_log info "Volume group $vg not found"
@@ -475,6 +483,8 @@ LVM_stop() {
 	fi
 
 	ocf_log info "Deactivating volume group $vg"
+
+	lv_nu=$(get_lv_number $vg)
 
 	case $(get_vg_mode) in
 		1) vgchange_options="-an" ;;
@@ -484,7 +494,9 @@ LVM_stop() {
 	do
 		ocf_run vgchange $vgchange_options $vg
 		res=$?
-		if LVM_status $vg; then
+		if [ $lv_nu -eq 0 ]; then
+			res=0
+		elif LVM_status $vg; then
 			ocf_exit_reason "LVM: $vg did not stop correctly"
 			res=1
 		fi


### PR DESCRIPTION
...e

It is not convinient now to a setup a LVM RA especially when using hawk
wizard. For example:
After configured a clvmd resource, we have to pause the configuration wizard;
Then create a vg and lv;
Then configue a LVM resource and start resources.

If remove the limit, we can:
Firstly create a clustered vg;
Then configure clvmd, LVM resoure and start resources;
At last create lv within the vg.

Also, when users configured a LVM resource with a vg with no lv,
the LVM resource will start failed and then stop clvmd resource too.
If users want to fix this they have to remove the LVM resource
and then create lv within the vg and then readd the LVM resource.