### PR TITLE
ocf_mkstatedir: fix path check

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -778,7 +778,7 @@ ocf_mkstatedir()
 	[ $(id -u) = 0 ] || return 1
 
 	case $path in
-	$HA_VARRUN/*) : this path is ok ;;
+	${HA_VARRUN%/}/*) : this path is ok ;;
 	*) ocf_log err "cannot create $path (does not start with $HA_VARRUN)"
 		return 1
 	;;


### PR DESCRIPTION
Check fails due to duble slashes in string comparison.

Path /var/run/apache2 is compared with /var/run//* giving the following error in the logs:

Dec 21 13:17:53 node1 apache(apache_/etc/apache2/apache2.conf)[826]: [868]: ERROR: cannot create /var/run/apache2 (does not start with /var/run/)