### PR TITLE
exportfs: Add pseudo resource factor (bsc#978680)

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -266,6 +266,10 @@ is_exported() {
 
 exportfs_monitor ()
 {
+	if ! ha_pseudo_resource "${OCF_RESOURCE_INSTANCE}" monitor; then
+		return $OCF_NOT_RUNNING
+	fi
+
 	if forall is_exported "${OCF_RESKEY_clientspec}"; then
 		if [ ${OCF_RESKEY_rmtab_backup} != "none" ]; then
 			forall backup_rmtab
@@ -311,6 +315,8 @@ exportfs_start ()
 		return $OCF_SUCCESS
 	fi
 	ocf_log info "Exporting file system(s) ..."
+
+	ha_pseudo_resource "${OCF_RESOURCE_INSTANCE}" start
 	forall export_one
 
 	# Restore the rmtab to ensure smooth NFS-over-TCP failover
@@ -391,6 +397,8 @@ exportfs_stop ()
 
 	if [ $rc -eq 0 ]; then
 		cleanup_export_cache
+		ha_pseudo_resource "${OCF_RESOURCE_INSTANCE}" stop
+
 		ocf_log info "Un-exported file system(s)"
 		return $OCF_SUCCESS
 	else

--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -613,8 +613,7 @@ dirname()
 # resource monitoring, and better resource tracking in general, this will
 # become essential.
 #
-# These scripts work because ${HA_RSCTMP} is cleaned out every time
-# heartbeat is started.
+# These scripts work because ${HA_RSCTMP} is cleaned on node reboot.
 #
 # We create "resource-string" tracking files under ${HA_RSCTMP} in a
 # very simple way:


### PR DESCRIPTION
exportfs resource relies on output from exportfs utility which in turn
stores its state data in /var/lib/nfs/etab. This file survives reboot
(e.g. after fencing) and when probe monitor operation is invoked
exportfs RA will report resource as *started* if there are respective
records in /var/lib/nfs/etab despite the fact nfsserver resource is
not started and exportfs resource is thus effectively *stopped*.

Normally this is not a problem because nfsserver clears content of
/var/lib/nfs/etab upon start, however, when only monitor operations are
executed (e.g. probing after reboot) wrong state of exportfs resource is
reported.

This solution puts alleged status of the resource in logical conjunction
with pseudo resource state (i.e. it's not pure pseudo resource, just
necessary condition). The idea is from @dmuhamedagic.

Note: pseudo resource state is kept in `$HA_RSCTMP` directory, which is
supposed to be empty after reboot. The comments in `ocf-shellfuncs` says:

> These scripts work because ${HA_RSCTMP} is cleaned out every time heartbeat is started.

That could be an issue when Pacemaker would be forcefully restarted with exported filesystems actually kept running, however, because `$HA_RSCTMP` directory would be empty the modified RA would report it as *not running*, which is wrong. OTOH, I can't find the place where `$HA_RSCTMP` directory is being erased and `doc/dev-guides/ra-dev-guide.txt` states:

> A temporary directory for use by resource agents. The system startup sequence (on any LSB compliant Linux distribution) guarantees that this directory is emptied on system startup, so this directory will not contain any stale data after a node reboot.

That'd imply that pseudo resource state lost only after full reboot (not only HA stack), which is desirable here.