### PR TITLE
mysql-common.sh: stop: check status after SIGKILL

### DIFF
--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -300,9 +300,15 @@ mysql_common_stop()
         /bin/kill -KILL $pid > /dev/null
     fi
 
-    ocf_log info "MySQL stopped";
-    rm -f /var/lock/subsys/mysqld
-    rm -f $OCF_RESKEY_socket
-    return $OCF_SUCCESS
+    mysql_common_status info $pid
+    if [ $? = $OCF_SUCCESS ]; then
+      ocf_log err "SIGKILL left a running process. Nothing more we can do."
+      return $OCF_ERR_GENERIC
+    else
+      ocf_log info "MySQL stopped";
+      rm -f /var/lock/subsys/mysqld
+      rm -f $OCF_RESKEY_socket
+      return $OCF_SUCCESS
+    fi
 
 }


### PR DESCRIPTION
I faced a situation where mysqld did not stop within the configured timeout, so the agent used kill -KILL. Unfortunately, for unknown reasons, even this left a running mysqld process on the system which hugged the data files and made a restart of the database impossible on that node.

Imho, return an error and run into fencing would have been the correct thing to do. Here's the log:

stop timeout is 180s

Feb  9 22:16:58 nodename mysql[20114]: INFO: MySQL failed to stop after 175s using SIGTERM. Trying SIGKILL...
Feb  9 22:16:58 nodename mysql[20114]: INFO: MySQL stopped
Feb  9 22:16:58 nodename lrmd: [1636]: info: operation stop[244] on MysqlServer for client 6292: pid 20114 exited with return code 0
Feb  9 22:16:58 nodename crmd: [6292]: info: process_lrm_event: LRM operation MysqlServer_stop_0 (call=244, rc=0, cib-update=27098, confirmed=true) ok
Feb  9 22:16:58 nodename crmd: [6292]: notice: run_graph: ==== Transition 100400 (Complete=2, Pending=0, Fired=0, Skipped=4, Incomplete=0, Source=/var/lib/pengine/pe-input-454.bz2): Stopped 
Feb  9 22:16:58 nodename crmd: [6292]: notice: do_state_transition: State transition S_TRANSITION_ENGINE -> S_POLICY_ENGINE [ input=I_PE_CALC cause=C_FSA_INTERNAL origin=notify_crmd ]
Feb  9 22:16:58 nodename pengine: [1638]: notice: unpack_config: On loss of CCM Quorum: Ignore
Feb  9 22:16:58 nodename pengine: [1638]: notice: unpack_rsc_op: Operation monitor found resource drbd-db:0 active in master mode on nodename
Feb  9 22:16:58 nodename pengine: [1638]: notice: LogActions: Start   MysqlServer (nodename)
Feb  9 22:16:58 nodename crmd: [6292]: notice: do_state_transition: State transition S_POLICY_ENGINE -> S_TRANSITION_ENGINE [ input=I_PE_SUCCESS cause=C_IPC_MESSAGE origin=handle_response ]
Feb  9 22:16:58 nodename crmd: [6292]: info: do_te_invoke: Processing graph 100401 (ref=pe_calc-dc-1455052618-27145) derived from /var/lib/pengine/pe-input-455.bz2
Feb  9 22:16:58 nodename crmd: [6292]: info: te_rsc_command: Initiating action 58: start MysqlServer_start_0 on nodename (local)
Feb  9 22:16:58 nodename lrmd: [1636]: info: rsc:MysqlServer start[245] (pid 21051)
Feb  9 22:16:58 nodename mysql[21051]: INFO: MySQL already running

So the cluster found mysqld already running although it sent SIGKILL just before.

Feb  9 22:16:58 nodename lrmd: [1636]: info: operation start[245] on MysqlServer for client 6292: pid 21051 exited with return code 0
Feb  9 22:16:58 nodename pengine: [1638]: notice: process_pe_message: Transition 100401: PEngine Input stored in: /var/lib/pengine/pe-input-455.bz2
Feb  9 22:16:58 nodename crmd: [6292]: info: process_lrm_event: LRM operation MysqlServer_start_0 (call=245, rc=0, cib-update=27100, confirmed=true) ok
Feb  9 22:16:58 nodename crmd: [6292]: info: te_rsc_command: Initiating action 59: monitor MysqlServer_monitor_53000 on nodename (local)
Feb  9 22:16:58 nodename lrmd: [1636]: info: rsc:MysqlServer monitor[246] (pid 21085)
Feb  9 22:16:58 nodename mysql[21085]: INFO: MySQL monitor succeeded
Feb  9 22:16:58 nodename lrmd: [1636]: info: operation monitor[246] on MysqlServer for client 6292: pid 21085 exited with return code 0
Feb  9 22:16:58 nodename crmd: [6292]: info: process_lrm_event: LRM operation MysqlServer_monitor_53000 (call=246, rc=0, cib-update=27101, confirmed=false) ok
Feb  9 22:16:58 nodename crmd: [6292]: notice: run_graph: ==== Transition 100401 (Complete=4, Pending=0, Fired=0, Skipped=0, Incomplete=0, Source=/var/lib/pengine/pe-input-455.bz2): Complete
Feb  9 22:16:58 nodename crmd: [6292]: notice: do_state_transition: State transition S_TRANSITION_ENGINE -> S_IDLE [ input=I_TE_SUCCESS cause=C_FSA_INTERNAL origin=notify_crmd ]
Feb  9 22:17:01 nodename /USR/SBIN/CRON[21139]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)
Feb  9 22:17:01 nodename /USR/SBIN/CRON[21140]: (root) CMD (/usr/sbin/crm_mon -Arf1 > /tmp/crm_mon)
Feb  9 22:17:03 nodename mysqld_safe: Number of processes running now: 0
Feb  9 22:17:03 nodename mysqld_safe: mysqld restarted

