### PR TITLE
Medium: ocf_shellfuncs: suppress bash specific trace_ra log on dash

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -902,7 +902,9 @@ ocf_start_trace() {
 			return
 		ocf_trace_redirect_to_file "$__OCF_TRC_DEST"
 	fi
-	PS4='+ `date +"%T"`: ${FUNCNAME[0]:+${FUNCNAME[0]}:}${LINENO}: '
+	if [ -n "$BASH_VERSION" ]; then
+		PS4='+ `date +"%T"`: ${FUNCNAME[0]:+${FUNCNAME[0]}:}${LINENO}: '
+	fi
 	set -x
 	env=$( echo; printenv | sort )
 }


### PR DESCRIPTION
Fixes the issue: https://github.com/ClusterLabs/resource-agents/issues/734
