### PR TITLE
High: SAPDatabase: Add START|STOP_TIMEOUT parameters

### DIFF
--- a/heartbeat/SAPDatabase
+++ b/heartbeat/SAPDatabase
@@ -19,6 +19,8 @@
 #       OCF_RESKEY_DBTYPE              (mandatory, one of the following values: ORA,ADA,DB6,SYB,HDB)
 #       OCF_RESKEY_DBINSTANCE          (optional, Database instance name, if not equal to SID)
 #       OCF_RESKEY_DBOSUSER            (optional, the Linux user that owns the database processes on operating system level)
+#       OCF_RESKEY_START_TIMEOUT       (optional, Timeout passed to saphostctrl for the StartDatabase action)
+#       OCF_RESKEY_STOP_TIMEOUT        (optional, Timeout passed to saphostctrl for the StopDatabase action)
 #       OCF_RESKEY_STRICT_MONITORING   (optional, activate application level monitoring - with Oracle a failover will occur in case of an archiver stuck)
 #       OCF_RESKEY_AUTOMATIC_RECOVER   (optional, automatic startup recovery, default is false)
 #       OCF_RESKEY_MONITOR_SERVICES    (optional, default is to monitor all database services)
@@ -124,6 +126,16 @@ Usually you can leave this empty. Then the default: /usr/sap/hostctrl/exe is use
  <parameter name="NETSERVICENAME" unique="0" required="0">
   <longdesc lang="en">Deprecated - do not use anymore. This parameter will be deleted in one of the next releases.</longdesc>
   <shortdesc lang="en">deprecated - do not use anymore</shortdesc>
+  <content type="string" default="" />
+ </parameter>
+  <parameter name="START_TIMEOUT" unique="0" required="0">
+  <longdesc lang="en">Timeout passed to saphostctrl for function StartDatabase. If is not set will use be default saphostctrl timeout.</longdesc>
+  <shortdesc lang="en">StartDatabase timeout parameter</shortdesc>
+  <content type="string" default="" />
+ </parameter>
+ <parameter name="STOP_TIMEOUT" unique="0" required="0">
+  <longdesc lang="en">Timeout passed to saphostctrl for function StopDatabase. If is not set will use be default saphostctrl timeout.</longdesc>
+  <shortdesc lang="en">StopDatabase timeout parameter</shortdesc>
   <content type="string" default="" />
  </parameter>
  <parameter name="DBJ2EE_ONLY" unique="0" required="0">
@@ -299,6 +311,8 @@ if  [ -z "$OCF_RESKEY_SID" ]; then
   exit $OCF_ERR_ARGS
 fi
 SID=`echo "$OCF_RESKEY_SID"`
+START_TIMEOUT=`echo "$OCF_RESKEY_START_TIMEOUT"`
+STOP_TIMEOUT=`echo "$OCF_RESKEY_STOP_TIMEOUT"`
 
 if [ -z "$OCF_RESKEY_DBTYPE" ]; then
   ocf_log err "Please set OCF_RESKEY_DBTYPE to the database vendor specific tag (ADA,DB6,ORA,SYB,HDB)!"

--- a/heartbeat/sapdb.sh
+++ b/heartbeat/sapdb.sh
@@ -136,8 +136,12 @@ sapdatabase_start() {
     then
       DBOSUSER="-dbuser $OCF_RESKEY_DBOSUSER "
     fi
-    output=`$SAPHOSTCTRL -function StartDatabase -dbname $SID -dbtype $DBTYPE $DBINST $DBOSUSER $FORCE -service`
-
+      if [ -z $START_TIMEOUT ]
+      then
+       output=`$SAPHOSTCTRL -function StartDatabase -dbname $SID -dbtype $DBTYPE $DBINST $FORCE -service`
+      else
+       output=`$SAPHOSTCTRL -function StartDatabase -dbname $SID -dbtype $DBTYPE $DBINST -timeout $STOP_TIMEOUT $FORCE -service`
+      fi
     sapdatabase_monitor 1
     rc=$?
 
@@ -178,8 +182,12 @@ sapdatabase_stop() {
     then
       DBOSUSER="-dbuser $OCF_RESKEY_DBOSUSER "
     fi
-    output=`$SAPHOSTCTRL -function StopDatabase -dbname $SID -dbtype $DBTYPE $DBINST $DBOSUSER -force -service`
-
+      if [ -z $STOP_TIMEOUT ]
+      then
+       output=`$SAPHOSTCTRL -function StopDatabase -dbname $SID -dbtype $DBTYPE $DBINST -force -service`
+      else
+       output=`$SAPHOSTCTRL -function StopDatabase -dbname $SID -dbtype $DBTYPE $DBINST -timeout $STOP_TIMEOUT -force -service`
+      fi     
     if [ $? -eq 0 ]
     then
       ocf_log info "SAP database $SID stopped: $output"


### PR DESCRIPTION
> This pull request combines #802 and #803 into a single branch.

Pass the timeout on stop/start operation to saphostctrl in order to avoid that SAPDatabase will run into timeout with big databases.

-with big SAP Hana Database, saphostctrl is running into a timeout when a start/stop is triggered, because ￼SAPDatabase is not passing  the timeout parameter to saphostctrl and saphostctrl is using default start/stop timeout which is not enough.

-saphostctrl running into a timeout is reporting the exit code to SAPDatabase and Pacemaker is interpreting the response as a fail, even if the SAP Hana is stopping / starting in background.

```
-saphostctrl accept timeout as argument:
StartDatabase
    -dbname <DB name> -dbtype <ada|db6|mss...> [-dbhost <hostname>] [-dbinstance <instance name>] [-dbuser <DB admin username>] [-dbpass <DB admin password>] [-timeout <timeout in sec>] [-service] [-instance] [-force]
  StopDatabase
    -dbname <DB name> -dbtype <ada|db6|mss...> [-dbhost <hostname>] [-dbinstance <instance name>] [-dbuser <DB admin username>] [-dbpass <DB admin password>] [-timeout <timeout in sec>] [-service] [-instance] [-force]
```

Fixes: #801 #802 #803 