### PR TITLE
iSCSILogicalUnit improvements

### DIFF
--- a/heartbeat/iSCSILogicalUnit
+++ b/heartbeat/iSCSILogicalUnit
@@ -429,15 +429,21 @@ iSCSILogicalUnit_stop() {
 		fi
 		;;
 	lio-t)
-		ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns delete ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
+		# "targetcli delete" will fail if the LUN is already
+		# gone. Log a warning and still push ahead.
+		ocf_run -warn targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns delete ${OCF_RESKEY_lun}
 		if [ -n "${OCF_RESKEY_allowed_initiators}" ]; then
 			for initiator in ${OCF_RESKEY_allowed_initiators}; do
 				if targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls/${initiator} status | grep "Mapped LUNs: 0" >/dev/null ; then
-					ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls/ delete ${initiator}
+					ocf_run -warn targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls/ delete ${initiator}
 				fi
 			done
 		fi
 
+		# If we've proceeded down to here and we're unable to
+		# delete the backstore, then something is seriously
+		# wrong and we need to fail the stop operation
+		# (potentially causing fencing)
 		ocf_run targetcli /backstores/block delete ${OCF_RESOURCE_INSTANCE} || exit $OCF_ERR_GENERIC
 		;;
 	esac

--- a/heartbeat/iSCSILogicalUnit
+++ b/heartbeat/iSCSILogicalUnit
@@ -486,6 +486,11 @@ iSCSILogicalUnit_monitor() {
 	lio-t)
 		configfs_path="/sys/kernel/config/target/iscsi/${OCF_RESKEY_target_iqn}/tpgt_1/lun/lun_${OCF_RESKEY_lun}/*/udev_path"
 		[ -e ${configfs_path} ] && [ `cat ${configfs_path}` = "${OCF_RESKEY_path}" ] && return $OCF_SUCCESS
+
+		# if we aren't activated, is a block device still left over?
+		block_configfs_path="/sys/kernel/config/target/core/iblock_*/${OCF_RESOURCE_INSTANCE}/udev_path"
+		[ -e ${block_configfs_path} ] && ocf_log warn "existing block without an active lun: ${block_configfs_path}"
+		[ -e ${block_configfs_path} ] && return $OCF_ERR_GENERIC
 		;;
 	esac
 

--- a/heartbeat/iSCSILogicalUnit
+++ b/heartbeat/iSCSILogicalUnit
@@ -446,6 +446,9 @@ iSCSILogicalUnit_stop() {
 }
 
 iSCSILogicalUnit_monitor() {
+	# If our backing device (or file) doesn't even exist, we're not running
+	[ -e ${OCF_RESKEY_path} ] || return $OCF_NOT_RUNNING
+
 	case $OCF_RESKEY_implementation in
 	iet)
 		# Figure out and set the target ID


### PR DESCRIPTION
This PR contains three improvements to `iSCSILogicalUnit`. One is generic, the other two are specific to the `lio-t` implementation.

- 1b3ac8f extends behavior previously present just for `lio` to `lio-t`, in that it checks for existence of the backing store ConfigFS entry in stop, as opposed to just that for the iSCSI LUN. Fixes #640.
- 7e051ab is being more persistent on stop. `targetcli` will fail when attempting to delete a LUN that has already been deleted; previously we would bail out then and there letting the backing store entries linger (and keeping underlying block devices busy). Fixes #642.
- aae6d1b is generic and checks the existence of the underlying block device on monitor. If the backing device is not there, we can safely assume that the LU is not exported. Fixes #641.

Issue #631 is related and is pending a merge.

@davidvossel, I believe you wrote the original `lio-t` implementation — would you mind taking a look? 