### PR TITLE
galera: start joining nodes during 'monitor' to allow long-running SST

### DIFF
--- a/heartbeat/README.galera
+++ b/heartbeat/README.galera
@@ -1,0 +1,132 @@
+Notes regarding the Galera resource agent
+---
+
+In the resource agent, the action of bootstrapping a Galera cluster is
+implemented into a series of small steps, by using:
+
+  * Two CIB attributes `last-committed` and `bootstrap` to elect a
+    bootstrap node that will restart the cluster.
+
+  * One CIB attribute `sync-needed` that will identify that joining
+    nodes are in the process of synchronizing their local database
+    via SST.
+
+  * A Master/Slave pacemaker resource which helps splitting the boot
+    into steps, up to a point where a galera node is available.
+
+  * the recurring monitor action to coordinate switch from one
+    state to another.
+
+How boot works
+====
+
+There are two things to know to understand how the resource agent
+restart a Galera cluster.
+
+### Bootstrap the cluster with the right node
+
+When synced, the nodes of a galera clusters have in common a last seqno,
+which identifies the last transaction considered successful by a
+majority of nodes in the cluster (think quorum).
+
+To restart a cluster, the resource agent must ensure that it will
+bootstrap the cluster from an node which is up-to-date, i.e which has
+the highest seqno of all nodes.
+
+As a result, if the resource agent cannot retrieve the seqno on all
+nodes, it won't be able to safely identify a bootstrap node, and
+will simply refuse to start the galera cluster.
+
+### synchronizing nodes can be a long operation
+
+Starting a bootstrap node is relatively fast, so it's performed
+during the "promote" operation, which is a one-off, time-bounded
+operation.
+
+Subsequent nodes will need to synchronize via SST, which consists
+in "pushing" an entire Galera DB from one node to another.
+
+There is no perfect time-out, as time spent during synchronization
+depends on the size of the DB. Thus, joiner nodes are started during
+the "monitor" operation, which is a recurring operation that can
+better track the progress of the SST.
+
+
+State flow
+====
+
+General idea for starting Galera:
+
+  * Before starting the Galera cluster each node needs to go in Slave
+    state so that the agent records its last seqno into the CIB.
+    __ This uses attribute last-committed __
+
+  * When all node went in Slave, the agent can safely determine the
+    last seqno and elect a bootstrap node (`detect_first_master()`).
+    __ This uses attribute bootstrap __
+
+  * The agent then sets the score of the elected bootstrap node to
+    Master so that pacemaker promote it and start the first Galera
+    server.
+
+  * Once the first Master is running, the agent can start joiner
+    nodes during the "monitor" operation, and starts monitoring
+    their SST sync.
+    __ This uses attribute sync-needed __
+
+  * Only when SST is over on joiner nodes, the agent promotes them
+    to Master. At this point, the entire Galera cluster is up.
+
+
+Attribute usage and liveness
+====
+
+Here is how attributes are created on a per-node basis. If you
+modify the resource agent make sure those properties still hold.
+
+### last-committed
+
+It is just a temporary hint for the resource agent to help
+elect a bootstrap node. Once the bootstrap attribute is set on one
+of the nodes, we can get rid of last-committed.
+
+ - Used   : during Slave state to compare seqno
+ - Created: before entering Slave state:
+              . at startup in `galera_start()`
+              . or when a Galera node is stopped in `galera_demote()`
+ - Deleted: just before node starts in `galera_start_local_node()`;
+            cleaned-up during `galera_demote()` and `galera_stop()`
+
+We delete last-committed before starting Galera, to avoid race
+conditions that could arise due to discrepancies between the CIB and
+Galera.
+
+### bootstrap
+
+Attribute set on the node that is elected to bootstrap Galera.
+
+- Used   : during promotion in `galera_start_local_node()`
+- Created: at startup once all nodes have `last-committed`;
+           or during monitor if all nodes have failed
+- Deleted: in `galera_start_local_node()`, just after the bootstrap
+           node started and is ready;
+           cleaned-up during `galera_demote()` and `galera_stop()`
+
+There cannot be more than one bootstrap node at any time, otherwise
+the Galera cluster would stop replicating properly.
+
+### sync-needed
+
+While this attribute is set on a node, the Galera node is in JOIN
+state, i.e. SST is in progress and the node cannot serve queries.
+
+The resource agent relies on the underlying SST method to monitor
+the progress of the SST. For instance, with `wsrep_sst_rsync`,
+timeout would be reported by rsync, the Galera node would go in
+Non-primary state, which would make `galera_monitor()` fail.
+
+- Used   : during recurring slave monitor in `check_sync_status()`
+- Created: in `galera_start_local_node()`, just after the joiner
+           node started and entered the Galera cluster
+- Deleted: during recurring slave monitor in `check_sync_status()`
+           as soon as the Galera code reports to be SYNC-ed.

