### PR TITLE
ldirectord: a further fix for spurious reminder e-mails

### DIFF
--- a/ldirectord/ldirectord.in
+++ b/ldirectord/ldirectord.in
@@ -2722,16 +2722,9 @@ sub run_child
 	my $virtual_id = get_virtual_id_str($v);
 	my $checkinterval = $$v{checkinterval} || $CHECKINTERVAL;
 
-	# delete any entries in EMAILSTATUS that don't belong to this child
-	my %myservices = ();
-	foreach my $r (@$real) {
-		my $virtual_str = &get_virtual($v);
-		my $id = $r->{server} . ":" . $r->{port} . " ($virtual_str)";
-		$myservices{$id} = 1;
-	}
-	foreach my $id (keys %EMAILSTATUS) {
-		delete $EMAILSTATUS{$id} unless defined $myservices{$id};
-	}
+	# delete any entries in EMAILSTATUS as we can't trust what has been
+	# set in the parent in the past.
+	%EMAILSTATUS = ();
 
 	$0 = "ldirectord $virtual_id";
 	while (1) {


### PR DESCRIPTION
A fairly obscure bug to trigger, but in forking mode the following can happen:

 * start ldirectord (children fork, EMAILSTATUS empty)
 * service down (children notice, EMAILSTATUS set in children, reminders start)
 * "reload" ldirectord (parent marks EMAILSTATUS set, children inherit EMAILSTATUS set)
 * service up (children clears EMAILSTATUS, reminders stop)
 * "reload" ldirectord (parent still has EMAILSTATUS set, children inherit EMAILSTATUS set)

children then start sending reminder notifications even though service is up.

This solution here is to completely clear %EMAILSTATUS after forking. The downside is that children will stop sending reminders after a parent reload, but they would in other situations anyway such as when a child process dies and is restarted.

This is a simplification of fd163033953cd950385728b9f86e5b5b358c3bb7, and related to b2612d380bcb8d691870bea9446e1d897603c0ca (which is still needed). Fixing this completely would probably require an architecture change to keep the current status in the parent and have the children open a pipe to parent to update data. Then everything would be consistent across child restarts rather than the status being lost.