### PR TITLE
ldirectord: Correctly suppress startup e-mails when emailalertstatus=running

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -2662,24 +2662,8 @@ sub ld_main
 			check_signal();
 
 		} else {
-			my @real_checked;
-			foreach my $v (@VIRTUAL) {
-				my $real = $$v{real};
-				my $virtual_id = get_virtual_id_str($v);
+			_ld_main_check_all();
 
-				REAL: foreach my $r (@$real) {
-					my $real_id = get_real_id_str($r, $v);
-					check_signal();
-					foreach my $tmp_id (@real_checked) {
-						if($real_id eq $tmp_id) {
-							&ld_debug(3, "Already checked: real server=$real_id (virtual=$virtual_id)");
-							next REAL;
-						}
-					}
-					_check_real($v, $r);
-					push(@real_checked, $real_id);
-				}
-			}
 			check_signal();
 			if (!check_cfgfile()) {
 				sleep $CHECKINTERVAL;
@@ -2727,6 +2711,30 @@ sub run_child
 		$0 = "ldirectord $virtual_id";
 		sleep $checkinterval;
 		ld_emailalert_resend();
+	}
+}
+
+# run checks for everything
+sub _ld_main_check_all
+{
+	my @real_checked;
+
+	foreach my $v (@VIRTUAL) {
+		my $real = $$v{real};
+		my $virtual_id = get_virtual_id_str($v);
+
+		REAL: foreach my $r (@$real) {
+			my $real_id = get_real_id_str($r, $v);
+			check_signal();
+			foreach my $tmp_id (@real_checked) {
+				if($real_id eq $tmp_id) {
+					&ld_debug(3, "Already checked: real server=$real_id (virtual=$virtual_id)");
+					next REAL;
+				}
+			}
+			_check_real($v, $r);
+			push(@real_checked, $real_id);
+		}
 	}
 }
 

--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -2590,6 +2590,10 @@ sub ld_start
 		}
 		purge_virtual($nv, "start");
 	}
+
+	# initial check of all real servers while we are still starting up so
+	# any e-mail notifications sent out are in 'starting' daemon status.
+	_ld_main_check_all();
 }
 
 sub ld_cmd_children


### PR DESCRIPTION
When the daemon is starting up it sets DAEMON_STATUS to STARTING, aligns its internal tables with those of ipvsadm (in ld_start), then sets DAEMON_STATUS to RUNNING.

This means that any services which are down (which is usually the case when ldirectord is not running, unless cleanstop=no is set) will be marked as down in STARTING state.

Then when the main loop in ld_main is run, the services will all be detected as 'up', but as we are now in RUNNING state, so e-mails will be sent out. This isn't really a running state, though - we've only just started up.

To prevent this from happening, do a one off initial check of all real servers in the ld_start, which means that services will be detected as 'up' when in DAEMON_STATUS STARTING. From then on the ld_main (or the children in fork=yes mode) will continue to check as usual and send e-mails out if applicable in RUNNING state.

In the other case, where emailalertstatus=starting, similarly now the startup e-mails will be sent, whereas previously e-mails would be sent to say the service is down, but not any to say that the servers were actually up and running.