### PR TITLE
Low: Fix directories in ocf-directories

### DIFF
--- a/heartbeat/ocf-directories.in
+++ b/heartbeat/ocf-directories.in
@@ -19,4 +19,4 @@ exec_prefix=@exec_prefix@
 : ${HA_DOCDIR:=@datadir@/doc/heartbeat}
 : ${__SCRIPT_NAME:=`basename $0`}
 : ${HA_VARRUN:=@localstatedir@/run}
-: ${HA_VARLOCK:=@localstatedir@/lock/subsys/}
+: ${HA_VARLOCK:=@localstatedir@/lock/subsys}

--- a/heartbeat/ocf-directories.in
+++ b/heartbeat/ocf-directories.in
@@ -18,5 +18,5 @@ exec_prefix=@exec_prefix@
 : ${HA_RESOURCEDIR:=$HA_DIR/resource.d}
 : ${HA_DOCDIR:=@datadir@/doc/heartbeat}
 : ${__SCRIPT_NAME:=`basename $0`}
-: ${HA_VARRUN:=@localstatedir@/run/}
+: ${HA_VARRUN:=@localstatedir@/run}
 : ${HA_VARLOCK:=@localstatedir@/lock/subsys/}

--- a/heartbeat/shellfuncs.in
+++ b/heartbeat/shellfuncs.in
@@ -78,7 +78,7 @@ BSD_Status() {
   fi
 
   if 
-    [ -f $HA_VARLOCK/var/lock/subsys/${base}.pid ] 
+    [ -f $HA_VARLOCK/${base}.pid ] 
   then
     echo "${base} dead but lock file exists"
     return 2


### PR DESCRIPTION
This change actually fixes issue #793 

With the HA_VARRUN directory changed. I could actually start the apache

Here's an example of the issues that got fixed. I delete the run and lock directory to make sure that the ocf script actually has to create them.

```
root@cluster-a:~# rm -rf /var/lock/apache2/
root@cluster-a:~# rm -rf /var/run/apache2/
root@cluster-a:~# export OCF_ROOT=/usr/lib/ocf
root@cluster-a:~# /usr/lib/ocf/resource.d/heartbeat/apache start
ERROR: cannot create /var/run/apache2 (does not start with /var/run/)
ocf-exit-reason:environment is invalid, resource considered stopped
```

After adjusting the directory path for HA_VARRUN
```
root@cluster-a:~# vi /usr/lib/ocf/lib/heartbeat/ocf-directories 
root@cluster-a:~# rm -rf /var/lock/apache2/
root@cluster-a:~# rm -rf /var/run/apache2/
root@cluster-a:~# /usr/lib/ocf/resource.d/heartbeat/apache start
INFO: apache not running
INFO: waiting for apache /etc/apache2/apache2.conf to come up
```

I was using Debian 8 with the HA Packages from Backports. resource-agents were are version 3.9.7 with the (debian fixed) apache ocf script from master.