### PR TITLE
Medium: symlink: Handle missing directories in target (bsc#973054)

### DIFF
--- a/heartbeat/symlink
+++ b/heartbeat/symlink
@@ -123,7 +123,7 @@ symlink_monitor() {
             ocf_log debug "$OCF_RESKEY_link exists but is not a symbolic link, will be moved to ${OCF_RESKEY_link}${OCF_RESKEY_backup_suffix} on start"
             rc=$OCF_NOT_RUNNING
         fi
-    elif readlink -f "$OCF_RESKEY_link" | egrep -q "^${OCF_RESKEY_target}$"; then
+    elif readlink -m "$OCF_RESKEY_link" | egrep -q "^${OCF_RESKEY_target}$"; then
         ocf_log debug "$OCF_RESKEY_link exists and is a symbolic link to ${OCF_RESKEY_target}."
         rc=$OCF_SUCCESS
     else


### PR DESCRIPTION
If the directory in which the symlink target is not existing, migration
after failure fails due to the probe reporting an error on the failed
node with a broken symlink.

To handle this, use "readlink -m" over "readlink -f". From the readlink
man page:

>        -f, --canonicalize
>               canonicalize by following every symlink in every component of the given name recursively; all but the last component must exist
>
>        -e, --canonicalize-existing
>               canonicalize by following every symlink in every component of the given name recursively, all components must exist
>
>        -m, --canonicalize-missing
>               canonicalize by following every symlink in every component of the given name recursively, without requirements on components existence