### PR TITLE
galera: don't bootstrap from a node with no grastate.dat when possible

### DIFF
--- a/heartbeat/README.galera
+++ b/heartbeat/README.galera
@@ -131,7 +131,7 @@ Non-primary state, which would make `galera_monitor()` fail.
 - Deleted: during recurring slave monitor in `check_sync_status()`
            as soon as the Galera code reports to be SYNC-ed.
 
-### heuristic-recovered
+### no-grastate
 
 If a galera node was unexpectedly killed in a middle of a replication,
 InnoDB can retain the equivalent of a XA transaction in prepared state
@@ -139,11 +139,10 @@ in its redo log. If so, mysqld cannot recover state (nor last seqno)
 automatically, and special recovery heuristic has to be used to
 unblock the node.
 
-This attribute is used to keep track of forced recoveries to prevent
-bootstrapping a cluster from a recovered node when possible.
+This transient attribute is used to keep track of forced recoveries to
+prevent bootstrapping a cluster from a recovered node when possible.
 
 - Used   : during `detect_first_master()` to elect the bootstrap node
 - Created: in `detect_last_commit()` if the node has a pending XA
            transaction to recover in the redo log
-- Deleted: when a node is promoted to Master. This attribute is
-           kept in the CIB if a node in stopped.
+- Deleted: when a node is promoted to Master.

--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -279,20 +279,20 @@ is_bootstrap()
 
 }
 
-set_heuristic_recovered()
+set_no_grastate()
 {
-    ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-heuristic-recovered" -v "true"
+    ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-no-grastate" -v "true"
 }
 
-clear_heuristic_recovered()
+clear_no_grastate()
 {
-    ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-heuristic-recovered" -D
+    ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-no-grastate" -D
 }
 
-is_heuristic_recovered()
+is_no_grastate()
 {
     local node=$1
-    ${HA_SBIN_DIR}/crm_attribute -N $node -l reboot --name "${INSTANCE_ATTR_NAME}-heuristic-recovered" -Q 2>/dev/null
+    ${HA_SBIN_DIR}/crm_attribute -N $node -l reboot --name "${INSTANCE_ATTR_NAME}-no-grastate" -Q 2>/dev/null
 }
 
 clear_last_commit()
@@ -463,7 +463,7 @@ detect_first_master()
 
     # avoid selecting a recovered node as bootstrap if possible
     for node in $(echo "$OCF_RESKEY_wsrep_cluster_address" | sed 's/gcomm:\/\///g' | tr -d ' ' | tr -s ',' ' '); do
-        if is_heuristic_recovered $node; then
+        if is_no_grastate $node; then
             nodes_recovered="$nodes_recovered $node"
         else
             nodes="$nodes $node"
@@ -631,10 +631,10 @@ galera_start_local_node()
         fi
 
         clear_bootstrap_node
-        # clear attribute heuristic-recovered. if last shutdown was
+        # clear attribute no-grastate. if last shutdown was
         # not clean, we cannot be extra-cautious by requesting a SST
         # since this is the bootstrap node
-        clear_heuristic_recovered
+        clear_no_grastate
     else
         # only start server, defer full checks to "monitor" op
         galera_start_nowait "$extra_opts"
@@ -644,7 +644,7 @@ galera_start_local_node()
         fi
 
         set_sync_needed
-        # attribute heuristic-recovered will be cleared once the joiner
+        # attribute no-grastate will be cleared once the joiner
         # has finished syncing and is promoted to Master
     fi
 
@@ -667,6 +667,12 @@ detect_last_commit()
     if [ -z "$last_commit" ] || [ "$last_commit" = "-1" ]; then
         local tmp=$(mktemp)
         local tmperr=$(mktemp)
+
+        # if we pass here because grastate.dat doesn't exist,
+        # try not to bootstrap from this node if possible
+        if [ ! -f ${OCF_RESKEY_datadir}/grastate.dat ]; then
+            set_no_grastate
+        fi
 
         ocf_log info "now attempting to detect last commit version using 'mysqld_safe --wsrep-recover'"
 
@@ -691,8 +697,8 @@ detect_last_commit()
                 if [ ! -z "$last_commit" ]; then
                     ocf_log warn "State recovered. force SST at next restart for full resynchronization"
                     rm -f ${OCF_RESKEY_datadir}/grastate.dat
-                    # try not to use this node if bootstrap is needed
-                    set_heuristic_recovered
+                    # try not to bootstrap from this node if possible
+                    set_no_grastate
                 fi
             fi
         fi
@@ -731,8 +737,8 @@ galera_promote()
         # promoting other masters only performs sanity checks
         # as the joining nodes were started during the "monitor" op
         if ! check_sync_needed; then
-            # sync is done, clear info about last recovery
-            clear_heuristic_recovered
+            # sync is done, clear info about last startup
+            clear_no_grastate
             return $OCF_SUCCESS
         else
             ocf_exit_reason "Attempted to promote local node while sync was still needed."
@@ -754,6 +760,7 @@ galera_demote()
     clear_bootstrap_node
     clear_last_commit
     clear_sync_needed
+    clear_no_grastate
 
     # record last commit for next promotion
     detect_last_commit
@@ -886,6 +893,7 @@ galera_stop()
     clear_master_score
     clear_bootstrap_node
     clear_sync_needed
+    clear_no_grastate
     return $rc
 }
 


### PR DESCRIPTION
This is a generalization of commit 4d98bbcdadda60166faf7ccc512b9095b439e2bd.

When several nodes can be chosen as the bootstrap node (e.g. identical last seqno), we avoid choosing a node whose local file grastate.dat doesn't exist.
  . This avoids choosing nodes recovered with --tc-heuristic-recovered because the agent explicitly removes grastate.dat on those nodes to force a SST at restart.
  . This further improves commit 4d98bbcdadda60166faf7ccc512b9095b439e2bd as we track grastate.dat via a transient attribute in the CIB set at node start up, rather than relying on long-lived attribute "galera-heuristic-recovered" which could get out of sync with the state of the DB at the time a node is restarted.
  . If other nodes have appropriate seqno, one can "force" the agent to avoid bootstrapping from a specific node by delete its grastate.dat locally. 

Tested with ra-tester https://github.com/dciabrin/ra-tester/tree/galera-recover-no-grastate
