### PR TITLE
Fix initialize replication slot2

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1333,23 +1333,33 @@ create_replication_slot() {
     local output
     local rc
     local CREATE_REPLICATION_SLOT_sql
+    local DELETE_REPLICATION_SLOT_sql
 
     replication_slot_name_list=`create_replication_slot_name`
     ocf_log debug "replication slot names are $replication_slot_name_list."
 
     for replication_slot_name in $replication_slot_name_list
     do
-        # create replication slot when the same name slot is not exists.
-        # If the same name slot is already exists, don't create new slot and reuse the old slot.
-        CREATE_REPLICATION_SLOT_sql="SELECT pg_create_physical_replication_slot('$replication_slot_name') \
-                                     FROM (VALUES (1)) AS t \
-                                     WHERE NOT EXISTS (SELECT * FROM pg_replication_slots WHERE slot_name = '$replication_slot_name');"
+        # If the same name slot is already exists, initialize(delete and create) the slot.
+        if [ `check_replication_slot $replication_slot_name` = "1" ]; then
+            DELETE_REPLICATION_SLOT_sql="SELECT pg_drop_replication_slot('$replication_slot_name');"
+            output=`exec_sql "$DELETE_REPLICATION_SLOT_sql"`
+            rc=$?
 
+            if [ $rc -eq 0 ]; then
+                ocf_log info "PostgreSQL delete the replication slot($replication_slot_name)."
+            else
+                ocf_exit_reason "$output"
+                return $OCF_ERR_GENERIC
+            fi
+        fi
+
+        CREATE_REPLICATION_SLOT_sql="SELECT pg_create_physical_replication_slot('$replication_slot_name');"
         output=`exec_sql "$CREATE_REPLICATION_SLOT_sql"`
         rc=$?
 
         if [ $rc -eq 0 ]; then
-            ocf_log info "PostgreSQL creates or alredy exist the replication slot($replication_slot_name)"
+            ocf_log info "PostgreSQL creates the replication slot($replication_slot_name)."
         else
             ocf_exit_reason "$output"
             return $OCF_ERR_GENERIC
@@ -1357,6 +1367,16 @@ create_replication_slot() {
     done
 
     return 0
+}
+
+# This function check the replication slot does exists.
+check_replication_slot(){
+    local replication_slot_name=$1
+    local output
+    local CHECK_REPLICATION_SLOT_sql="SELECT count(*) FROM pg_replication_slots WHERE slot_name = '$replication_slot_name'"
+
+    output=`exec_sql "$CHECK_REPLICATION_SLOT_sql"`
+    echo "$output"
 }
 
 get_my_location() {

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -506,6 +506,22 @@ EOF
 }
 
 
+# Execulte SQL and return the result.
+exec_sql() {
+    local sql=$1
+    local output
+    local rc
+
+    output=`su $OCF_RESKEY_pgdba -c "cd $OCF_RESKEY_pgdata; \
+                $OCF_RESKEY_psql $psql_options -U $OCF_RESKEY_pgdba \
+                -Atc \"$sql\""`
+    rc=$?
+
+    echo $output
+    return $?
+}
+
+
 #pgsql_real_start: Starts PostgreSQL
 pgsql_real_start() {
     local pgctl_options
@@ -895,10 +911,9 @@ pgsql_real_monitor() {
 
     if is_replication; then
         #Check replication state
-        output=`su $OCF_RESKEY_pgdba -c "cd $OCF_RESKEY_pgdata; \
-                $OCF_RESKEY_psql $psql_options -U $OCF_RESKEY_pgdba \
-                -Atc \"${CHECK_MS_SQL}\""`
+        output=`exec_sql "${CHECK_MS_SQL}"`
         rc=$?
+
         if [ $rc -ne  0 ]; then
             report_psql_error $rc $loglevel "Can't get PostgreSQL recovery status."
             return $OCF_ERR_GENERIC
@@ -1095,10 +1110,9 @@ control_slave_status() {
     local tmp_data_status
     local number_of_nodes
 
-    all_data_status=`su $OCF_RESKEY_pgdba -c "cd $OCF_RESKEY_pgdata; \
-                     $OCF_RESKEY_psql $psql_options -U $OCF_RESKEY_pgdba \
-                     -Atc \"${CHECK_REPLICATION_STATE_SQL}\""`
+    all_data_status=`exec_sql "${CHECK_REPLICATION_STATE_SQL}"`
     rc=$?
+
     if [ $rc -eq 0 ]; then
         if [ -n "$all_data_status" ]; then
             all_data_status=`echo $all_data_status | sed "s/\n/ /g"`
@@ -1331,10 +1345,9 @@ create_replication_slot() {
                                      FROM (VALUES (1)) AS t \
                                      WHERE NOT EXISTS (SELECT * FROM pg_replication_slots WHERE slot_name = '$replication_slot_name');"
 
-        output=`su $OCF_RESKEY_pgdba -c "cd $OCF_RESKEY_pgdata; \
-                $OCF_RESKEY_psql $psql_options -U $OCF_RESKEY_pgdba \
-                -Atc \"$CREATE_REPLICATION_SLOT_sql\""`
+        output=`exec_sql "$CREATE_REPLICATION_SLOT_sql"`
         rc=$?
+
         if [ $rc -eq 0 ]; then
             ocf_log info "PostgreSQL creates or alredy exist the replication slot($replication_slot_name)"
         else
@@ -1357,10 +1370,9 @@ get_my_location() {
     local log2
     local newer_location
 
-    output=`su $OCF_RESKEY_pgdba -c "cd $OCF_RESKEY_pgdata; \
-            $OCF_RESKEY_psql $psql_options -U $OCF_RESKEY_pgdba \
-            -Atc \"${CHECK_XLOG_LOC_SQL}\""`
+    output=`exec_sql "$CHECK_REPLICATION_SLOT_sql"`
     rc=$?
+
     if [ $rc -ne 0 ]; then
         report_psql_error $rc err "Can't get my xlog location."
         return 1


### PR DESCRIPTION
Initialize the replication slot (delete an old slot if exists and create a new one)
to prevent that the old slot runs out of disk space.

Without the initialization, PostgreSQL would try to use the old slot after a node
failed once and re-joined to the cluster, and continue to accumulate WAL files for
the old slot, which would eventually run out of disk space.

Reflects following comments #619 