### PR TITLE
High: SAPDatabase: Add START|STOP_TIMEOUT parameters

### DIFF
--- a/heartbeat/SAPDatabase
+++ b/heartbeat/SAPDatabase
@@ -2,7 +2,7 @@
 #
 # SAPDatabase
 #
-# Description:	Manages any type of SAP supported database instance
+# Description:  Manages any type of SAP supported database instance
 #               as a High-Availability OCF compliant resource.
 #
 # Author:       Alexander Krauth, October 2006
@@ -10,7 +10,7 @@
 # License:      GNU General Public License (GPL)
 # Copyright:    (c) 2006, 2007, 2010, 2012 Alexander Krauth
 #
-# An example usage: 
+# An example usage:
 #      See usage() function below for more details...
 #
 # OCF instance parameters:
@@ -19,6 +19,8 @@
 #       OCF_RESKEY_DBTYPE              (mandatory, one of the following values: ORA,ADA,DB6,SYB,HDB)
 #       OCF_RESKEY_DBINSTANCE          (optional, Database instance name, if not equal to SID)
 #       OCF_RESKEY_DBOSUSER            (optional, the Linux user that owns the database processes on operating system level)
+#       OCF_RESKEY_START_TIMEOUT       (optional, Timeout passed to saphostctrl for function StartDatabase)
+#       OCF_RESKEY_STOP_TIMEOUT        (optional, Timeout passed to saphostctrl for function StopDatabase)
 #       OCF_RESKEY_STRICT_MONITORING   (optional, activate application level monitoring - with Oracle a failover will occur in case of an archiver stuck)
 #       OCF_RESKEY_AUTOMATIC_RECOVER   (optional, automatic startup recovery, default is false)
 #       OCF_RESKEY_MONITOR_SERVICES    (optional, default is to monitor all database services)
@@ -48,34 +50,32 @@ usage() {
   methods=`sapdatabase_methods`
   methods=`echo $methods | tr ' ' '|'`
   cat <<-!
-	usage: $0 ($methods)
+        usage: $0 ($methods)
 
-	$0 manages a SAP database of any type as an HA resource.
+        $0 manages a SAP database of any type as an HA resource.
         Currently Oracle, MaxDB, DB/2 UDB, Sybase ASE and SAP HANA Database are supported.
         ABAP databases as well as JAVA only databases are supported.
 
-	The 'start' operation starts the instance.
-	The 'stop' operation stops the instance.
-	The 'status' operation reports whether the instance is running
-	The 'monitor' operation reports whether the instance seems to be working
-	The 'recover' operation tries to recover the instance after a crash (instance will be stopped first!)
-	The 'validate-all' operation reports whether the parameters are valid
-	The 'methods' operation reports on the methods $0 supports
+        The 'start' operation starts the instance.
+        The 'stop' operation stops the instance.
+        The 'status' operation reports whether the instance is running
+        The 'monitor' operation reports whether the instance seems to be working
+        The 'recover' operation tries to recover the instance after a crash (instance will be stopped first!)
+        The 'validate-all' operation reports whether the parameters are valid
+        The 'methods' operation reports on the methods $0 supports
 
-	!
+        !
 }
 
 meta_data() {
-	cat <<END
+        cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
 <resource-agent name="SAPDatabase">
 <version>2.14</version>
-
 <shortdesc lang="en">Manages a SAP database instance as an HA resource.</shortdesc>
 <longdesc lang="en">
 Resource script for SAP databases. It manages a SAP database of any type as an HA resource.
-
 The purpose of the resource agent is to start, stop and monitor the database instance of a SAP system. Together with the RDBMS system it will also control the related network service for the database. Like the Oracle Listener and the xserver of MaxDB.
 The resource agent expects a standard SAP installation of the database and therefore needs less parameters to configure.
 The resource agent supports the following databases:
@@ -84,7 +84,6 @@ The resource agent supports the following databases:
 - SAP-DB / MaxDB 7.x
 - Sybase ASE 15.7
 - SAP HANA Database since 1.00 - with SAP node 1625203 (http://sdn.sap.com)
-
 In fact this resource agent does not run any database commands directly. It uses the SAP standard process SAPHostAgent to control the database.
 The SAPHostAgent must be installed on each cluster node locally. It will not work, if you try to run the SAPHostAgent also as a HA resource.
 Please follow SAP note 1031096 for the installation of SAPHostAgent.
@@ -197,7 +196,6 @@ Usually you can leave this empty. Then the default: /usr/sap/hostctrl/exe is use
   <content type="string" default="" />
  </parameter>
 </parameters>
-
 <actions>
 <action name="start" timeout="1800" />
 <action name="stop" timeout="1800" />
@@ -217,16 +215,16 @@ END
 #
 sapdatabase_methods() {
   cat <<-!
-	start
-	stop
-	status
-	monitor
-	recover
-	validate-all
-	methods
-	meta-data
-	usage
-	!
+        start
+        stop
+        status
+        monitor
+        recover
+        validate-all
+        methods
+        meta-data
+        usage
+        !
 }
 
 
@@ -273,7 +271,7 @@ saphostctrl_installed() {
 
 
 #
-#	'main' starts here...
+#       'main' starts here...
 #
 
 if
@@ -285,19 +283,19 @@ fi
 
 # These operations don't require OCF instance parameters to be set
 case "$1" in
-  meta-data)	meta_data
-		exit $OCF_SUCCESS;;
+  meta-data)    meta_data
+                exit $OCF_SUCCESS;;
 
-  usage) 	usage
-		exit $OCF_SUCCESS;;
+  usage)        usage
+                exit $OCF_SUCCESS;;
 
