### PR TITLE
Fix return code in asterisk_monitor

### DIFF
--- a/heartbeat/asterisk
+++ b/heartbeat/asterisk
@@ -287,7 +287,7 @@ asterisk_monitor() {
 
     if [ $rc -ne 0 ]; then
       ocf_log err "Failed to connect to the Asterisk PBX"
-      return $OCF_ERR_GENERIC
+      return $OCF_NOT_RUNNIG
     fi
 
     # Optionally check the monitor URI with sipsak


### PR DESCRIPTION
When asterisk_monitor is called from asteris_startup, it could take a long time to allow asterisk -rx connection (on hevy loaded virtual host) so return NOT_RUNNTING instead of ERR_GENERIC