### PR TITLE
Fixed attempts to create iqn multiple times for every portal.

### DIFF
--- a/heartbeat/iSCSITarget
+++ b/heartbeat/iSCSITarget
@@ -325,10 +325,10 @@ iSCSITarget_start() {
 		# number 1. In lio, creating a network portal
 		# automatically creates the corresponding target if it
 		# doesn't already exist.
+		ocf_run targetcli /iscsi set global auto_add_default_portal=false || exit $OCF_ERR_GENERIC
+		ocf_run targetcli /iscsi create ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
 		for portal in ${OCF_RESKEY_portals}; do
 			if [ $portal != ${OCF_RESKEY_portals_default} ] ; then
-				ocf_run targetcli /iscsi set global auto_add_default_portal=false || exit $OCF_ERR_GENERIC
-				ocf_run targetcli /iscsi create ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
 				IFS=':' read -a sep_portal <<< "$portal"
 				ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/portals create "${sep_portal[0]}" "${sep_portal[1]}" || exit $OCF_ERR_GENERIC
 			else


### PR DESCRIPTION
When multiple portals are provided using "portals=" switch
the old code will attempt to create IQN for every portal. This is not
correct. There should be just one IQN and multiple portals to it.
targetcli will return error if attempting to create IQN that already exists.