### PR TITLE
pgsql: fix stop_escalate parameter issue

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -782,7 +782,7 @@ pgsql_real_stop() {
 
     # Stop PostgreSQL, do not wait for clients to disconnect
     if [ $stop_escalate -gt 0 ]; then
-            runasowner "$OCF_RESKEY_pgctl -D $OCF_RESKEY_pgdata stop -m fast"
+            runasowner "$OCF_RESKEY_pgctl -W -D $OCF_RESKEY_pgdata stop -m fast"
     fi
 
     # stop waiting
@@ -802,7 +802,7 @@ pgsql_real_stop() {
     then
         #PostgreSQL is still up. Use another shutdown mode.
         ocf_log info "PostgreSQL failed to stop after ${stop_escalate}s using -m fast. Trying -m immediate..."
-        runasowner "$OCF_RESKEY_pgctl -D $OCF_RESKEY_pgdata stop -m immediate"
+        runasowner "$OCF_RESKEY_pgctl -W -D $OCF_RESKEY_pgdata stop -m immediate"
     fi
 
     while :

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -53,7 +53,7 @@ OCF_RESKEY_start_opt_default=""
 OCF_RESKEY_ctl_opt_default=""
 OCF_RESKEY_pgdb_default=template1
 OCF_RESKEY_logfile_default=/dev/null
-OCF_RESKEY_stop_escalate_default=30
+OCF_RESKEY_stop_escalate_default=90
 OCF_RESKEY_monitor_user_default=""
 OCF_RESKEY_monitor_password_default=""
 OCF_RESKEY_monitor_sql_default="select now();"
@@ -71,7 +71,7 @@ OCF_RESKEY_restart_on_promote_default="false"
 OCF_RESKEY_tmpdir_default="/var/lib/pgsql/tmp"
 OCF_RESKEY_xlog_check_count_default="3"
 OCF_RESKEY_crm_attr_timeout_default="5"
-OCF_RESKEY_stop_escalate_in_slave_default=30
+OCF_RESKEY_stop_escalate_in_slave_default=90
 OCF_RESKEY_replication_slot_name_default=""
 
 : ${OCF_RESKEY_pgctl=${OCF_RESKEY_pgctl_default}}
@@ -273,7 +273,7 @@ If you use PostgreSQL 9.3 or higher and define unix_socket_directories in the po
 
 <parameter name="stop_escalate" unique="0" required="0">
 <longdesc lang="en">
-Number of shutdown retries (using -m fast) before resorting to -m immediate
+Number of seconds to wait for stop (using -m fast) before resorting to -m immediate
 </longdesc>
 <shortdesc lang="en">stop escalation</shortdesc>
 <content type="integer" default="${OCF_RESKEY_stop_escalate_default}" />
@@ -425,7 +425,7 @@ This is optional for replication.
 
 <parameter name="stop_escalate_in_slave" unique="0" required="0">
 <longdesc lang="en">
-Number of shutdown retries (using -m fast) before resorting to -m immediate
+Number of seconds to wait for stop (using -m fast) before resorting to -m immediate
 in slave state.
 This is optional for replication.
 </longdesc>

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -779,6 +779,12 @@ pgsql_real_stop() {
     if [ "$1" = "slave" ]; then
         stop_escalate="$OCF_RESKEY_stop_escalate_in_slave"
     fi
+    # adjust stop_escalate time when it is longer than the timeout
+    if [ -n "$OCF_RESKEY_CRM_meta_timeout" ] && \
+        [ "$stop_escalate" -ge $((OCF_RESKEY_CRM_meta_timeout/1000)) ]; then
+        stop_escalate=$(((OCF_RESKEY_CRM_meta_timeout/1000) - 10))
+        ocf_log info "stop_escalate(or stop_escalate_in_slave) time is adjusted to ${stop_escalate} based on the configured timeout."
+    fi
 
     # Stop PostgreSQL, do not wait for clients to disconnect
     if [ $stop_escalate -gt 0 ]; then


### PR DESCRIPTION
This pull request fixes the issues below as discovered in #795.
 - stop escalation did not work and caused an unnecessary fencing when a stop timeout is configured too short (approx. <= 60s)
 - 'stop_escalate' parameter was obscure and hard to estimate the time to invoke stop escalation

