### PR TITLE
nfsserver: dont stop rpcbind, as other services might use it

### DIFF
--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -804,10 +804,7 @@ nfsserver_stop ()
 
 	# systemd
 	case $EXEC_MODE in
-            [23]) nfs_exec stop rpcbind > /dev/null 2>&1
-		  ocf_log info "Stop: rpcbind"
-
-		  nfs_exec stop rpc-gssd > /dev/null 2>&1
+            [23]) nfs_exec stop rpc-gssd > /dev/null 2>&1
 		  ocf_log info "Stop: rpc-gssd"
 	esac
 


### PR DESCRIPTION
Services like NIS/ypbind use rpcbind and will stop when it is stopped