### PR TITLE
Dump/restore users even in case of RabbitMQ 3.6.x and also dump/restore user permissions during restarts

### DIFF
--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -370,35 +370,36 @@ rmq_start() {
 		BaseDataDir=`dirname $RMQ_DATA_DIR`
 		if [ -f $BaseDataDir/users.erl ] ; then
 			rabbitmqctl eval "
-				%% Run only if Mnesia is ready, otherwise exit.
-				lists:any(fun({mnesia,_,_}) -> true; ({_,_,_}) -> false end, application:which_applications()) orelse halt(),
+				%% Run only if Mnesia is ready.
+				lists:any(fun({mnesia,_,_}) -> true; ({_,_,_}) -> false end, application:which_applications()) andalso
+				begin
+					[WildPattern] = ets:select(mnesia_gvar, [ { {{rabbit_user, wild_pattern}, '\\\$1'}, [], ['\\\$1'] } ]),
 
-				[WildPattern] = ets:select(mnesia_gvar, [ { {{rabbit_user, wild_pattern}, '\\\$1'}, [], ['\\\$1'] } ]),
+					%% Read users first
+					{ok, [Users]} = file:consult(\"$BaseDataDir/users.erl\"),
 
-				%% Read users first
-				{ok, [Users]} = file:consult(\"$BaseDataDir/users.erl\"),
+					Upgrade = fun
+						({internal_user, A, B, C}) -> {internal_user, A, B, C, rabbit_password_hashing_md5};
+						({internal_user, A, B, C, D}) -> {internal_user, A, B, C, D}
+					end,
 
-				Upgrade = fun
-					({internal_user, A, B, C}) -> {internal_user, A, B, C, rabbit_password_hashing_md5};
-					({internal_user, A, B, C, D}) -> {internal_user, A, B, C, D}
-				end,
+					Downgrade = fun
+						({internal_user, A, B, C}) -> {internal_user, A, B, C};
+						({internal_user, A, B, C, rabbit_password_hashing_md5}) -> {internal_user, A, B, C};
+						%% Incompatible scheme, so we will loose user's password ('B' value) during conversion.
+						%% Unfortunately, this case will require manual intervention - user have to run:
+						%%    rabbitmqctl change_password <A> <somenewpassword>
+						({internal_user, A, B, C, _}) -> {internal_user, A, B, C}
+					end,
 
-				Downgrade = fun
-					({internal_user, A, B, C}) -> {internal_user, A, B, C};
-					({internal_user, A, B, C, rabbit_password_hashing_md5}) -> {internal_user, A, B, C};
-					%% Incompatible scheme, so we will loose user's password ('B' value) during conversion.
-					%% Unfortunately, this case will require manual intervention - user have to run:
-					%%    rabbitmqctl change_password <A> <somenewpassword>
-					({internal_user, A, B, C, _}) -> {internal_user, A, B, C}
-				end,
-
-				case WildPattern of
-					%% Version < 3.6.0
-					{internal_user,'_','_','_'} ->
-						lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user, Downgrade(X)) end, Users);
-					%% Version >= 3.6.0
-					{internal_user,'_','_','_','_'} ->
-						lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user, Upgrade(X)) end, Users)
+					case WildPattern of
+						%% Version < 3.6.0
+						{internal_user,'_','_','_'} ->
+							lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user, Downgrade(X)) end, Users);
+						%% Version >= 3.6.0
+						{internal_user,'_','_','_','_'} ->
+							lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user, Upgrade(X)) end, Users)
+					end
 				end.
 			"
 			rm -f $BaseDataDir/users.erl
