### PR TITLE
oracle: inform user that monprofile must start with C## for container databases

### DIFF
--- a/heartbeat/oracle
+++ b/heartbeat/oracle
@@ -402,6 +402,9 @@ check_mon_profile() {
 	output=`dbasql mk_mon_profile show_mon_profile`
 	if echo "$output" | grep -iw "^$MONPROFILE" >/dev/null; then
 		return 0
+	elif echo "$output" | grep ORA-65140 >/dev/null 2>&1; then
+		ocf_exit_reason "monprofile must start with C## for container databases"
+		return $OCF_ERR_CONFIGURED
 	else
 		ocf_exit_reason "could not create $MONPROFILE oracle profile"
 		ocf_log err "sqlplus output: $output"


### PR DESCRIPTION
From log:
ERROR: could not create OCFMONPROFILE oracle profile
ERROR: sqlplus output: create profile OCFMONPROFILE limit FAILED_LOGIN_ATTEMPTS UNLIMITED PASSWORD_LIFE_TIME UNLIMITED#012               *#012ERROR at line 1:#012ORA-65140: invalid common profile name

Ref:
https://www.oraexcel.com/oracle-12cR1-ORA-65140