### PR TITLE
Medium: docker: Correction of the mistake of the variable name.

### DIFF
--- a/heartbeat/docker
+++ b/heartbeat/docker
@@ -350,16 +350,16 @@ docker_stop()
 image_exists()
 {
 	# assume that OCF_RESKEY_name have been validated
-	local IMAGE_NAME="$(echo ${OCF_RESKEY_name} | awk -F':' '{print $1}')"
+	local IMAGE_NAME="$(echo ${OCF_RESKEY_image} | awk -F':' '{print $1}')"
 
 	# if no tag was specified, use default "latest"
 	local COLON_FOUND=0
 	local IMAGE_TAG="latest"
 
-	COLON_FOUND="$(echo "${OCF_RESKEY_name}" | grep -o ':' | grep -c .)"
+	COLON_FOUND="$(echo "${OCF_RESKEY_image}" | grep -o ':' | grep -c .)"
 
 	if [ ${COLON_FOUND} -ne 0 ]; then
-		IMAGE_TAG="$(echo ${OCF_RESKEY_name} | awk -F':' '{print $NF}')"
+		IMAGE_TAG="$(echo ${OCF_RESKEY_image} | awk -F':' '{print $NF}')"
 	fi
 
 	# IMAGE_NAME might be following formats:


### PR DESCRIPTION
I know that a correction of docker RA still remains.

https://github.com/ClusterLabs/resource-agents/pull/649
https://github.com/ClusterLabs/resource-agents/pull/651

However, handling of the variable of next commit is like the mistake on
latest docker RA.
https://github.com/ClusterLabs/resource-agents/commit/5a6a77f963d90d818ca556104790a7e7fc9d84fa

But I do not know a lot about docker RA, this correction may be wrong.

Best Regards,
Hideo Yamauchi.