### PR TITLE
Ignore bogus mysql seconds_behind_master values

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -470,6 +470,10 @@ get_slave_info() {
             slave_io=`parse_slave_info Slave_IO_Running $tmpfile`
             last_errno=`parse_slave_info Last_Errno $tmpfile`
             secs_behind=`parse_slave_info Seconds_Behind_Master $tmpfile`
+            if [ $secs_behind -gt 86400 ]; then
+                ocf_log debug "Ignoring enourmous secs_behind: $secs_behind"
+                secs_behind=0
+            fi
             ocf_log debug "MySQL instance running as a replication slave"
         else
             # Instance produced an empty "SHOW SLAVE STATUS" output --


### PR DESCRIPTION
Sometimes show slave status reports enourmous
seconds_behind_master values, leading to zagent
thinking a slave is down. This is probably
when you wake up after periods of inactivity.

This is a mysql bug:

bugs.mysql.com/bug.php?id=52166

There are three suggestions in the
bug report

1. Upgrade MySQL
2. Trigger periodic data updates
3. Ignore bogus secs_behind values

We cannot do 1. so easily, involves more
testing and different distribution (not in rhel6)

We tried 2 but it's perhaps not reliable.

So, here is approach 3.

All of this will go away using MySQL/Galera