### PR TITLE
galera: fix permission of temporary log file for mariadb 10.1.21+

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -520,6 +520,7 @@ detect_last_commit()
     last_commit="$(cat ${OCF_RESKEY_datadir}/grastate.dat | sed -n 's/^seqno.\s*\(.*\)\s*$/\1/p')"
     if [ -z "$last_commit" ] || [ "$last_commit" = "-1" ]; then
         local tmp=$(mktemp)
+        chown $OCF_RESKEY_user:$OCF_RESKEY_group $tmp
 
         # if we pass here because grastate.dat doesn't exist,
         # try not to bootstrap from this node if possible


### PR DESCRIPTION
Since MariaDB/server@8fcdd6b0ecbb966f4479856efe93a963a7a422f7,
mysqld_safe relies on a helper subprocess to write into log files.
This new logging mechanism expects log file to be writable by the
user configured to run mysqld.

Fix the generation of temporary log file accordingly.