### PR TITLE
Fix race condition with iSCSITarget with lio-t

### DIFF
--- a/heartbeat/iSCSITarget
+++ b/heartbeat/iSCSITarget
@@ -111,6 +111,7 @@ Allowed initiators. A space-separated list of initiators allowed to
 connect to this target. Initiators may be listed in any syntax
 the target implementation allows. If this parameter is empty or
 not set, access to this target will be allowed from any initiator.
+When using lio-t you should set this in iSCSILogicalUnit - not here.
 </longdesc>
 <shortdesc lang="en">List of iSCSI initiators allowed to connect
 to this target</shortdesc>
@@ -555,10 +556,15 @@ iSCSITarget_validate() {
 		# specific IP address.
 		unsupported_params="portals"
 		;;
-	lio|lio-t)
+	lio)
 		# TODO: Remove incoming_username and incoming_password
 		# from this check when LIO 3.0 gets CHAP authentication
 		unsupported_params="tid incoming_username incoming_password"
+		;;
+	lio-t)
+		# TODO: Remove incoming_username and incoming_password
+		# from this check when LIO 3.0 gets CHAP authentication
+		unsupported_params="tid incoming_username incoming_password allowed_initiators"
 		;;
 	esac
 


### PR DESCRIPTION
Fixes #637

When using lio-t (targetcli) you should not set the allowed_initiators in the iSCSITarget and instead set it in iSCSILogicalUnit.

If allowed_initiators is set in iSCSITarget you will likely encounter a race condition where by the iSCSILogicalUnit must be cleaned-up before it will start as ACL generation would have been duplicated by iSCSITarget.