### PR TITLE
Dev: Add shebang to runocft script

### DIFF
--- a/tools/ocft/runocft
+++ b/tools/ocft/runocft
@@ -1,3 +1,4 @@
+#!/bin/sh
 OCFTDIR=/usr/share/resource-agents/ocft
 CONFDIR=$OCFTDIR/configs
 


### PR DESCRIPTION
The script is executable, but doesn't have a shebang.
