### PR TITLE
Low: pgsql: eliminate duplicate "ocf_exit_reason".

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -592,7 +592,7 @@ pgsql_real_start() {
         create_replication_slot
         rc=$?
         if [ $rc -eq $OCF_ERR_GENERIC ]; then
-            ocf_exit_reason ocf_exit_reason "PostgreSQL can't create replication_slot."
+            ocf_exit_reason "PostgreSQL can't create replication_slot."
             return $OCF_ERR_GENERIC
         fi
     fi


### PR DESCRIPTION
This pull request aim to eliminate duplicate "ocf_exit_reason" in the pgsql RA.