### PR TITLE
When stop processing is carried out when mysql fell while monitor does not detect an error, the cluster fails in a stop of mysql.

### DIFF
--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -159,8 +159,10 @@ mysql_common_status() {
     if [ $? -eq 0 ]; then
         return $OCF_SUCCESS;
     else
-        ocf_log $loglevel "MySQL not running: removing old PID file"
-        rm -f $OCF_RESKEY_pid
+        if [ -e $OCF_RESKEY_pid ]; then
+            ocf_log $loglevel "MySQL not running: removing old PID file"
+            rm -f $OCF_RESKEY_pid
+        fi
         return $OCF_NOT_RUNNING;
     fi
 }

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -130,6 +130,17 @@ mysql_common_validate()
     return $OCF_SUCCESS
 }
 
+mysql_common_check_pid() {
+    local pid=$1
+
+    if [ -d /proc -a -d /proc/1 ]; then
+        [ "u$pid" != "u" -a -d /proc/$pid ]
+    else
+        kill -s 0 $pid >/dev/null 2>&1
+    fi
+    return $?
+}
+
 mysql_common_status() {
     local loglevel=$1
     local pid=$2
@@ -141,11 +152,9 @@ mysql_common_status() {
 
         pid=`cat $OCF_RESKEY_pid`;
     fi
-    if [ -d /proc -a -d /proc/1 ]; then
-        [ "u$pid" != "u" -a -d /proc/$pid ]
-    else
-        kill -s 0 $pid >/dev/null 2>&1
-    fi
+
+    mysql_common_check_pid $pid
+
 
     if [ $? -eq 0 ]; then
         return $OCF_SUCCESS;

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -258,6 +258,14 @@ mysql_common_stop()
     fi
 
     pid=`cat $OCF_RESKEY_pid 2> /dev/null `
+
+    mysql_common_check_pid $pid
+    if [ $? -ne 0 ]; then
+        rm -f $OCF_RESKEY_pid
+        ocf_log info "MySQL is already stopped"
+        return $OCF_SUCCESS;
+    fi
+
     /bin/kill $pid > /dev/null
     rc=$?
     if [ $rc != 0 ]; then


### PR DESCRIPTION
Hi All,

I send a patch to improve the problem of the stop that I reported by an email
 * http://clusterlabs.org/pipermail/users/2015-November/001773.html

The patch includes the next change.
 * Commonization of the function
 * Restraint of the output of the redundant deletion message of the PID file

Best Regards,
Hideo Yamauchi.
