### PR TITLE
Low: clvm: Check use_lvmetad (bsc#970439)

### DIFF
--- a/heartbeat/clvm
+++ b/heartbeat/clvm
@@ -151,6 +151,12 @@ clvmd_validate()
 		check_binary $LVM_VGSCAN
 	fi
 
+	LVM_CONF_F="/etc/lvm/lvm.conf"
+	if [ -f $LVM_CONF_F ] && grep -qs '^[ ]*use_lvmetad[ ]*=[ ]*1' < $LVM_CONF_F; then
+		ocf_exit_reason "lvmetad is not cluster aware but use_lvmetad = 1 in $LVM_CONF_F"
+		return $OCF_ERR_CONFIGURED
+	fi
+
 	# Future validation checks here.
 	return $OCF_SUCCESS
 }


### PR DESCRIPTION
lvmetad is not cluster aware.

If lvmetad is enabled in lvm.conf as "use_lvmetad = 1",
the agent must not start lvm resources, and must report
failure, and should provide a suggestion to the user to
disable lvmetad.