### PR TITLE
ifcheck must not suppress stdout of "ip" command …

### DIFF
--- a/heartbeat/findif.sh
+++ b/heartbeat/findif.sh
@@ -10,7 +10,7 @@ ipcheck_ipv6() {
 }
 ifcheck() {
   local ifname="$1"
-  $IP2UTIL link show dev $ifname >/dev/null 2>&1
+  $IP2UTIL link show dev $ifname 2>&1
 }
 prefixcheck() {
   local prefix=$1


### PR DESCRIPTION
so that it can be printed out in case of an error (e.g., usage in findif_check_params).

This resolves the issue #883 