### PR TITLE
High: mysql: fix grep failure on MySQL5.6 or higher when checking read_only variable

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -324,7 +324,7 @@ get_read_only() {
     local read_only_state
 
     read_only_state=`$MYSQL $MYSQL_OPTIONS_REPL \
-        -e "SHOW VARIABLES" | grep read_only | awk '{print $2}'`
+        -e "SHOW VARIABLES" | grep -w read_only | awk '{print $2}'`
 
     if [ "$read_only_state" = "ON" ]; then
         return 0


### PR DESCRIPTION
On MySQL 5.6 or higher, the "SHOW VARIABLES" command returns the multiple rows that contains the "read_only".(innodb_read_only, read_only and tx_read_only)
So, I add "-w" to grep option.