-  methods)	sapdatabase_methods
-		exit $?;;
+  methods)      sapdatabase_methods
+                exit $?;;
 
   *);;
 esac
 
-if  ! ocf_is_root 
+if  ! ocf_is_root
 then
   ocf_log err "$0 must be run as root"
   exit $OCF_ERR_PERM
@@ -332,9 +330,9 @@ fi
 sapdatabase_init
 
 
-# we always want to fall to the faster status method in case of a probe by the cluster  
+# we always want to fall to the faster status method in case of a probe by the cluster
 ACTION=$1
-if ocf_is_probe 
+if ocf_is_probe
 then
   ACTION=status
 fi
@@ -348,6 +346,6 @@ case "$ACTION" in
                                exit $?;;
   validate-all)                sapdatabase_validate
                                exit $?;;
-  *)		                   sapdatabase_methods
+  *)                               sapdatabase_methods
                                exit $OCF_ERR_UNIMPLEMENTED;;
 esac

--- a/heartbeat/SAPDatabase
+++ b/heartbeat/SAPDatabase
@@ -126,6 +126,16 @@ Usually you can leave this empty. Then the default: /usr/sap/hostctrl/exe is use
   <shortdesc lang="en">deprecated - do not use anymore</shortdesc>
   <content type="string" default="" />
  </parameter>
+  <parameter name="START_TIMEOUT" unique="0" required="0">
+  <longdesc lang="en">Timeout passed to saphostctrl for function StartDatabase. If is not set will use be default saphostctrl timeout.</longdesc>
+  <shortdesc lang="en">StartDatabase timeout parameter</shortdesc>
+  <content type="string" default="" />
+ </parameter>
+ <parameter name="STOP_TIMEOUT" unique="0" required="0">
+  <longdesc lang="en">Timeout passed to saphostctrl for function StopDatabase. If is not set will use be default saphostctrl timeout.</longdesc>
+  <shortdesc lang="en">StopDatabase timeout parameter</shortdesc>
+  <content type="string" default="" />
+ </parameter>
  <parameter name="DBJ2EE_ONLY" unique="0" required="0">
   <longdesc lang="en">Deprecated - do not use anymore. This parameter will be deleted in one of the next releases.</longdesc>
   <shortdesc lang="en">deprecated - do not use anymore</shortdesc>
@@ -299,6 +309,8 @@ if  [ -z "$OCF_RESKEY_SID" ]; then
   exit $OCF_ERR_ARGS
 fi
 SID=`echo "$OCF_RESKEY_SID"`
+START_TIMEOUT=`echo "$OCF_RESKEY_START_TIMEOUT"`
+STOP_TIMEOUT=`echo "$OCF_RESKEY_STOP_TIMEOUT"`
 
 if [ -z "$OCF_RESKEY_DBTYPE" ]; then
   ocf_log err "Please set OCF_RESKEY_DBTYPE to the database vendor specific tag (ADA,DB6,ORA,SYB,HDB)!"


### PR DESCRIPTION
Pass the timeout on stop/start operation to saphostctrl in order to avoid that SAPDatabase will run into timeout with big databases.

-with big SAP Hana Database, saphostctrl is running into a timeout when a start/stop is triggered, because SAPDatabase is not passing  the timeout parameter to saphostctrl and saphostctrl is using default start/stop timeout which is not enough.

-saphostctrl running into a timeout is reporting the exit code to SAPDatabase and Pacemaker is interpreting the response as a fail, even if the SAP Hana is stopping / starting in background.

-saphostctrl accept timeout as argument:
StartDatabase
    -dbname <DB name> -dbtype <ada|db6|mss...> [-dbhost <hostname>] [-dbinstance <instance name>] [-dbuser <DB admin username>] [-dbpass <DB admin password>] [-timeout <timeout in sec>] [-service] [-instance] [-force]
  StopDatabase
    -dbname <DB name> -dbtype <ada|db6|mss...> [-dbhost <hostname>] [-dbinstance <instance name>] [-dbuser <DB admin username>] [-dbpass <DB admin password>] [-timeout <timeout in sec>] [-service] [-instance] [-force]