### PR TITLE
Mid: pgsql: Change to crm_resource.

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1064,7 +1064,7 @@ pgsql_pre_promote() {
                           sort | head -1`
             if [ "$cmp_location" != "$my_master_baseline" ]; then
                 ocf_exit_reason "My data is newer than new master's one. New master's location : $master_baseline"
-                exec_with_retry 0 $CRM_FAILCOUNT -r $OCF_RESOURCE_INSTANCE -U $NODENAME -v INFINITY
+                exec_with_retry 0 $CRM_RESOURCE -B -r $OCF_RESOURCE_INSTANCE -N $NODENAME -Q
                 return $OCF_ERR_GENERIC
             fi
         fi
@@ -1977,7 +1977,7 @@ if is_replication; then
     CRM_MASTER="${HA_SBIN_DIR}/crm_master -l reboot"
     CRM_ATTR_REBOOT="${HA_SBIN_DIR}/crm_attribute -l reboot"
     CRM_ATTR_FOREVER="${HA_SBIN_DIR}/crm_attribute -l forever"
-    CRM_FAILCOUNT="${HA_SBIN_DIR}/crm_failcount"
+    CRM_RESOURCE="${HA_SBIN_DIR}/crm_resource"
 
     CAN_NOT_PROMOTE="-INFINITY"
     CAN_PROMOTE="100"


### PR DESCRIPTION
Hi All,

From the next release of Pacemaker, user and RA cannot appoint INFINTIY by crm_failcount command.

 * https://github.com/ClusterLabs/pacemaker/commit/95db10602e8f646eefed335414e40a994498cafd

I abolish the use of crm_failcount.
By this correction, crm_resource -U(--clear) is necessary for restoration from trouble.

Best Regards,
Hideo Yamauchi.
