### PR TITLE
Resource agent :Heartbeat :Raid1: fix RA cannot  manage include of start and stop Raid1 service.

### DIFF
--- a/heartbeat/Raid1
+++ b/heartbeat/Raid1
@@ -360,6 +360,7 @@ raid1_monitor_one() {
 	# check if the md device exists first
 	# but not if we are in the stop operation
 	# device existence is important only for the running arrays
+	echo $mddev | grep -q -o "/dev/" || mddev="/dev/$mddev"
 	if [ "$__OCF_ACTION" != "stop" -a ! -b $mddev ]; then
 		ocf_log info "$mddev is not a block device"
 		return $OCF_NOT_RUNNING


### PR DESCRIPTION
Resource agent : Heartbeat : Raid1
redefine $mddev in function raid1_monitor_one and fix RA cannot  manage Raid1. The mddev comes directly from the configuration file (OCF_RESKEY_raidconf, typically /etc/mdadm.conf) from the ARRAY stanza. The mdadm.conf man page says: If the name does not  start  with  a  slash  ('/'),  it  is  treated as being in /dev/md/.  This patch adds the "/dev" prefix instead.