### PR TITLE
Medium: exportfs: Only strip brackets from edges of clientspec

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -266,11 +266,14 @@ is_exported() {
 
 exportfs_monitor ()
 {
+	local spec
+
 	if ! ha_pseudo_resource "${OCF_RESOURCE_INSTANCE}" monitor; then
 		return $OCF_NOT_RUNNING
 	fi
 
-	if forall is_exported "$(echo "${OCF_RESKEY_clientspec}" | tr -d '[]')"; then
+	spec="$(echo "$OCF_RESKEY_clientspec" | sed -e 's/^\[*//' -e 's/\]*$//')"
+	if forall is_exported "$spec"; then
 		if [ ${OCF_RESKEY_rmtab_backup} != "none" ]; then
 			forall backup_rmtab
 		fi

--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -165,7 +165,7 @@ return $OCF_SUCCESS
 }
 
 exportfs_methods() {
-  cat <<-!
+  cat <<-EOF
 	start
 	stop
 	status
@@ -174,7 +174,7 @@ exportfs_methods() {
 	methods
 	meta-data
 	usage
-	!
+	EOF
 }
 
 reset_fsid() {


### PR DESCRIPTION
regexps are valid inputs to clientspec (like `node[0-2].example.com`), which breaks if internal brackets are stripped.

Technically, removing from the beginning and end also breaks some regexps, but at least this should help some cases.