--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -32,7 +32,7 @@
 # Slave vs Master role:
 #
 # During the 'Slave' role, galera instances are in read-only mode and
-# will not attempt to connect to the cluster. This role exists only as
+# will not attempt to connect to the cluster. This role exists as
 # a means to determine which galera instance is the most up-to-date. The
 # most up-to-date node will be used to bootstrap a galera cluster that
 # has no current members.
@@ -40,9 +40,12 @@
 # The galera instances will only begin to be promoted to the Master role
 # once all the nodes in the 'wsrep_cluster_address' connection address
 # have entered read-only mode. At that point the node containing the
-# database that is most current will be promoted to Master. Once the first
-# Master instance bootstraps the galera cluster, the other nodes will be
-# promoted to Master as well.
+# database that is most current will be promoted to Master.
+#
+# Once the first Master instance bootstraps the galera cluster, the
+# other nodes will join the cluster and start synchronizing via SST.
+# They will stay in Slave role as long as the SST is running. Their
+# promotion to Master will happen once synchronization is finished.
 #
 # Example: Create a galera cluster using nodes rhel7-node1 rhel7-node2 rhel7-node3
 #
@@ -309,6 +312,43 @@ wait_for_sync()
     ocf_log info "Database synced."
 }
 
+set_sync_needed()
+{
+    ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-sync-needed" -v "true"
+}
+
+clear_sync_needed()
+{
+    ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-sync-needed" -D
+}
+
+check_sync_needed()
+{
+    ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-sync-needed" -Q 2>/dev/null
+}
+
+check_sync_status()
+{
+    local state=$(get_status_variable "wsrep_local_state")
+    local ready=$(get_status_variable "wsrep_ready")
+
+    if [ -z "$state" -o -z "$ready" ]; then
+        ocf_exit_reason "Unable to retrieve state transfer status, verify check_user '$OCF_RESKEY_check_user' has permissions to view status"
+        return $OCF_ERR_GENERIC
+    fi
+
+    if [ "$state" == "4" -a "$ready" == "ON" ]; then
+        ocf_log info "local node synced with the cluster"
+        # when sync is finished, we are ready to switch to Master
+        clear_sync_needed
+        set_master_score
+        return $OCF_SUCCESS
+    else
+        ocf_log info "local node syncing"
+        return $OCF_SUCCESS
+    fi
+}
+
 is_primary()
 {
     cluster_status=$(get_status_variable "wsrep_cluster_status")
@@ -376,15 +416,6 @@ set_master_score()
     fi
 }
 
-promote_everyone()
-{
-
-    for node in $(echo "$OCF_RESKEY_wsrep_cluster_address" | sed 's/gcomm:\/\///g' | tr -d ' ' | tr -s ',' ' '); do
-
-        set_master_score $node
-    done
-}
-
 greater_than_equal_long()
 {
     # there are values we need to compare in this script
@@ -430,42 +461,31 @@ detect_first_master()
     set_bootstrap_node $best_node
 }
 
