### PR TITLE
Low: slapd: Change of the stop processing.

### DIFF
--- a/heartbeat/slapd
+++ b/heartbeat/slapd
@@ -219,32 +219,6 @@ Maximum number of open files (for ulimit -n)
 END
 }
 
-terminate()
-{
-  local pid=$1
-  local signal=$2
-  local recheck=${3-0}
-  local rc
-  local waited=0
-
-  kill -$signal $pid >/dev/null 2>&1; rc=$?
-
-  while [ \( $rc -eq 0 \) -a \( $recheck -eq 0 -o $waited -lt $recheck \) ]; do
-    kill -0 $pid >/dev/null 2>&1; rc=$?
-    let "waited += 1"
-
-    if [ $rc -eq 0 ]; then
-      sleep 1
-    fi
-  done
-
-  if [ $rc -ne 0 ]; then
-    return 0
-  fi
-
-  return 1
-}
-
 watch_suffix()
 {
   local rc
@@ -382,10 +356,10 @@ slapd_stop()
     return $state
   fi
 
-  terminate $pid TERM $OCF_RESKEY_stop_escalate; rc=$?
-  if [ $rc -ne 0  ]; then
-    ocf_exit_reason "slapd failed to stop. Escalating to KILL."
-    terminate $pid KILL; rc=$?
+  ocf_stop_processes TERM $OCF_RESKEY_stop_escalate $pid; rc=$?
+  if [ $rc -eq 1 ]; then
+    ocf_log err "cannot stop slapd."
+    return $OCF_ERR_GENERIC
   fi
 
   if [ -f "$pid_file" ]; then


### PR DESCRIPTION
Hi All,

I change the stop processing to the ocf_stop_processes processing.
Because the time-out of the KILL stop becomes effective, it may become late than before, but is not different in movement.

This correction changed former pullrequest.
 - https://github.com/ClusterLabs/resource-agents/pull/850

Best Regards,
Hideo Yamauchi.