### PR TITLE
pgsql: Double-quote value of synchronous_standby_names in rep_mode.conf

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1493,7 +1493,7 @@ set_sync_mode() {
         ocf_log debug "$sync_node_in_conf is already sync mode."
     else
         ocf_log info "Setup $1 into sync mode."
-        runasowner -q err "echo \"synchronous_standby_names = '$1'\" > \"$REP_MODE_CONF\""
+        runasowner -q err "echo \"synchronous_standby_names = '\\\"$1\\\"'\" > \"$REP_MODE_CONF\""
         [ "$RE_CONTROL_SLAVE" = "false" ] && RE_CONTROL_SLAVE="true"
         exec_with_retry 0 reload_conf
     fi


### PR DESCRIPTION
PostgreSQL 9.6 introduced a new syntax for specifying
synchronous_standby_names. The old syntax, used by the pgsql RA, is
still valid but PostgreSQL now treats the standby-names in
synchronous_standby_names as SQL identifiers. This means such values
need to be double-quoted since they can easily contain dashes or other
characters that are not valid in a bare SQL identifier.

See the docs for synchronous_standby_names in
https://www.postgresql.org/docs/9.6/static/runtime-config-replication.html
for confirmation and
https://www.postgresql.org/message-id/21183.1481253534%40sss.pgh.pa.us
for a short discussion.