### PR TITLE
Low: extend support for AWS elastic ip association

### DIFF
--- a/heartbeat/awseip
+++ b/heartbeat/awseip
@@ -78,6 +78,22 @@ reserved elastic ip for ec2 instance
 <content type="string" default="" />
 </parameter>
 
+<parameter name="allocation_id" unique="1" required="0">
+<longdesc lang="en">
+reserved allocation id for ec2 instance
+</longdesc>
+<shortdesc lang="en">reserved allocation id for ec2 instance</shortdesc>
+<content type="string" default="" />
+</parameter>
+
+<parameter name="private_ip_address" unique="1" required="0">
+<longdesc lang="en">
+predefined private ip address for ec2 instance
+</longdesc>
+<shortdesc lang="en">predefined private ip address for ec2 instance</shortdesc>
+<content type="string" default="" />
+</parameter>
+
 <parameter name="api_delay" unique="0">
 <longdesc lang="en">
 a short delay between API calls, to avoid sending API too quick
@@ -116,10 +132,19 @@ END
 awseip_start() {
     awseip_monitor && return $OCF_SUCCESS
 
-    $AWSCLI ec2 associate-address  \
-        --instance-id ${INSTANCE_ID} \
-        --public-ip ${ELASTIC_IP}
-    RET=$?
+    if [ -n "${ALLOCATION_ID}" ] && [ -n "${PRIVATE_IP_ADDRESS}" ]; then
+        $AWSCLI ec2 associate-address  \
+            --instance-id ${INSTANCE_ID} \
+            --network-interface-id ${NETWORK_ID} \
+            --allocation-id ${ALLOCATION_ID} \
+            --private-ip-address ${PRIVATE_IP_ADDRESS}
+        RET=$?
+    else
+        $AWSCLI ec2 associate-address  \
+            --instance-id ${INSTANCE_ID} \
+            --public-ip ${ELASTIC_IP}
+        RET=$?
+    fi
 
     # delay to avoid sending request too fast
     sleep ${OCF_RESKEY_api_delay}
@@ -174,7 +199,10 @@ awseip_validate() {
 : ${OCF_RESKEY_awscli="/usr/bin/aws"}
 AWSCLI="${OCF_RESKEY_awscli}"
 ELASTIC_IP="${OCF_RESKEY_elastic_ip}"
+ALLOCATION_ID="${OCF_RESKEY_allocation_id}"
+PRIVATE_IP_ADDRESS="${OCF_RESKEY_private_ip_address}"
 INSTANCE_ID="$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
+NETWORK_ID="$($AWSCLI ec2 describe-instances --instance-id ${INSTANCE_ID} | grep -m 1 'eni' | awk -F'"' '{print$4}')"
 
 case $__OCF_ACTION in
     meta-data)
@@ -192,7 +220,7 @@ case $__OCF_ACTION in
         ;;
     migrate_to)
         ocf_log info "Migrating ${OCF_RESOURCE_INSTANCE} to ${OCF_RESKEY_CRM_meta_migrate_target}."
-	awseip_stop
+        awseip_stop
         ;;
     migrate_from)
         ocf_log info "Migrating ${OCF_RESOURCE_INSTANCE} from ${OCF_RESKEY_CRM_meta_migrate_source}."


### PR DESCRIPTION
make it possible to associate secondary private ip address with elastic
ip address, if allocation-id.

if private-ip-address were both set, it will try to associate elastic
interface with the allocation-id, otherwise, it will try to associate
elastic ip with private ip instead (default).

reference docs:
http://docs.aws.amazon.com/cli/latest/reference/ec2/associate-address.html