### PR TITLE
Fix return code in asterisk_monitor No.2

### DIFF
--- a/heartbeat/asterisk
+++ b/heartbeat/asterisk
@@ -286,8 +286,13 @@ asterisk_monitor() {
     rc=$?
 
     if [ $rc -ne 0 ]; then
-      ocf_log err "Failed to connect to the Asterisk PBX"
-      return $OCF_ERR_GENERIC
+      if [ "$__OCF_ACTION" = "start" ]; then
+      	ocf_log info "Asterisk PBX not running yet"
+	return $OCF_NOT_RUNNING;
+      else
+      	ocf_log err "Failed to connect to the Asterisk PBX"
+        return $OCF_ERR_GENERIC;
+      fi
     fi
 
     # Optionally check the monitor URI with sipsak


### PR DESCRIPTION
If asterisk_monitor called from asterisk_start, return OCF_NOT_RUNNING instead of OCF_ERR_GENERIC