### PR TITLE
garbd: fix install and man page

### DIFF
--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -105,6 +105,7 @@ man_MANS	       = ocf_heartbeat_AoEtarget.7 \
                           ocf_heartbeat_exportfs.7 \
                           ocf_heartbeat_fio.7 \
                           ocf_heartbeat_galera.7 \
+                          ocf_heartbeat_garbd.7 \
                           ocf_heartbeat_iSCSILogicalUnit.7 \
                           ocf_heartbeat_iSCSITarget.7 \
                           ocf_heartbeat_iface-bridge.7 \

--- a/heartbeat/Makefile.am
+++ b/heartbeat/Makefile.am
@@ -76,6 +76,7 @@ ocf_SCRIPTS	     =  ClusterMon		\
 			Filesystem		\
 			fio			\
 			galera			\
+			garbd			\
 			ids			\
 			iscsi			\
 			ICP			\


### PR DESCRIPTION
New garbd agent is not installed and man page is not generated either.  This pull request fixes that.