@@ -417,21 +418,22 @@ rmq_stop() {
 	# Backup users
 	BaseDataDir=`dirname $RMQ_DATA_DIR`
 	rabbitmqctl eval "
-		%% Run only if Mnesia is still available, otherwise exit.
-		lists:any(fun({mnesia,_,_}) -> true; ({_,_,_}) -> false end, application:which_applications()) orelse halt(),
+		%% Run only if Mnesia is still available.
+		lists:any(fun({mnesia,_,_}) -> true; ({_,_,_}) -> false end, application:which_applications()) andalso
+		begin
+			[WildPattern] = ets:select(mnesia_gvar, [ { {{rabbit_user, wild_pattern}, '\\\$1'}, [], ['\\\$1'] } ]),
 
-		[WildPattern] = ets:select(mnesia_gvar, [ { {{rabbit_user, wild_pattern}, '\\\$1'}, [], ['\\\$1'] } ]),
+			Users = case WildPattern of
+				%% Version < 3.6.0
+				{internal_user,'_','_','_'} ->
+					mnesia:dirty_select(rabbit_user, [{ {internal_user, '\\\$1', '_', '_'}, [{'/=', '\\\$1', <<\"guest\">>}], ['\\\$_'] } ]);
+				%% Version >= 3.6.0
+				{internal_user,'_','_','_','_'} ->
+					mnesia:dirty_select(rabbit_user, [{ {internal_user, '\\\$1', '_', '_', '_'}, [{'/=', '\\\$1', <<\"guest\">>}], ['\\\$_'] } ])
+			end,
 
-		Users = case WildPattern of
-			%% Version < 3.6.0
-			{internal_user,'_','_','_'} ->
-				mnesia:dirty_select(rabbit_user, [{ {internal_user, '\\\$1', '_', '_'}, [{'/=', '\\\$1', <<\"guest\">>}], ['\\\$_'] } ]);
-			%% Version >= 3.6.0
-			{internal_user,'_','_','_','_'} ->
-				mnesia:dirty_select(rabbit_user, [{ {internal_user, '\\\$1', '_', '_', '_'}, [{'/=', '\\\$1', <<\"guest\">>}], ['\\\$_'] } ])
-		end,
-
-		file:write_file(\"$BaseDataDir/users.erl\", io_lib:fwrite(\"~p.~n\", [Users])).
+			file:write_file(\"$BaseDataDir/users.erl\", io_lib:fwrite(\"~p.~n\", [Users]))
+		end.
 	"
 
 	rmq_monitor

--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -366,14 +366,40 @@ rmq_start() {
 		rmq_join_existing "$join_list"
 		rc=$?
 
-                # Restore users (if any)
-                BaseDataDir=`dirname $RMQ_DATA_DIR`
-                if [ -f $BaseDataDir/users.erl ] ; then
-                        rabbitmqctl eval "
-                                {ok, [Users]} = file:consult(\"$BaseDataDir/users.erl\"),
-                                lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user, X) end, Users).
-                        "
-                        rm -f $BaseDataDir/users.erl
+		# Restore users (if any)
+		BaseDataDir=`dirname $RMQ_DATA_DIR`
+		if [ -f $BaseDataDir/users.erl ] ; then
+			rabbitmqctl eval "
+
+				[WildPattern] = ets:select(mnesia_gvar, [ { {{rabbit_user, wild_pattern}, '\\\$1'}, [], ['\\\$1'] } ]),
+
+				%% Read users first
+				{ok, [Users]} = file:consult(\"$BaseDataDir/users.erl\"),
+
+				Upgrade = fun
+					({internal_user, A, B, C}) -> {internal_user, A, B, C, rabbit_password_hashing_md5};
+					({internal_user, A, B, C, D}) -> {internal_user, A, B, C, D}
+				end,
+
+				Downgrade = fun
+					({internal_user, A, B, C}) -> {internal_user, A, B, C};
+					({internal_user, A, B, C, rabbit_password_hashing_md5}) -> {internal_user, A, B, C};
+					%% Incompatible scheme, so we will loose user's password ('B' value) during conversion.
+					%% Unfortunately, this case will require manual intervention - user have to run:
+					%%    rabbitmqctl change_password <A> <somenewpassword>
+					({internal_user, A, B, C, _}) -> {internal_user, A, B, C}
+				end,
+
+				case WildPattern of
+					%% Version < 3.6.0
+					{internal_user,'_','_','_'} ->
+						lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user, Downgrade(X)) end, Users);
+					%% Version >= 3.6.0
+					{internal_user,'_','_','_','_'} ->
+						lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user, Upgrade(X)) end, Users)
+				end.
+			"
+			rm -f $BaseDataDir/users.erl
                 fi
 
 		if [ $rc -ne 0 ]; then
@@ -386,12 +412,22 @@ rmq_start() {
 }
 
 rmq_stop() {
-        # Backup users
-        BaseDataDir=`dirname $RMQ_DATA_DIR`
-        rabbitmqctl eval "
-                Users = mnesia:dirty_select(rabbit_user, [{ {internal_user, '\\\$1', '_', '_'}, [{'/=', '\\\$1', <<\"guest\">>}], ['\\\$_'] } ]),
-                file:write_file(\"$BaseDataDir/users.erl\", io_lib:fwrite(\"~p.~n\", [Users])).
-        "
+	# Backup users
+	BaseDataDir=`dirname $RMQ_DATA_DIR`
+	rabbitmqctl eval "
+		[WildPattern] = ets:select(mnesia_gvar, [ { {{rabbit_user, wild_pattern}, '\\\$1'}, [], ['\\\$1'] } ]),
+
+		Users = case WildPattern of
+			%% Version < 3.6.0
+			{internal_user,'_','_','_'} ->
+				mnesia:dirty_select(rabbit_user, [{ {internal_user, '\\\$1', '_', '_'}, [{'/=', '\\\$1', <<\"guest\">>}], ['\\\$_'] } ]);
+			%% Version >= 3.6.0
+			{internal_user,'_','_','_','_'} ->
+				mnesia:dirty_select(rabbit_user, [{ {internal_user, '\\\$1', '_', '_', '_'}, [{'/=', '\\\$1', <<\"guest\">>}], ['\\\$_'] } ])
+		end,
+
+		file:write_file(\"$BaseDataDir/users.erl\", io_lib:fwrite(\"~p.~n\", [Users])).
+	"
 
 	rmq_monitor
 	if [ $? -eq $OCF_NOT_RUNNING ]; then

--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -366,7 +366,7 @@ rmq_start() {
 		rmq_join_existing "$join_list"
 		rc=$?
 
-		# Restore users (if any)
+		# Restore users and users' permissions (if any)
 		BaseDataDir=`dirname $RMQ_DATA_DIR`
 		if [ -f $BaseDataDir/users.erl ] ; then
 			rabbitmqctl eval "
@@ -408,9 +408,10 @@ rmq_start() {
                 if [ -f $BaseDataDir/users_perms.erl ] ; then
                         rabbitmqctl eval "
                                 {ok, [UsersPerms]} = file:consult(\"$BaseDataDir/users_perms.erl\"),
-                                lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user_permission, X) end, UsersPerms).
+                                lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user_permission, X) end, UsersPerms),
+
+				ok = file:delete(\"$BaseDataDir/users_perms.erl\").
                         "
-                        rm -f $BaseDataDir/users_perms.erl
                 fi
 
 		if [ $rc -ne 0 ]; then
@@ -423,7 +424,7 @@ rmq_start() {
 }
 
 rmq_stop() {
-	# Backup users
+	# Backup users and users' permissions
 	BaseDataDir=`dirname $RMQ_DATA_DIR`
 	rabbitmqctl eval "
 		%% Run only if Mnesia is still available.
@@ -440,14 +441,12 @@ rmq_stop() {
 					mnesia:dirty_select(rabbit_user, [{ {internal_user, '\\\$1', '_', '_', '_'}, [{'/=', '\\\$1', <<\"guest\">>}], ['\\\$_'] } ])
 			end,
 
-			Users /= [] andalso file:write_file(\"$BaseDataDir/users.erl\", io_lib:fwrite(\"~p.~n\", [Users]))
+			Users /= [] andalso file:write_file(\"$BaseDataDir/users.erl\", io_lib:fwrite(\"~p.~n\", [Users])),
+
+			UsersPerms = mnesia:dirty_select(rabbit_user_permission, [{{'\\\$1', {'\\\$2', '\\\$3','\\\$4'}, '\\\$5'}, [{'/=', '\\\$3', <<\"guest\">>}], ['\\\$_']}]),
+			UsersPerms /= [] andalso file:write_file(\"$BaseDataDir/users_perms.erl\", io_lib:fwrite(\"~p.~n\", [UsersPerms]))
 		end.
 	"
-
-        rabbitmqctl eval "
-                UsersPerms = mnesia:dirty_select(rabbit_user_permission, [{ {'\\\$1', '\\\$2', '\\\$3'}, [{'/=', '\\\$2', {{user_vhost,<<\"guest\">>,<<\"/\">>}}}], ['\\\$_'] } ]),
-                file:write_file(\"$BaseDataDir/users_perms.erl\", io_lib:fwrite(\"~p.~n\", [UsersPerms])).
-        "
 
 	rmq_monitor
 	if [ $? -eq $OCF_NOT_RUNNING ]; then

--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -433,7 +433,7 @@ rmq_stop() {
 					mnesia:dirty_select(rabbit_user, [{ {internal_user, '\\\$1', '_', '_', '_'}, [{'/=', '\\\$1', <<\"guest\">>}], ['\\\$_'] } ])
 			end,
 
-			file:write_file(\"$BaseDataDir/users.erl\", io_lib:fwrite(\"~p.~n\", [Users]))
+			Users /= [] andalso file:write_file(\"$BaseDataDir/users.erl\", io_lib:fwrite(\"~p.~n\", [Users]))
 		end.
 	"
 

--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -399,10 +399,11 @@ rmq_start() {
 						%% Version >= 3.6.0
 						{internal_user,'_','_','_','_'} ->
 							lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user, Upgrade(X)) end, Users)
-					end
+					end,
+
+					ok = file:delete(\"$BaseDataDir/users.erl\")
 				end.
 			"
-			rm -f $BaseDataDir/users.erl
                 fi
 
 		if [ $rc -ne 0 ]; then

--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -370,6 +370,8 @@ rmq_start() {
 		BaseDataDir=`dirname $RMQ_DATA_DIR`
 		if [ -f $BaseDataDir/users.erl ] ; then
 			rabbitmqctl eval "
+				%% Run only if Mnesia is ready, otherwise exit.
+				lists:any(fun({mnesia,_,_}) -> true; ({_,_,_}) -> false end, application:which_applications()) orelse halt(),
 
 				[WildPattern] = ets:select(mnesia_gvar, [ { {{rabbit_user, wild_pattern}, '\\\$1'}, [], ['\\\$1'] } ]),
 
@@ -415,6 +417,9 @@ rmq_stop() {
 	# Backup users
 	BaseDataDir=`dirname $RMQ_DATA_DIR`
 	rabbitmqctl eval "
+		%% Run only if Mnesia is still available, otherwise exit.
+		lists:any(fun({mnesia,_,_}) -> true; ({_,_,_}) -> false end, application:which_applications()) orelse halt(),
+
 		[WildPattern] = ets:select(mnesia_gvar, [ { {{rabbit_user, wild_pattern}, '\\\$1'}, [], ['\\\$1'] } ]),
 
 		Users = case WildPattern of

--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -407,10 +407,14 @@ rmq_start() {
                 fi
                 if [ -f $BaseDataDir/users_perms.erl ] ; then
                         rabbitmqctl eval "
-                                {ok, [UsersPerms]} = file:consult(\"$BaseDataDir/users_perms.erl\"),
-                                lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user_permission, X) end, UsersPerms),
+				%% Run only if Mnesia is ready.
+				lists:any(fun({mnesia,_,_}) -> true; ({_,_,_}) -> false end, application:which_applications()) andalso
+				begin
+					{ok, [UsersPerms]} = file:consult(\"$BaseDataDir/users_perms.erl\"),
+					lists:foreach(fun(X) -> mnesia:dirty_write(rabbit_user_permission, X) end, UsersPerms),
 
-				ok = file:delete(\"$BaseDataDir/users_perms.erl\").
+					ok = file:delete(\"$BaseDataDir/users_perms.erl\")
+				end.
                         "
                 fi
 


### PR DESCRIPTION
This PR fixes dump/restore users from RabbitMQ 3.6.x where internal structure was changed a little. Also it allows dumping/restoring users' permissions (see RHBZ 1342376).