### PR TITLE
v3.9.7 build failure

### DIFF
--- a/tools/ocft/Makefile.am
+++ b/tools/ocft/Makefile.am
@@ -17,7 +17,7 @@
 
 MAINTAINERCLEANFILES = Makefile.in
 
-EXTRA_DIST		= $(ocftcfgs_DATA) $(ocft_DATA)
+EXTRA_DIST		= $(ocftcfgs_DATA) $(ocft_DATA) $(ocft_SCRIPTS)
 
 sbin_SCRIPTS		= ocft
 


### PR DESCRIPTION
v3.9.7 fails to build the rpm by using the included configure scritps. Apparently runocft script is missing in the tarball which is introduced by #730.

Steps to reproduce:
```
[root@build-centos71 resource-agents (master)]# git checkout v3.9.7
[root@build-centos71 resource-agents ((v3.9.7))]# ./autogen.sh && ./configure && make rpm
(omit)
Making all in ocft
gmake[4]: Entering directory `/root/rpmbuild/devel/resource-agents/resource-agents-3.9.6.272-e697f/tools/ocft'
gmake[4]: *** No rule to make target `runocft', needed by `all-am'.  Stop.
gmake[4]: Leaving directory `/root/rpmbuild/devel/resource-agents/resource-agents-3.9.6.272-e697f/tools/ocft'
gmake[3]: *** [all-recursive] Error 1
(omit)
```
