### PR TITLE
targetcli concurrent-safe

### DIFF
--- a/heartbeat/iSCSILogicalUnit
+++ b/heartbeat/iSCSILogicalUnit
@@ -43,6 +43,7 @@ elif have_binary lio_node; then
 	OCF_RESKEY_implementation_default="lio"
 elif have_binary targetcli; then
 	OCF_RESKEY_implementation_default="lio-t"
+	targetcli_safe=${OCF_FUNCTIONS_DIR}/targetcli_safe
 fi
 : ${OCF_RESKEY_implementation=${OCF_RESKEY_implementation_default}}
 
@@ -373,16 +374,16 @@ iSCSILogicalUnit_start() {
 	lio-t)
 		# For lio, we first have to create a target device, then
 		# add it to the Target Portal Group as an LU.
-		ocf_run targetcli /backstores/block create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
+		ocf_run $targetcli_safe /backstores/block create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
 		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
 			echo ${OCF_RESKEY_scsi_sn} > /sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/wwn/vpd_unit_serial
 		fi
-		ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns create /backstores/block/${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
+		ocf_run $targetcli_safe /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns create /backstores/block/${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
 
 		if [ -n "${OCF_RESKEY_allowed_initiators}" ]; then
 			for initiator in ${OCF_RESKEY_allowed_initiators}; do
-				ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls create ${initiator} add_mapped_luns=False || exit $OCF_ERR_GENERIC
-				ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls/${initiator} create ${OCF_RESKEY_lun} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
+				ocf_run $targetcli_safe /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls create ${initiator} add_mapped_luns=False || exit $OCF_ERR_GENERIC
+				ocf_run $targetcli_safe /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls/${initiator} create ${OCF_RESKEY_lun} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
 			done
 		fi
 		;;
@@ -442,11 +443,11 @@ iSCSILogicalUnit_stop() {
 	lio-t)
 		# "targetcli delete" will fail if the LUN is already
 		# gone. Log a warning and still push ahead.
-		ocf_run -warn targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns delete ${OCF_RESKEY_lun}
+		ocf_run -warn $targetcli_safe /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns delete ${OCF_RESKEY_lun}
 		if [ -n "${OCF_RESKEY_allowed_initiators}" ]; then
 			for initiator in ${OCF_RESKEY_allowed_initiators}; do
-				if targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls/${initiator} status | grep "Mapped LUNs: 0" >/dev/null ; then
-					ocf_run -warn targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls/ delete ${initiator}
+				if $targetcli_safe /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls/${initiator} status | grep "Mapped LUNs: 0" >/dev/null ; then
+					ocf_run -warn $targetcli_safe /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls/ delete ${initiator}
 				fi
 			done
 		fi
@@ -455,7 +456,7 @@ iSCSILogicalUnit_stop() {
 		# delete the backstore, then something is seriously
 		# wrong and we need to fail the stop operation
 		# (potentially causing fencing)
-		ocf_run targetcli /backstores/block delete ${OCF_RESOURCE_INSTANCE} || exit $OCF_ERR_GENERIC
+		ocf_run $targetcli_safe /backstores/block delete ${OCF_RESOURCE_INSTANCE} || exit $OCF_ERR_GENERIC
 		;;
 	esac
 

--- a/heartbeat/iSCSITarget
+++ b/heartbeat/iSCSITarget
@@ -41,6 +41,7 @@ elif have_binary lio_node; then
 	OCF_RESKEY_implementation_default="lio"
 elif have_binary targetcli; then
 	OCF_RESKEY_implementation_default="lio-t"
+	targetcli_safe=${OCF_FUNCTIONS_DIR}/targetcli_safe
 fi
 : ${OCF_RESKEY_implementation=${OCF_RESKEY_implementation_default}}
 
@@ -334,14 +335,14 @@ iSCSITarget_start() {
 		# number 1. In lio, creating a network portal
 		# automatically creates the corresponding target if it
 		# doesn't already exist.
-		ocf_run targetcli /iscsi set global auto_add_default_portal=false || exit $OCF_ERR_GENERIC
-		ocf_run targetcli /iscsi create ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
+		ocf_run $targetcli_safe /iscsi set global auto_add_default_portal=false || exit $OCF_ERR_GENERIC
+		ocf_run $targetcli_safe /iscsi create ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
 		for portal in ${OCF_RESKEY_portals}; do
 			if [ $portal != ${OCF_RESKEY_portals_default} ] ; then
 				IFS=':' read -a sep_portal <<< "$portal"
-				ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/portals create "${sep_portal[0]}" "${sep_portal[1]}" || exit $OCF_ERR_GENERIC
+				ocf_run $targetcli_safe /iscsi/${OCF_RESKEY_iqn}/tpg1/portals create "${sep_portal[0]}" "${sep_portal[1]}" || exit $OCF_ERR_GENERIC
 			else
-				ocf_run targetcli /iscsi create ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
+				ocf_run $targetcli_safe /iscsi create ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
 			fi
 		done
 		# in lio, we can set target parameters by manipulating
@@ -371,15 +372,15 @@ iSCSITarget_start() {
 		# this, we need to switch the target to "permissive mode".
 		if [ -n "${OCF_RESKEY_allowed_initiators}" ]; then
 			for initiator in ${OCF_RESKEY_allowed_initiators}; do
-				ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/acls create ${initiator} || exit $OCF_ERR_GENERIC
+				ocf_run $targetcli_safe /iscsi/${OCF_RESKEY_iqn}/tpg1/acls create ${initiator} || exit $OCF_ERR_GENERIC
 			done
 		else
-			ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/ set attribute authentication=0 demo_mode_write_protect=0 generate_node_acls=1 cache_dynamic_acls=1 || exit $OCF_ERR_GENERIC
+			ocf_run $targetcli_safe /iscsi/${OCF_RESKEY_iqn}/tpg1/ set attribute authentication=0 demo_mode_write_protect=0 generate_node_acls=1 cache_dynamic_acls=1 || exit $OCF_ERR_GENERIC
 		fi
 		# TODO: add CHAP authentication support when it gets added
 		# back into LIO
-		ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/ set attribute authentication=0 || exit $OCF_ERR_GENERIC
-#			   ocf_run targetcli /iscsi 
+		ocf_run $targetcli_safe /iscsi/${OCF_RESKEY_iqn}/tpg1/ set attribute authentication=0 || exit $OCF_ERR_GENERIC
+#			   ocf_run $targetcli_safe /iscsi 
 		;;
 	esac
 
@@ -499,7 +500,7 @@ iSCSITarget_stop() {
 		ocf_run lio_node --deliqn ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
 		;;
 	lio-t)
-		ocf_run targetcli /iscsi delete ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
+		ocf_run $targetcli_safe /iscsi delete ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
 		;;
 	esac
 

--- a/rgmanager/src/resources/targetcli_safe
+++ b/rgmanager/src/resources/targetcli_safe
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+#     targetcli safe invokation. Avoids concurrent use of targetcli.
+#
+# Copyright (C) 2016 Universidad de La Laguna. All Rights Reserved.
+
+if [ -z "$OCF_ROOT" ]; then
+    : ${OCF_ROOT=/usr/lib/ocf}
+fi
+
+if [ "$OCF_FUNCTIONS_DIR" = ${OCF_ROOT}/resource.d/heartbeat ]; then  # old
+        unset OCF_FUNCTIONS_DIR
+fi
+
+: ${OCF_FUNCTIONS_DIR:=${OCF_ROOT}/lib/heartbeat}
+
+. ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
+
+
+function __trap_error() {
+  ha_log "ERROR: targetcli_safe lock aborted."
+  exit $OCF_ERR_GENERIC
+}
+
+
+# lock and retry until fd is released
+function __lock() {
+  local -r LOCKNAME=$1
+  local -r LOCKFILE_DIR=/var/lock
+  # lock file descriptor
+  local -r LOCK_FD=200
+  local lock_file=$LOCKFILE_DIR/$LOCKNAME.lock
+  local rnd=$(ocf_maybe_random)
+
+  # lock file
+  eval "exec $LOCK_FD>$lock_file"
+  
+  flock -n $LOCK_FD
+
+  # retry until lock is released
+  while [ $? -ne 0 ]
+  do
+    ocf_log info "Sleeping until $lock_file is released..."
+    sleep 0.$rnd
+    flock -n $LOCK_FD
+  done
+}
+
+function targetcli_safe() {
+  trap __trap_error SIGINT SIGTERM
+  __lock targetcli_safe
+  # invoke targetcli with original arguments
+  targetcli $@
+}
+
+
+targetcli_safe $@


### PR DESCRIPTION
targetcli is not concurrent-safe. Using iscsi resources in different groups and shutting down a node causes race conditions.
Basically this serializes access to targetcli via lock file.