### PR TITLE
Fixed redis start operation if replication sync takes > 20 seconds

### DIFF
--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -289,39 +289,6 @@ function monitor() {
 	return $OCF_SUCCESS
 }
 
-function get_replication_status() {
-	typeset -A info
-	while read line; do
-		[[ "$line" == "#"* ]] && continue
-		[[ "$line" != *":"* ]] && continue
-		IFS=':' read -r key value <<< "$line"
-		info[$key]="$value"
-	done < <(redis_client info)
-
-	if [[ -z "${info[role]}" ]]; then
-		ocf_log err "monitor: Could not get role from \`$REDIS_CLIENT -s $REDIS_SOCKET info\`"
-		return $OCF_ERR_GENERIC
-	fi
-
-	if [[ "${info[role]}" != "slave" ]]; then
-		ocf_log err "get_replication_status: Is not a slave (role=${info[role]})\`"
-		return $OCF_ERR_GENERIC
-	fi
-
-	if [[ "${info[master_sync_in_progress]}" == "1" ]]; then
-		ocf_log info "get_replication_status: Master / Slave sync in progress, (master=${info[master_host]}, link=${info[master_link_status]}, master_sync_in_progress=${info[master_sync_in_progress]})"
-		return 128
-	fi
-
-	if [[ "${info[master_sync_in_progress]}" == "0" ]] && [[ "${info[master_link_status]}" == "up" ]] ; then
-		ocf_log info "get_replication_status: Master / Slave in sync and up (master=${info[master_host]}, link=${info[master_link_status]}, master_sync_in_progress=${info[master_sync_in_progress]})"
-		return $OCF_SUCCESS
-	fi
-
-	return $OCF_ERR_GENERIC
-
-}
-
 function start() {
 	monitor
 	status=$?
@@ -468,18 +435,9 @@ function demote() {
 	#       This can take an arbitraty time (data) and should 
 	#       only be parametrized by the start operation timeout
 	#	by the administrator, not by this resource agent code
-	for (( c=1; c <= 20; c++ ))
-	do
+	while true; do 
 		# Wait infinite if replication is syncing
 		# Then start/demote operation timeout determines timeout
-		get_replication_status
-		status=$?
-		if (( status == 128 )); then
-			c=1
-			sleep 1
-			continue
-		fi
-
 		monitor
 		status=$?
 		if (( status == OCF_SUCCESS )); then

--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -289,6 +289,39 @@ function monitor() {
 	return $OCF_SUCCESS
 }
 
+function get_replication_status() {
+	typeset -A info
+	while read line; do
+		[[ "$line" == "#"* ]] && continue
+		[[ "$line" != *":"* ]] && continue
+		IFS=':' read -r key value <<< "$line"
+		info[$key]="$value"
+	done < <(redis_client info)
+
+	if [[ -z "${info[role]}" ]]; then
+		ocf_log err "monitor: Could not get role from \`$REDIS_CLIENT -s $REDIS_SOCKET info\`"
+		return $OCF_ERR_GENERIC
+	fi
+
+	if [[ "${info[role]}" != "slave" ]]; then
+		ocf_log err "get_replication_status: Is not a slave (role=${info[role]})\`"
+		return $OCF_ERR_GENERIC
+	fi
+
+	if [[ "${info[master_sync_in_progress]}" == "1" ]]; then
+		ocf_log info "get_replication_status: Master / Slave sync in progress, (master=${info[master_host]}, link=${info[master_link_status]}, master_sync_in_progress=${info[master_sync_in_progress]})"
+		return 128
+	fi
+
+	if [[ "${info[master_sync_in_progress]}" == "0" ]] && [[ "${info[master_link_status]}" == "up" ]] ; then
+		ocf_log info "get_replication_status: Master / Slave in sync and up (master=${info[master_host]}, link=${info[master_link_status]}, master_sync_in_progress=${info[master_sync_in_progress]})"
+		return $OCF_SUCCESS
+	fi
+
+	return $OCF_ERR_GENERIC
+
+}
+
 function start() {
 	monitor
 	status=$?
@@ -427,14 +460,32 @@ function demote() {
 
 	redis_client slaveof "$master_host" "$master_port"
 
-	# wait briefly for the slave to connect to the master	
+	# Wait forever for the slave to connect to the master and finish the 
+	# sync. Timeout is controlled by Pacemaker "op start timeout=XX".
+	#
+	# hint: redis master_link_status will only come "up" when 
+	#       the SYNC with the master has completed.
+	#       This can take an arbitraty time (data) and should 
+	#       only be parametrized by the start operation timeout
+	#	by the administrator, not by this resource agent code
 	for (( c=1; c <= 20; c++ ))
 	do
+		# Wait infinite if replication is syncing
+		# Then start/demote operation timeout determines timeout
+		get_replication_status
+		status=$?
+		if (( status == 128 )); then
+			c=1
+			sleep 1
+			continue
+		fi
+
 		monitor
 		status=$?
 		if (( status == OCF_SUCCESS )); then
 			return $OCF_SUCCESS
 		fi
+		
 		sleep 1
 	done
 


### PR DESCRIPTION
Current Resource Agent wait 20 seconds to initial sync to finish. 

If the sync takes longer then 20 seconds (can be if huge amount of data is synced), the start fails, altought fully OK. This fix waits for the sync to finish forever. meta op start timeut=xxx should set an appropriate value for the start to timeout.