### PR TITLE
add network namespace support to IPaddr2

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -368,6 +368,16 @@ Expects a value as specified in section 5.5.4 of RFC 4862.
 <content type="string" default="${OCF_RESKEY_preferred_lft_default}"/>
 </parameter>
 
+<parameter name="network_namespace">
+<longdesc lang="en">
+Specifies the network namespace to operate within.
+The namespace must already exist, and the interface to be used must be within
+the namespace.
+</longdesc>
+<shortdesc lang="en">Network namespace to use</shortdesc>
+<content type="string" default=""/>
+</parameter>
+
 </parameters>
 <actions>
 <action name="start"   timeout="20s" />
@@ -1125,6 +1135,10 @@ set_send_arp_program() {
 ip_validate() {
     check_binary $IP2UTIL
     IP_CIP=
+
+    if [ -n "$OCF_RESKEY_network_namespace" ]; then
+        OCF_RESKEY_network_namespace= exec $IP2UTIL netns exec "$OCF_RESKEY_network_namespace" "$0" "$__OCF_ACTION"
+    fi
 
     ip_init
 


### PR DESCRIPTION
Simple implementation of network namespace support. Basically the script changes its own network namespace if configured. Then any commands run by the script inherit the namespace.

Just FYI, we've been using this since around the time this PR was created (now 7 months as of mid-June) on 15 different servers, with 255 total different VIPs, and have not had any issues with it.