### PR TITLE
heartbeat/mysql: Handle non-standard mysql server port

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -549,6 +549,7 @@ set_master() {
 
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
         -e "CHANGE MASTER TO MASTER_HOST='$new_master', \
+        MASTER_PORT=$OCF_RESKEY_replication_port, \
         MASTER_USER='$OCF_RESKEY_replication_user', \
         MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $master_params"
     rm -f $tmpfile


### PR DESCRIPTION
In case the mysql master server is running on non-standard port, like 3308 for example, and on the same machine there is another mysql server listening on 3306, the ocf script sets the wrong details.

The problem comes from the fact, that this OCF script exports a parameter replication_port, which is actually never used.

Signed-off-by: Marian Marinov <mm@yuhu.biz>