### PR TITLE
pgsql: Fix return code override in pgsql_real_start()

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -613,8 +613,7 @@ pgsql_real_start() {
     # creating slot on the slave node is in preparation for failover.
     if use_replication_slot; then
         create_replication_slot
-        rc=$?
-        if [ $rc -eq $OCF_ERR_GENERIC ]; then
+        if [ $? -eq $OCF_ERR_GENERIC ]; then
             ocf_exit_reason "PostgreSQL can't create replication_slot."
             return $OCF_ERR_GENERIC
         fi


### PR DESCRIPTION
Commit d67c0ae (pgsql: Support replication slots) overrides return code of pgsql_real_monitor() in pgsql_real_start() function when replication_slot_name is defined.
So pgsql_real_start() never returns $OCF_RUNNING_MASTER and pgsql_promote() failed with error "Can't start PostgreSQL as primary on promote." on cluster startup.
