### PR TITLE
Low: pgsql: fix grep failure when using pacemaker 1.1.12

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -979,7 +979,7 @@ pgsql_replication_monitor() {
 
     # I can't get master node name from $OCF_RESKEY_CRM_meta_notify_master_uname on monitor,
     # so I will get master node name using crm_mon -n
-    print_crm_mon | tr -d "\t" | tr -d " " | grep -q "^${RESOURCE_NAME}[(:].*[):]Master"
+    print_crm_mon | tr -d "\t" | tr -d " " | grep -q "^${RESOURCE_NAME}[(:].*[):]\(FAILED\|ORPHANED\)*Master"
     if [ $? -ne 0 ] ; then
         # If I am Slave and Master is not exist
         ocf_log info "Master does not exist."


### PR DESCRIPTION
The keywords "FAILED" or "ORPHANED" might be displayed in previous position of the role.
So, I add that keywords to grep pattern.