### PR TITLE
Low: exportfs: check fsid parameter for not containing a comma

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -79,8 +79,8 @@ The directory or directories to export.
 <parameter name="fsid" unique="1" required="1">
 <longdesc lang="en">
 The fsid option to pass to exportfs. This can be a unique positive
-integer, a UUID, or the special string "root" which is functionally
-identical to numeric fsid of 0.
+integer, a UUID (assuredly sans comma characters), or the special string
+"root" which is functionally identical to numeric fsid of 0.
 If multiple directories are being exported, then they are
 assigned ids sequentially starting with this fsid (fsid, fsid+1,
 fsid+2, ...). Obviously, in that case the fsid must be an
@@ -290,7 +290,7 @@ export_one() {
 	fi
 	if echo "$opts" | grep fsid >/dev/null; then
 		#replace fsid in options list
-		opts=`echo "$opts" | sed "s/fsid=[0-9]\+/fsid=$(get_fsid)/g"`
+		opts=`echo "$opts" | sed "s,fsid=[^,]*,fsid=$(get_fsid),g"`
 	else
 		#tack the fsid option onto our options list.
 		opts="${opts}${sep}fsid=$(get_fsid)"
@@ -417,6 +417,10 @@ testdir() {
 }
 exportfs_validate_all ()
 {
+	if echo "$OCF_RESKEY_fsid" | grep -q -F ','; then
+		ocf_exit_reason "$OCF_RESKEY_fsid cannot contain a comma"
+		return $OCF_ERR_CONFIGURED
+	fi
 	if [ $NUMDIRS -gt 1 ] &&
 			! ocf_is_decimal "$OCF_RESKEY_fsid"; then
 		ocf_exit_reason "use integer fsid when exporting multiple directories"


### PR DESCRIPTION
Otherwise, it would be possible to circumvent the handling logic in
multiple ways, at the very least:
a. inject new (and potentionally unchecked as in standard flow)
   export options through fsid parameter
b. accidentally make sed expression intended to override
   fsid option present in export options with explicitly
   provided fsid invalid if this explicit input contains
   a character finalizing the sed substutition command
c. allow for repeated fsid specification in the resulting
   export options, possibly verging on undefined (implementation
   specific) behavior, because of matching only numerical fsid
   already existing in options

Because in standard Linux implementation of NFS exports, there
is no strict restriction on string reprezentation of UUID data
type[*], solution on the resource-agents' side is to enforce one
-- fsid parameter can now no longer contain a comma.
This should make us safe in both a. and b.  And existing sed
expression is refined to tackle case c.

[*] nfs-utils in fact only have these restrictions on UUID:
- only hex characters do count (as in isxdigit(3))
- there must be exactly 32 of them throughout the value, i.e.,
  "punctuation" is an arbitrary byte X for which isxdigit(X) == 0
http://git.linux-nfs.org/?p=steved/nfs-utils.git;a=blob;f=utils/mountd/cache.c;hb=nfs-utils-1-3-5-rc3#l260
http://git.linux-nfs.org/?p=steved/nfs-utils.git;a=blob;f=support/nfs/exports.c;hb=nfs-utils-1-3-5-rc3#l391