Now mysqld's native shutdown is complete I guess.

Feb  9 22:17:03 nodename mysqld: 160209 22:17:03 [Warning] 'for replication startup options' is deprecated and will be removed in a future release. Please use ''CHANGE MASTER'' instead.
Feb  9 22:17:03 nodename mysqld: 160209 22:17:03 [Note] Plugin 'FEDERATED' is disabled.
Feb  9 22:17:03 nodename mysqld: InnoDB: The InnoDB memory heap is disabled
Feb  9 22:17:03 nodename mysqld: InnoDB: Mutexes and rw_locks use GCC atomic builtins
Feb  9 22:17:03 nodename mysqld: InnoDB: Compressed tables use zlib 1.2.3.4
Feb  9 22:17:03 nodename mysqld: 160209 22:17:03  InnoDB: Initializing buffer pool, size = 80.0G
Feb  9 22:17:07 nodename mysqld: 160209 22:17:07  InnoDB: Completed initialization of buffer pool
Feb  9 22:17:07 nodename mysqld: 160209 22:17:07  InnoDB: highest supported file format is Barracuda.
Feb  9 22:17:08 nodename mysqld: InnoDB: Log scan progressed past the checkpoint lsn 7167299504505
Feb  9 22:17:08 nodename mysqld: 160209 22:17:08  InnoDB: Database was not shut down normally!
Feb  9 22:17:08 nodename mysqld: InnoDB: Starting crash recovery.
Feb  9 22:17:08 nodename mysqld: InnoDB: Reading tablespace information from the .ibd files...
Feb  9 22:17:12 nodename mysqld: InnoDB: Restoring possible half-written data pages from the doublewrite
Feb  9 22:17:12 nodename mysqld: InnoDB: buffer...
Feb  9 22:17:13 nodename mysqld: InnoDB: Doing recovery: scanned up to log sequence number 7167304747008
Feb  9 22:17:13 nodename mysqld: InnoDB: Doing recovery: scanned up to log sequence number 7167309989888
Feb  9 22:17:13 nodename mysqld: InnoDB: Doing recovery: scanned up to log sequence number 7167315232768
Feb  9 22:17:13 nodename mysqld: InnoDB: Doing recovery: scanned up to log sequence number 7167320475648
Feb  9 22:17:14 nodename mysqld: InnoDB: Doing recovery: scanned up to log sequence number 7167325718528
Feb  9 22:17:14 nodename mysqld: InnoDB: Doing recovery: scanned up to log sequence number 7167330961408
Feb  9 22:17:14 nodename mysqld: InnoDB: Doing recovery: scanned up to log sequence number 7167336204288
Feb  9 22:17:14 nodename mysqld: InnoDB: Doing recovery: scanned up to log sequence number 7167341447168
Feb  9 22:17:14 nodename mysqld: InnoDB: Doing recovery: scanned up to log sequence number 7167346690048
Feb  9 22:17:14 nodename mysqld: InnoDB: Doing recovery: scanned up to log sequence number 7167347887285
Feb  9 22:17:14 nodename mysqld: 160209 22:17:14  InnoDB: Starting an apply batch of log records to the database...
Feb  9 22:17:36 nodename cib: [1634]: info: cib_stats: Processed 22 operations (2272.00us average, 0% utilization) in the last 10min
Feb  9 22:17:51 nodename mysql[21237]: ERROR: MySQL is not running
Feb  9 22:17:51 nodename crmd: [6292]: info: process_lrm_event: LRM operation MysqlServer_monitor_53000 (call=246, rc=7, cib-update=27102, confirmed=false) not running

This is the first monitor op coming around. And since mysql's internal recovery is still running, the cluster now finds out mysqld is not running and starts recovering from that error, which could have been prevented if the stop was checked correctly in the first place.