### PR TITLE
Doc: docker: Clarify limitations of monitor_cmd in parameter description

### DIFF
--- a/heartbeat/docker
+++ b/heartbeat/docker
@@ -115,6 +115,13 @@ container has failed and should be recovered.
 
 If 'docker exec' is supported, it is used to execute the command. If not,
 nsenter is used.
+
+Note: Using this method for monitoring processes inside a container
+is not recommended, as containerd tries to track processes running
+inside the container and does not deal well with many short-lived
+processes being spawned. Ensure that your container monitors its
+own processes and terminates on fatal error rather than invoking
+a command from the outside.
 </longdesc>
 <shortdesc lang="en">monitor command</shortdesc>
 <content type="string"/>


### PR DESCRIPTION
Background:

Running a monitor_cmd regularly generated a lot of warning output in syslog from containerd. When investigating this, I got the following response:

```
The problem is that containerd is trying 
to keep track of all of the container processes, and you're starting and 
stopping processes using `docker exec`.

The warnings aren't really much to worry about, but AFAIK the only way 
of removing the warnings is patching container to stop emitting them. :/

However, I would in general warn against using Docker exec a lot. Due to 
a lot of ... interesting ... design choices, Docker exec isn't the best 
thing to be spamming against running containers.
```

Taking another look at the interaction between the resource agent and docker, it is probably better to recommend that a container monitors itself and for the resource agent to monitor the container state only.
