### PR TITLE
[galera] Add /etc/default/clustercheck importation

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -76,6 +76,8 @@
 # in this file
 if [ -f "/etc/sysconfig/clustercheck" ]; then
     . /etc/sysconfig/clustercheck
+elif [ -f "/etc/default/clustercheck" ]; then
+    . /etc/default/clustercheck
 fi
 
 #######################################################################


### PR DESCRIPTION
On Debian and Ubuntu distributions, the ``/etc/sysconfig/`` directory doesn't exist.

This directory is replaced by ``/etc/default/``.