### PR TITLE
IPaddr2: potential syntax error on if-then-else

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -800,7 +800,7 @@ ip_start() {
 		exit $OCF_SUCCESS
 	fi
 	
-	if [ -n "$IP_CIP" ] && [ $ip_status = "no" ] || [ $ip_status = "partial2" ]; then
+	if [ -n "$IP_CIP" ] && ([ $ip_status = "no" ] || [ $ip_status = "partial2" ]); then
 		$MODPROBE ip_conntrack
 		$IPTABLES -I INPUT -d $OCF_RESKEY_ip -i $NIC -j CLUSTERIP \
 				--new \


### PR DESCRIPTION
what we need here should be `A && (B || C)`

please refer to the result of following simple tests

before patch:
```
  true  && true  || true;  echo $?;  # return value: 0
  true  && true  || false; echo $?;  # return value: 0
  true  && false || true;  echo $?;  # return value: 0
  true  && false || false; echo $?;  # return value: 1
  false && true  || true;  echo $?;  # return value: 0
  false && true  || false; echo $?;  # return value: 1
  false && false || true;  echo $?;  # return value: 0
  false && false || false; echo $?;  # return value: 1
```
after patch:
```
  true  && (true  || true);  echo $? # return value: 0
  true  && (true  || false); echo $? # return value: 0
  true  && (false || true);  echo $? # return value: 0
  true  && (false || false); echo $? # return value: 1
  false && (true  || true);  echo $? # return value: 1
  false && (true  || false); echo $? # return value: 1
  false && (false || true);  echo $? # return value: 1
  false && (false || false); echo $? # return value: 1
```