### PR TITLE
/var/lock/subsys is non-standard, check for it first

### DIFF
--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -570,7 +570,7 @@ locking_start()
 		ocf_log err "Failed to start rpc.statd"
 		return $ret
 	fi
-	touch /var/lock/subsys/nfslock
+	[ -d /var/lock/subsys ] && touch /var/lock/subsys/nfslock
 
 	return $ret
 }


### PR DESCRIPTION
/var/lock/subsys does not exist on debian/ubuntu. Primarily a RedHat-ism. Check for it first.