### PR TITLE
galera: add support for MYSQL_HOST and MYSQL_PORT from clustercheck

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -704,6 +704,18 @@ if [ -n "${OCF_RESKEY_check_passwd}" ]; then
     MYSQL_OPTIONS_CHECK="$MYSQL_OPTIONS_CHECK --password=${OCF_RESKEY_check_passwd}"
 fi
 
+# This value is automatically sourced from /etc/sysconfig/checkcluster if available
+if [ -n "${MYSQL_HOST}" ]; then
+    MYSQL_OPTIONS_CHECK="$MYSQL_OPTIONS_CHECK -h ${MYSQL_HOST}"
+fi
+
+# This value is automatically sourced from /etc/sysconfig/checkcluster if available
+if [ -n "${MYSQL_PORT}" ]; then
+    MYSQL_OPTIONS_CHECK="$MYSQL_OPTIONS_CHECK -P ${MYSQL_PORT}"
+fi
+
+
+
 # What kind of method was invoked?
 case "$1" in
   start)    galera_start;;


### PR DESCRIPTION
The MYSQL_HOST and MYSQL_PORT settings are part of /etc/sysconfig/clustercheck and are interpreted by the /bin/clustercheck script; this PR ensures that they are also interpreted by the galera resource agent.

The rationale for these settings, even though right now we connect to MySQL/MariaDB using a locak socket connection, is that when using MariaDB-Galera, we have the option to use the [extra_port](https://mariadb.com/kb/en/mariadb/server-system-variables/#extra_port) option, which specifies an alternate listening port for MariaDB with its own max connections limit set via [extra_max_connections](https://mariadb.com/kb/en/mariadb/server-system-variables/#extra_max_connections).  

The primary rationale for these settings is so that the MariaDB server is able to report that it's "up" as a resource even if all current connections specified by max_connections is taken up, or more crucially if using the [mariadb threadpool](https://mariadb.com/kb/en/mariadb/thread-pool-in-mariadb/#best-of-both-worlds-running-with-pool-of-threads-and-with-one-thread-per-connection) which will cause queries to block while other queries are running; easily long enough for Pacemaker to assume the node is unavailable.   Because Pacemaker shuts the node down when detected as "unavailable", in the case of both hitting the max_connections limit as well as when using the threadpool with a fully saturated connection set (which can still be well under max_connections), using this feature is critical so that the normal work of the database isn't interpreted as a shutdown situation.   The former case has been observed on customer deployments and the latter in my own testing with the MariaDB threadpool.
