### PR TITLE
[rabbitmq-cluster] Typo fix

### DIFF
--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -156,7 +156,7 @@ rmq_monitor() {
 		return $OCF_NOT_RUNNING
 	;;
 	*)
-		ocf_log err "Unexpected return code from '$RMQ_CTL cluster status' exit code: $rc"
+		ocf_log err "Unexpected return code from '$RMQ_CTL cluster_status' exit code: $rc"
 		rmq_delete_nodename
 		return $OCF_ERR_GENERIC
 	;;


### PR DESCRIPTION
This fixes a very small but annoying typo. In case of rabbitmqctl cluster_monitor failure make error message print exact command failed.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>