### PR TITLE
Medium: ldirectord: Remove IPv6 workaround (bsc#977193)

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -2864,10 +2864,6 @@ sub check_http
 	if (inet_pton(AF_INET6,&ld_strip_brackets($host))) {
 		no warnings 'once';
 		require Net::INET6Glue::INET_is_INET6;
-		# Workaround for Net-HTTP IPv6 Address URLs Broken
-		@LWP::Protocol::http::EXTRA_SOCK_OPTS = (PeerAddr => $host,
-							 PeerHost => &ld_strip_brackets($host),
-							 Host => &ld_strip_brackets($host));
 	}
 
 	my $ua = new LWP::UserAgent(ssl_opts => { verify_hostname => 0 });


### PR DESCRIPTION
Remove workaround for missing IPv6 support in perl-libwww.

The workaround causes issues in a mixed IPv4 and IPv6 environment,
as it overwrites the global EXTRA_SOCK_OPTS.

The underlying issue is fixed with libwww-perl/net-http#10 and libwww-perl/libwww-perl#58.

I would suggest that users and distributions make sure that their
version of libwww-perl has those patches applied, instead of trying
to work around the problem in ldirectord.

Version 6.080 of libwww-perl includes the patches.

The related CPAN issue suggests an alternative workaround if that is
not possible, see https://rt.cpan.org/Public/Bug/Display.html?id=75618