### PR TITLE
Low: mysql: tmpfile is leaking when set the OCF_CHECK_LEVEL to 10

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -347,6 +347,7 @@ is_slave() {
    
     get_slave_info
     rc=$?
+    rm -f $tmpfile
 
     if [ $rc -eq 0 ]; then
        # show slave status is not empty


### PR DESCRIPTION
The function get_slave_info() makes a tmpfile that named /var/run/resource-agents/check_slave.mysql.XXXXXX.
This tmpfile is removed by the function that called a get_slave_info().

However, The function is_slave() calls the get_slave_info() , but does not remove tmpfile.
When set the OCF_CHECK_LEVEL to 10, in the Slave node, the function is_slave() will be called from the mysql_monitor.
So, the number of the tmpfile continues increasing in every 10 seconds in the Slave node.