### PR TITLE
RabbitMQ: New error code - 69

### DIFF
--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -167,6 +167,11 @@ rmq_monitor() {
 		rmq_delete_nodename
 		return $OCF_NOT_RUNNING
 	;;
+	69)
+		ocf_log info "RabbitMQ server is not running"
+		rmq_delete_nodename
+		return $OCF_NOT_RUNNING
+	;;
 	*)
 		ocf_log err "Unexpected return code from '$RMQ_CTL cluster_status' exit code: $rc"
 		rmq_delete_nodename


### PR DESCRIPTION
Recent RabbitMQ versions return 69 when a node isn't running. Previous
versions return 2 in this case. This change was introduced in commit
rabbitmq/rabbitmq-server@7984540175d0b8852025165b6b6a0ac05d692c98.

See this RHBZ issue for further details:

* https://bugzilla.redhat.com/1338657#c8

Signed-off-by: Peter Lemenkov <lemenkov@redhat.com>