### PR TITLE
Fix Route for IPv6 default gateway

### DIFF
--- a/heartbeat/Route
+++ b/heartbeat/Route
@@ -291,7 +291,7 @@ done
 
 route_validate || exit $?
 
-case $OCF_RESKEY_destination in
+case $OCF_RESKEY_gateway in
 *:*) addr_family="-6" ;;
   *) addr_family="-4" ;;
 esac


### PR DESCRIPTION
The IPv6 ressource checks the "destination" paramter for a ":" to decide if
the route is IPv4 or IPv6. If the destination is "default", it always assumes that
IPv4 is given, even it the gateway has a ":" in it.

The "gateway" parameter is more failsave for this, so we changed the logic to it.