### PR TITLE
Add portal check to open_iscsi_get_session_id()

### DIFF
--- a/heartbeat/iscsi
+++ b/heartbeat/iscsi
@@ -268,14 +268,16 @@ open_iscsi_add() {
 }
 open_iscsi_get_session_id() {
 	local target="$1"
+	local portal="$2"
 	$iscsiadm -m session 2>/dev/null |
 		grep -E "$target($|[[:space:]])" |
+		grep -E "] $portal" |
 		awk '{print $2}' | tr -d '[]'
 }
 open_iscsi_remove() {
 	local target="$1"
 	local session_id
-	session_id=`open_iscsi_get_session_id "$target"`
+	session_id=`open_iscsi_get_session_id "$target" "$OCF_RESKEY_portal"`
 	if [ "$session_id" ]; then
 		$iscsiadm -m session -r $session_id -u
 	else
@@ -296,7 +298,7 @@ open_iscsi_monitor() {
 	local recov
 
 	recov=${2:-$OCF_RESKEY_try_recovery}
-	session_id=`open_iscsi_get_session_id "$target"`
+	session_id=`open_iscsi_get_session_id "$target" "$OCF_RESKEY_portal"`
 	prev_state=""
 	if [ -z "$session_id" ]; then
 		if $iscsiadm -m node -p $OCF_RESKEY_portal -T $target >/dev/null 2>&1; then


### PR DESCRIPTION
Based on issue "resource-agents/heartbeat/iscsi works incorrectly with multipath scheme #744"