-# For galera, promote is really start
-galera_promote()
+galera_start_local_node()
 {
     local rc
     local extra_opts
     local bootstrap
+
+    bootstrap=$(is_bootstrap)
     
     master_exists
     if [ $? -eq 0 ]; then
         # join without bootstrapping
+        ocf_log info "Node <${NODENAME}> is joining the cluster"
         extra_opts="--wsrep-cluster-address=${OCF_RESKEY_wsrep_cluster_address}"
+    elif ocf_is_true $bootstrap; then
+        ocf_log info "Node <${NODENAME}> is bootstrapping the cluster"
+        extra_opts="--wsrep-cluster-address=gcomm://"
     else
-        bootstrap=$(is_bootstrap)
-
-        if ocf_is_true $bootstrap; then
-            ocf_log info "Node <${NODENAME}> is bootstrapping the cluster"
-            extra_opts="--wsrep-cluster-address=gcomm://"
-        else
-            ocf_exit_reason "Failure, Attempted to promote Master instance of $OCF_RESOURCE_INSTANCE before bootstrap node has been detected."
-            clear_last_commit
-            return $OCF_ERR_GENERIC
-        fi
-    fi
-
-    galera_monitor
-    if [ $? -eq $OCF_RUNNING_MASTER ]; then
-        if ocf_is_true $bootstrap; then
-            promote_everyone
-            clear_bootstrap_node
-            ocf_log info "boostrap node already up, promoting the rest of the galera instances."
-        fi
+        ocf_exit_reason "Failure, Attempted to join cluster of $OCF_RESOURCE_INSTANCE before master node has been detected."
         clear_last_commit
-        return $OCF_SUCCESS
+        return $OCF_ERR_GENERIC
     fi
 
-    # last commit is no longer relevant once promoted
+    # clear last_commit before we start galera to make sure there
+    # won't be discrepency between the cib and galera if this node
+    # processes a few transactions and fails before we detect it
     clear_last_commit
 
     mysql_common_prepare_dirs
@@ -475,9 +495,10 @@ galera_promote()
         return $rc
     fi
 
-    galera_monitor
+    mysql_common_status info
     rc=$?
-    if [ $rc != $OCF_SUCCESS -a $rc != $OCF_RUNNING_MASTER ]; then
+
+    if [ $rc != $OCF_SUCCESS ]; then
         ocf_exit_reason "Failed initial monitor action"
         return $rc
     fi
@@ -495,17 +516,43 @@ galera_promote()
     fi
 
     if ocf_is_true $bootstrap; then
-        promote_everyone
         clear_bootstrap_node
-        ocf_log info "Bootstrap complete, promoting the rest of the galera instances."
     else
-        # if this is not the bootstrap node, make sure this instance
-        # syncs with the rest of the cluster before promotion returns.
-        wait_for_sync
+        set_sync_needed
     fi
 
     ocf_log info "Galera started"
     return $OCF_SUCCESS
+}
+
+
+galera_promote()
+{
+    local rc
+    local extra_opts
+    local bootstrap
+
+    master_exists
+    if [ $? -ne 0 ]; then
+        # promoting the first master will bootstrap the cluster
+        if is_bootstrap; then
+            galera_start_local_node
+            rc=$?
+            return $rc
+        else
+            ocf_exit_reason "Attempted to start the cluster without being a bootstrap node."
+            return $OCF_ERR_GENERIC
+        fi
+    else
+        # promoting other masters only performs sanity checks
+        # as the joining nodes were started during the "monitor" op
+        if ! check_sync_needed; then
+            return $OCF_SUCCESS
+        else
+            ocf_exit_reason "Attempted to promote local node while sync was still needed."
+            return $OCF_ERR_GENERIC
+        fi
+    fi
 }
 
 galera_demote()
@@ -520,6 +567,7 @@ galera_demote()
     # if this node was previously a bootstrap node, that is no longer the case.
     clear_bootstrap_node
     clear_last_commit
+    clear_sync_needed
 
     # record last commit by "starting" galera. start is just detection of the last sequence number
     galera_start
@@ -535,8 +583,8 @@ galera_start()
         return $OCF_ERR_CONFIGURED
     fi
 
-    galera_monitor
-    if [ $? -eq $OCF_RUNNING_MASTER ]; then
+    mysql_common_status info
+    if [ $? -ne $OCF_NOT_RUNNING ]; then
         ocf_exit_reason "master galera instance started outside of the cluster's control"
         return $OCF_ERR_GENERIC
     fi
@@ -574,8 +622,7 @@ galera_start()
 
     master_exists
     if [ $? -eq 0 ]; then
-        ocf_log info "Master instances are already up, setting master score so this instance will join galera cluster."
-        set_master_score $NODENAME
+        ocf_log info "Master instances are already up, local node will join in when started"
     else
         clear_master_score
         detect_first_master
@@ -598,18 +645,24 @@ galera_monitor()
     rc=$?
 
     if [ $rc -eq $OCF_NOT_RUNNING ]; then
-        last_commit=$(get_last_commit $node)
-        if [ -n "$last_commit" ]; then
-            # if last commit is set, this instance is considered started in slave mode
+        last_commit=$(get_last_commit $NODENAME)
+        if [ -n "$last_commit" ];then
             rc=$OCF_SUCCESS
+
+            if ocf_is_probe; then
+                # prevent state change during probe
+                return $rc
+            fi
+
             master_exists
             if [ $? -ne 0 ]; then
                 detect_first_master
             else
