### PR TITLE
Dev: Add Travis CI job which runs shellcheck on all scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: bash
+install:
+  - ./ci/install.sh
+script:
+  - ./ci/build.sh
+notifications:
+  email: false
+sudo: required

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ "${DEBUG:-}" ]] && set -x
+
+declare -i failed
+failed=0
+
+success() {
+  printf "\r\033[2K  [ \033[00;32mOK\033[0m ] Checking %s...\n" "$1"
+}
+
+fail() {
+	printf "\r\033[2K  [\033[0;31mFAIL\033[0m] Checking %s...\n" "$1"
+	failed=1
+}
+
+check() {
+  local script="$1"
+  shellcheck "$script" || fail "$script"
+  success "$script"
+}
+
+find_prunes() {
+  local prunes="! -path './.git/*'"
+  if [ -f .gitmodules ]; then
+    while read module; do
+      prunes="$prunes ! -path './$module/*'"
+    done < <(grep path .gitmodules | awk '{print $3}')
+  fi
+  echo "$prunes"
+}
+
+find_cmd() {
+  echo "find . -type f -and \( -perm +111 -or -name '*.sh' \) $(find_prunes)"
+}
+
+check_all_executables() {
+  echo "Checking executables and .sh files..."
+  eval "$(find_cmd)" | while read script; do
+    head=$(head -n1 "$script")
+    check "$script"
+  done
+  exit $failed
+}
+
+check_all_executables

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eo pipefail
+
+main() {
+  local filename="shellcheck_0.3.7-1_amd64.deb"
+  wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/$filename"
+  sudo dpkg -i "$filename"
+}
+
+main


### PR DESCRIPTION
This adds a Travis CI which invokes shellcheck on all scripts
in the repository. It doesn't currently signal failure, but the
build job output can be inspected for any issues that should
be fixed.