### PR TITLE
Redis: restore rundir security context

### DIFF
--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -324,6 +324,10 @@ function start() {
 
 	[[ ! -d "$REDIS_RUNDIR" ]] && mkdir -p "$REDIS_RUNDIR"
 	chown -R "$REDIS_USER" "$REDIS_RUNDIR"
+	if have_binary "restorecon"; then
+		restorecon -Rv "$REDIS_RUNDIR"
+	fi
+
 
 	# check for 0 byte database dump file. This is an unrecoverable start
 	# condition that we can avoid by deleting the 0 byte database file.


### PR DESCRIPTION
When selinux rules packages are installed, rundir does not yet exist,
and security context for it cannot be applied. Calling restorecon after
dir creation ensures that the proper context is applied to the rundir.
If the context is not applied, selinux denies write permission, the unix
socket cannot be created, and redis does not start