-                # a master instance exists and is healthy, promote this
-                # local read only instance
-                # so it can join the master galera cluster.
-                set_master_score
+                # a master instance exists and is healthy.
+                # start this node and mark it as "pending sync"
+                ocf_log info "cluster is running. start local node to join in"
+                galera_start_local_node
+                rc=$?
             fi
         fi
         return $rc
@@ -627,13 +680,26 @@ galera_monitor()
 
     is_primary
     if [ $? -eq 0 ]; then
+        check_sync_needed
+        if [ $? -eq 0 ]; then
+            # galera running and sync is needed: slave state
+            if ocf_is_probe; then
+                # prevent state change during probe
+                rc=$OCF_SUCCESS
+            else
+                check_sync_status
+                rc=$?
+            fi
+        else
+            # galera running, no need to sync: master state and everything's clear
+            rc=$OCF_RUNNING_MASTER
 
-        if ocf_is_probe; then
-            # restore master score during probe
-            # if we detect this is a master instance
-            set_master_score
+            if ocf_is_probe; then
+                # restore master score during probe
+                # if we detect this is a master instance
+                set_master_score
+            fi
         fi
-        rc=$OCF_RUNNING_MASTER
     else
         ocf_exit_reason "local node <${NODENAME}> is started, but not in primary mode. Unknown state."
         rc=$OCF_ERR_GENERIC
@@ -647,11 +713,12 @@ galera_stop()
     local rc
     # make sure the process is stopped
     mysql_common_stop
-    rc=$1
+    rc=$?
 
     clear_last_commit
     clear_master_score
     clear_bootstrap_node
+    clear_sync_needed
     return $rc
 }
 


### PR DESCRIPTION
When a Galera cluster is starting, the joining nodes which require a SST can take a long time to transfer the required data. This can cause the resource agent to fail the promotion to Master due to timeout.

This pull request changes the way a cluster is started:
  . The bootstrap galera server is still started and switched to Master during the promote 'op' as usual.
  . The remaining galera servers are started by the monitor 'op'.
  . The monitor 'op' tracks the progress of the SST and triggers the promotion to Master only after the SST is finished.

Squashed commit of the following:

commit d34ea174b9abdca5101fea65d0ae594f9ec45d3c
Author: Damien Ciabrini <dciabrin@redhat.com>
Date:   Mon Oct 5 12:20:45 2015 +0200

    galera: document the updated boot process

commit dba7120896a53b6009aa9f91a2aa203c82444ce3
Author: Damien Ciabrini <dciabrin@redhat.com>
Date:   Mon Oct 5 11:53:11 2015 +0200

    galera: clean up debug and unused code

commit da4c8b6849eae9c4ae789330795a13b3a24e02ad
Author: Damien Ciabrini <dciabrin@redhat.com>
Date:   Mon Oct 5 11:45:17 2015 +0200

    galera: fix promotion and associated checks

commit c01d5824f601dbce4045a8259cde6c4517b24e20
Author: Damien Ciabrini <dciabrin@redhat.com>
Date:   Wed Sep 23 09:58:29 2015 +0200

    galera: sanity checks during promote operation

commit 04d8a36dee09ea96c7478f0205b80cdf704af18a
Author: Damien Ciabrini <dciabrin@redhat.com>
Date:   Wed Sep 23 09:53:49 2015 +0200

    galera: fix return code in galera_stop()

commit 22220bda1728b5ce54643650238d0a99fe997d87
Author: Damien Ciabrini <dciabrin@redhat.com>
Date:   Wed Sep 23 09:42:49 2015 +0200

    galera: do not promote joiner nodes in start operation

commit 60342c56ce3843f915f830104332d56833d764c6
Author: Damien Ciabrini <dciabrin@redhat.com>
Date:   Mon Sep 21 12:13:28 2015 +0200

    galera: prevent state change during probe

commit 1fe6415f7ec4c7b54d12696f0defc2cab2324bcf
Author: Damien Ciabrini <dciabrin@redhat.com>
Date:   Mon Sep 21 12:02:44 2015 +0200

    galera: improved monitoring of the syncing progress

commit fdad75f97cea2bb3a513eb61ece5f31ce2344fa8
Author: Damien Ciabrini <dciabrin@redhat.com>
Date:   Fri Sep 18 01:00:20 2015 +0200

    galera: code style fixes

commit 25cdde0342992fcfdef59b58083da4692ce31707
Author: Damien Ciabrini <dciabrin@redhat.com>
Date:   Wed Sep 16 19:12:24 2015 +0200

    galera: multi-stage cluster startup to better track long-running IST/SST