### PR TITLE
findif.sh: Add + and - broadcast arguments (bsc#940931) (#656)

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -169,8 +169,10 @@ routing table.
 
 <parameter name="broadcast">
 <longdesc lang="en">
-Broadcast address associated with the IP. If left empty, the script will
-determine this from the netmask.
+Broadcast address associated with the IP. It is possible to use the
+special symbols '+' and '-' instead of the broadcast address. In this
+case, the broadcast address is derived by setting/resetting the host
+bits of the interface prefix.
 </longdesc>
 <shortdesc lang="en">Broadcast address</shortdesc>
 <content type="string" default=""/>

--- a/heartbeat/findif.sh
+++ b/heartbeat/findif.sh
@@ -182,8 +182,10 @@ findif_check_params()
     if [ -n "$brdcast" ] ; then
       ipcheck_ipv4 $brdcast
       if [ $? = 1 ] ; then
-        ocf_log err "Invalid broadcast address [$brdcast]."
-        return $OCF_ERR_CONFIGURED
+        if [ "$brdcast" != "+" -a "$brdcast" != "-" ]; then
+          ocf_log err "Invalid broadcast address [$brdcast]."
+          return $OCF_ERR_CONFIGURED
+        fi
       fi
     fi
   fi


### PR DESCRIPTION
Remove inaccurate statement about not passing a broadcast argument, and add description of `+` and `-` arguments for broadcast address.

These are passed to `ip address` to calculate the broadcast address based on the prefix.