### PR TITLE
targetcli lockfile

### DIFF
--- a/heartbeat/iSCSILogicalUnit
+++ b/heartbeat/iSCSILogicalUnit
@@ -75,6 +75,8 @@ OCF_RESKEY_lio_iblock=${OCF_RESKEY_lio_iblock:-$OCF_RESKEY_lio_iblock_default}
 # OCF_RESKEY_tgt_bsopts
 # OCF_RESKEY_tgt_device_type
 
+# targetcli: iSCSITarget and iSCSILogicalUnit must use the same lockfile
+TARGETLOCKFILE=${HA_RSCTMP}/targetcli.lock
 #######################################################################
 
 meta_data() {
@@ -371,6 +373,8 @@ iSCSILogicalUnit_start() {
 		fi
 		;;
 	lio-t)
+		ocf_take_lock $TARGETLOCKFILE
+		ocf_release_lock_on_exit $TARGETLOCKFILE
 		# For lio, we first have to create a target device, then
 		# add it to the Target Portal Group as an LU.
 		ocf_run targetcli /backstores/block create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
@@ -440,6 +444,8 @@ iSCSILogicalUnit_stop() {
 		fi
 		;;
 	lio-t)
+		ocf_take_lock $TARGETLOCKFILE
+		ocf_release_lock_on_exit $TARGETLOCKFILE
 		# "targetcli delete" will fail if the LUN is already
 		# gone. Log a warning and still push ahead.
 		ocf_run -warn targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns delete ${OCF_RESKEY_lun}

--- a/heartbeat/iSCSITarget
+++ b/heartbeat/iSCSITarget
@@ -50,6 +50,9 @@ OCF_RESKEY_portals_default="0.0.0.0:3260"
 
 # Lockfile, used for selecting a target ID
 LOCKFILE=${HA_RSCTMP}/iSCSITarget-${OCF_RESKEY_implementation}.lock
+
+# targetcli: iSCSITarget and iSCSILogicalUnit must use the same lockfile
+TARGETLOCKFILE=${HA_RSCTMP}/targetcli.lock
 #######################################################################
 
 meta_data() {
@@ -334,6 +337,8 @@ iSCSITarget_start() {
 		# number 1. In lio, creating a network portal
 		# automatically creates the corresponding target if it
 		# doesn't already exist.
+		ocf_take_lock $TARGETLOCKFILE
+		ocf_release_lock_on_exit $TARGETLOCKFILE
 		ocf_run targetcli /iscsi set global auto_add_default_portal=false || exit $OCF_ERR_GENERIC
 		ocf_run targetcli /iscsi create ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
 		for portal in ${OCF_RESKEY_portals}; do
@@ -499,6 +504,8 @@ iSCSITarget_stop() {
 		ocf_run lio_node --deliqn ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
 		;;
 	lio-t)
+		ocf_take_lock $TARGETLOCKFILE
+		ocf_release_lock_on_exit $TARGETLOCKFILE
 		ocf_run targetcli /iscsi delete ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
 		;;
 	esac


### PR DESCRIPTION
targetcli is not concurrent-safe. Using iscsi resources in different groups and shutting down a node causes race conditions.