### PR TITLE
adjusting sapdb.sh to work with HANA Multi-Tenant Databases

### DIFF
--- a/heartbeat/sapdb.sh
+++ b/heartbeat/sapdb.sh
@@ -229,7 +229,7 @@ sapdatabase_monitor() {
       # we have to parse the output, because the returncode doesn't tell anything about the instance status
       for SERVICE in `echo "$output" | grep -i 'Component[ ]*Name *[:=] [A-Za-z][A-Za-z0-9_]* (' | sed 's/^.*Component[ ]*Name *[:=] *\([A-Za-z][A-Za-z0-9_]*\).*$/\1/i'`
       do 
-        COLOR=`echo "$output" | grep -i "Component[ ]*Name *[:=] *$SERVICE (" | sed 's/^.*Status *[:=] *\([A-Za-z][A-Za-z0-9_]*\).*$/\1/i'`
+        COLOR=`echo "$output" | grep -i "Component[ ]*Name *[:=] *$SERVICE (" | sed 's/^.*Status *[:=] *\([A-Za-z][A-Za-z0-9_]*\).*$/\1/i' | uniq`
         STATE=0
 
         case $COLOR in


### PR DESCRIPTION
When working with Multi-Tenant Databases in SAP Hana it creates multiple index servers and others  services with repeated names..
```
hana01:/usr/sap/hostctrl/exe> saphostctrl -function GetDatabaseStatus -dbname HPA -dbtype hdb 01 slehaloc
Database Status: Warning
    Component name: hdbdaemon (HDB Daemon), Status: Running (Running)
    Component name: hdbcompileserver (HDB Compileserver), Status: Running (Running)
    Component name: hdbnameserver (HDB Nameserver), Status: Running (Running)
    Component name: hdbpreprocessor (HDB Preprocessor), Status: Running (Running)
    Component name: hdbwebdispatcher (HDB Web Dispatcher), Status: Running (Running)
    Component name: hdbindexserver (indexserver-DB1), Status: Running (Running)
    Component name: hdbindexserver (indexserver-DB2), Status: Running (Running)
    Component name: hdbindexserver (indexserver-DB3), Status: Running (Running)
    Component name: hdbconnectivity (HDB Connectivity), Status: Running (connect possible)
    Component name: hdbalertmanager (HDB Alertmanager), Status: Warning (alerts on database.)
```

This behavior impact in COLORS var to have multiple lines of "Running".
```
hana01:/usr/sap/hostctrl/exe> echo "$output" | grep -i "Component[ ]*Name *[:=] *hdbindexserver (" | sed 's/^.*Status *[:=] *\([A-Za-z][A-Za-z0-9_]*\).*$/\1/i'
Running
Running
Running
```

The simpler way to resolve this is append a uniq into COLORS command.

If a Tenant or any service fail, subsequent case will result in OCF_NOT_RUNNING as expected.

If a Tenant is stopped by user, the status is supressed from saphostctrl output. So the result keep fine.



