### PR TITLE
High: sapdb.sh: Pass timeouts to saphostctrl

### DIFF
--- a/heartbeat/sapdb.sh
+++ b/heartbeat/sapdb.sh
@@ -136,8 +136,12 @@ sapdatabase_start() {
     then
       DBOSUSER="-dbuser $OCF_RESKEY_DBOSUSER "
     fi
-    output=`$SAPHOSTCTRL -function StartDatabase -dbname $SID -dbtype $DBTYPE $DBINST $DBOSUSER $FORCE -service`
-
+      if [ -z $START_TIMEOUT ]
+      then
+       output=`$SAPHOSTCTRL -function StartDatabase -dbname $SID -dbtype $DBTYPE $DBINST $FORCE -service`
+      else
+       output=`$SAPHOSTCTRL -function StartDatabase -dbname $SID -dbtype $DBTYPE $DBINST -timeout $STOP_TIMEOUT $FORCE -service`
+      fi
     sapdatabase_monitor 1
     rc=$?
 
@@ -178,8 +182,12 @@ sapdatabase_stop() {
     then
       DBOSUSER="-dbuser $OCF_RESKEY_DBOSUSER "
     fi
-    output=`$SAPHOSTCTRL -function StopDatabase -dbname $SID -dbtype $DBTYPE $DBINST $DBOSUSER -force -service`
-
+      if [ -z $STOP_TIMEOUT ]
+      then
+       output=`$SAPHOSTCTRL -function StopDatabase -dbname $SID -dbtype $DBTYPE $DBINST -force -service`
+      else
+       output=`$SAPHOSTCTRL -function StopDatabase -dbname $SID -dbtype $DBTYPE $DBINST -timeout $STOP_TIMEOUT -force -service`
+      fi     
     if [ $? -eq 0 ]
     then
       ocf_log info "SAP database $SID stopped: $output"


### PR DESCRIPTION
Pass the timeout on stop/start operation to saphostctrl in order to avoid that SAPDatabase will run into timeout with big databases.

-with big SAP Hana Databases, saphostctrl is running into a timeout when a start/stop is triggered, because Ocf::heartbeat:SAPDatabase is not passing  the timeout parameter to saphostctrl and saphostctrl is using default start/stop timeout which is not enough.

-saphostctrl running into a timeout is reporting the exit code to Ocf::heartbeat:SAPDatabase and Pacemaker is interpreting the response as a fail operation, even if the SAP Hana is stopping / starting in background.

-saphostctrl accept timeout as argument:
StartDatabase
    -dbname <DB name> -dbtype <ada|db6|mss...> [-dbhost <hostname>] [-dbinstance <instance name>] [-dbuser <DB admin username>] [-dbpass <DB admin password>] [-timeout <timeout in sec>] [-service] [-instance] [-force]
  StopDatabase
    -dbname <DB name> -dbtype <ada|db6|mss...> [-dbhost <hostname>] [-dbinstance <instance name>] [-dbuser <DB admin username>] [-dbpass <DB admin password>] [-timeout <timeout in sec>] [-service] [-instance] [-force]
~