### PR TITLE
Low: ldirectord: Fix unset failcount error

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -2108,7 +2108,7 @@ sub add_real_server
 	my $new_rsrv;
 	my $rsrv;
 
-	$new_rsrv = {"server"=>$ip, "port"=>$port};
+	$new_rsrv = {"server"=>$ip, "port"=>$port, "failcount"=>0};
 
 	$flags =~ /(\w+)(.*)/ && ($1 eq "gate" || $1 eq "masq" || $1 eq "ipip")
 		or &config_error($line,	"forward method must be gate, masq or ipip");


### PR DESCRIPTION
This error was noticed in the logs:

Use of uninitialized value in numeric gt (>)

The uninitialized use comes from the "_service_up" function
which tries to read an uninitialized array element "failcount"
which get only written (set > 0) in the "_service_down" function.

This patch sets failcount to 0 in the constructor to avoid
triggering the error.