### PR TITLE
Medium: SAPDatabase: Fix process detection if DIR_EXECUTABLE is set

### DIFF
--- a/heartbeat/sapdb.sh
+++ b/heartbeat/sapdb.sh
@@ -44,11 +44,11 @@ background_check_saphostexec() {
 #                       misbehavior
 #
 cleanup_saphostexec() {
-  pkill -9 -f "$SAPHOSTEXEC"
-  pkill -9 -f "$SAPHOSTSRV"
-  oscolpid=`pgrep -f "$SAPHOSTOSCOL"`       # we check saposcol pid, because it
-                                            # might not run under control of
-					    # saphostexec
+  pkill -9 -f saphostexec
+  pkill -9 -f sapstartsrv
+  oscolpid=`pgrep -f saposcol`       # we check saposcol pid, because it
+                                     # might not run under control of
+                                     # saphostexec
 
   # cleanup saposcol shared memory, otherwise it will not start again
   if [ -n "$oscolpid" ];then
@@ -70,7 +70,7 @@ cleanup_saphostexec() {
 #
 check_saphostexec() {
   chkrc=$OCF_SUCCESS
-  running=`pgrep -f "$SAPHOSTEXEC" | wc -l`
+  running=`pgrep -f saphostexec | wc -l`
 
   if [ $running -gt 0 ]; then
     if background_check_saphostexec; then
@@ -88,7 +88,7 @@ check_saphostexec() {
     
     # now make sure the daemon has been started and is able to respond
     srvrc=1
-    while [ $srvrc -ne 0 -a `pgrep -f "$SAPHOSTEXEC" | wc -l` -gt 0 ]
+    while [ $srvrc -ne 0 -a `pgrep -f saphostexec | wc -l` -gt 0 ]
     do
       sleep 1
       background_check_saphostexec


### PR DESCRIPTION
(bsc#947243)

SAPDatabase uses pgrep and pkill to discover running SAP processes,
but if those processes were not started with the same absolute path
to the executable, pgrep/pkill won't match if the absolute path is
used when searching.

Since DIR_EXECUTABLE only ever changes the path and not the executable
name, it should be safe to use the executable name only and not the
absolute path when calling pgrep/pkill.