### PR TITLE
ldirectord: Don't send Inaccessible real server e-mails in fork=yes mode

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -2718,6 +2718,18 @@ sub run_child
 	my $real = $$v{real};
 	my $virtual_id = get_virtual_id_str($v);
 	my $checkinterval = $$v{checkinterval} || $CHECKINTERVAL;
+
+	# delete any entries in EMAILSTATUS that don't belong to this child
+	my %myservices = ();
+	foreach my $r (@$real) {
+		my $virtual_str = &get_virtual($v);
+		my $id = $r->{server} . ":" . $r->{port} . " ($virtual_str)";
+		$myservices{$id} = 1;
+	}
+	foreach my $id (keys %EMAILSTATUS) {
+		delete $EMAILSTATUS{$id} unless defined $myservices{$id};
+	}
+
 	$0 = "ldirectord $virtual_id";
 	while (1) {
 		foreach my $r (@$real) {


### PR DESCRIPTION
When starting up, if a service is not listed in the ipvsadm table the parent process will mark it as 'down'. Each child process will then go through its own services and mark them as 'up'.

However, if there is more than one service defined, the services from the other children are still marked as 'down'.  In this case each child will repeatedly e-mail out 'Inaccessible real server' messages for services now managed by the other children.

To prevent this, we go through the e-mail status hash as a child starts up and remove any services that now belong to other children.