### PR TITLE
clvm: remove reload action from metadata

### DIFF
--- a/heartbeat/clvm
+++ b/heartbeat/clvm
@@ -78,7 +78,6 @@ is set to.
 <action name="start"        timeout="90" />
 <action name="stop"         timeout="90" />
 <action name="monitor"      timeout="90" interval="30" depth="0" />
-<action name="reload"       timeout="90" />
 <action name="meta-data"    timeout="10" />
 <action name="validate-all"   timeout="20" />
 </actions>


### PR DESCRIPTION
Remove reload-action as it's announced, but not available in the resource agent.

Decided to remove it as some settings require a restart, while others does not, so it's better to keep it consistent, as it's possible to do the reload changes yourself while unmanage'ing the resource.