### PR TITLE
specfile: Add metadata.rng to the file to be collected

### DIFF
--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -233,6 +233,7 @@ rm -rf %{buildroot}
 %if %{with linuxha}
 %doc doc/README.webapps
 %doc %{_datadir}/%{name}/ra-api-1.dtd
+%doc %{_datadir}/%{name}/metadata.rng
 %endif
 
 %if %{with rgmanager}


### PR DESCRIPTION
Make rpm of v4.0.0rc1 fails.
Is not it necessary to collect metadata.rng?
```
# make rpm
(snip)
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/resource-agents-4.0.0-0rc1.el7.x86_64
error: Installed (but unpackaged) file(s) found:
   /usr/share/resource-agents/metadata.rng


RPM build errors:
    Installed (but unpackaged) file(s) found:
   /usr/share/resource-agents/metadata.rng
make: *** [rpm] Error 1
```