### PR TITLE
galera: prevent promote right after demote

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -764,6 +764,13 @@ galera_demote()
     clear_sync_needed
     clear_no_grastate
 
+    # Clear master score here rather than letting pacemaker do so once
+    # demote finishes. This way a promote cannot take place right
+    # after this demote even if pacemaker is requested to do so. It
+    # will first have to run a start/monitor op, to reprobe the state
+    # of the other galera nodes and act accordingly.
+    clear_master_score
+
     # record last commit for next promotion
     detect_last_commit
     rc=$?


### PR DESCRIPTION
During a demote, let the resource agent clear the master score of the
resource rather than letting pacemaker do so once demote finishes.

This way a promote cannot take place right after the current demote,
even if pacemaker is requested to do so. It will first have to run a
start/monitor op, to reprobe the state of the other galera nodes and
act accordingly.