### PR TITLE
LVM: fix partial activation

### DIFF
--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -548,7 +548,8 @@ LVM_validate_all() {
 		# "unknown device" then another node may have marked a device missing 
 		# where we have access to all of them and can start without issue. 
 		if vgs -o pv_attr --noheadings $OCF_RESKEY_volgrpname 2>/dev/null | grep 'm' > /dev/null 2>&1; then
-			if vgs -o pv_name --noheadings $OCF_RESKEY_volgrpname 2>/dev/null | grep -E "unknown device|Couldn't find device|Device mismatch detected" > /dev/null 2>&1; then
+			case $(vgs -o attr --noheadings $OCF_RESKEY_volgrpname | tr -d ' ') in
+			???p??*)
 				if ! ocf_is_true "$OCF_RESKEY_partial_activation" ; then
 					# We are missing devices and cannot activate partially
 					ocf_exit_reason "Volume group [$VOLUME] has devices missing.  Consider partial_activation=true to attempt to activate partially"
@@ -558,7 +559,8 @@ LVM_validate_all() {
 					# Assume that caused the vgck failure and carry on
 					ocf_log warn "Volume group inconsistency detected with missing device(s) and partial_activation enabled.  Proceeding with requested action."
 				fi
-			fi
+				;;
+			esac
 			# else the vg is partial but all devices are accounted for, so another 
 			# node must have marked the device missing.  Proceed.
 		else


### PR DESCRIPTION
Detects partial issues even when the old code didnt (and if it's partial after the device becomes available again).