### PR TITLE
Changes to support load-balanced/distributed NFS v3 exports 

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -13,14 +13,20 @@
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
 
+STATD_PATH="/var/lib/nfs/statd"
+
 # Defaults
 OCF_RESKEY_unlock_on_stop_default=1
 OCF_RESKEY_wait_for_leasetime_on_stop_default=0
 OCF_RESKEY_rmtab_backup_default=".rmtab"
+OCF_RESKEY_merge_notify_list_default=0
+OCF_RESKEY_state_subdir_default=".clumanager"
 
 : ${OCF_RESKEY_unlock_on_stop=${OCF_RESKEY_unlock_on_stop_default}}
 : ${OCF_RESKEY_wait_for_leasetime_on_stop=${OCF_RESKEY_wait_for_leasetime_on_stop_default}}
 : ${OCF_RESKEY_rmtab_backup=${OCF_RESKEY_rmtab_backup_default}}
+: ${OCF_RESKEY_merge_notify_list=${OCF_RESKEY_merge_notify_list_default}}
+: ${OCF_RESKEY_state_subdir=${OCF_RESKEY_state_subdir_default}}
 #######################################################################
 
 exportfs_meta_data() {
@@ -149,6 +155,33 @@ Location of the rmtab backup, relative to directory.
 </shortdesc>
 <content type="string" default="${OCF_RESKEY_rmtab_backup_default}" />
 </parameter>
+
+<parameter name="merge_notify_list" unique="0" required="0">
+<longdesc lang="en">
+In a multi-server configuration it is necessary to run rpc.statd with
+an HA callout.  Setting merge_notify_list to true will cause the contents
+of the hidden directory created on each export by the HA callout to be
+merged into /var/lib/nfs/statd/sm upon failover.  This is necessary so
+the correct clients are notified to reclaim their locks.
+</longdesc>
+<shortdesc lang="en">
+Merge notify list?
+</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_merge_notify_list_default}" />
+</parameter>
+
+<parameter name="state_subdir">
+<longdesc lang="en">
+The name of the hidden subdirectory used by rpc.statd's HA callout to
+share information about monitored clients.  This parameter is only
+meaningful if merge_notify_list is set to true.
+</longdesc>
+<shortdesc lang="en">
+Location of the state subdirectory, relative to directory.
+</shortdesc>
+<content type="string" default="${OCF_RESKEY_state_subdir_default}" />
+</parameter>
+
 </parameters>
 
 <actions>
@@ -311,6 +344,28 @@ export_one() {
 	ocf_log info "directory $dir exported"
 	return $OCF_SUCCESS
 }
+
+merge_notify_list()
+{
+	local dir=$1
+	local subdir=${OCF_RESKEY_state_subdir}
+
+	if [ ! -d $dir/$subdir/statd ]; then
+		mkdir -p $dir/$subdir/statd/sm
+		chown -R rpcuser.rpcuser $dir/$subdir/statd
+	fi
+	if selinuxenabled; then
+		if [ $(ls -ldZ $STATD_PATH | awk '{ print NF }') -gt 5 ]; then
+			SELINUX_LABEL="$(ls -ldZ $STATD_PATH | cut -f5 -d' ')"
+		else
+			SELINUX_LABEL="$(ls -ldZ $STATD_PATH | cut -f4 -d' ')"
+		fi
+		chcon -R $SELINUX_LABEL $dir/$subdir/statd
+	fi
+	cp -Rdpf $dir/$subdir/statd/sm/* $STATD_PATH/sm
+	return 0
+}
+
 exportfs_start ()
 {
 	if exportfs_monitor; then
@@ -325,6 +380,10 @@ exportfs_start ()
 	# Restore the rmtab to ensure smooth NFS-over-TCP failover
 	if [ ${OCF_RESKEY_rmtab_backup} != "none" ]; then
 		forall restore_rmtab
+	fi
+
+	if ocf_is_true ${OCF_RESKEY_merge_notify_list}; then
+		forall merge_notify_list
 	fi
 }
 

--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -354,7 +354,10 @@ merge_notify_list()
 		mkdir -p $dir/$subdir/statd/sm
 		chown -R rpcuser.rpcuser $dir/$subdir/statd
 	fi
-	if selinuxenabled; then
+
+	which restorecon > /dev/null 2>&1 && selinuxenabled
+	SELINUX_ENABLED=$?
+	if [ $SELINUX_ENABLED -eq 0 ]; then
 		if [ $(ls -ldZ $STATD_PATH | awk '{ print NF }') -gt 5 ]; then
 			SELINUX_LABEL="$(ls -ldZ $STATD_PATH | cut -f5 -d' ')"
 		else

--- a/heartbeat/nfsnotify
+++ b/heartbeat/nfsnotify
@@ -193,7 +193,7 @@ copy_statd()
 		mkdir -p "$dest"
 	fi
 
-	cp -rpfn $src/sm $src/sm.bak $src/state $dest > /dev/null 2>&1
+	cp -rpf $src/sm $src/sm.bak $src/state $dest > /dev/null 2>&1
 
 	# make sure folder ownership and selinux lables stay consistent
 	[ -n "`id -u rpcuser`" -a "`id -g rpcuser`" ] && chown rpcuser.rpcuser "$dest"

--- a/heartbeat/nfsnotify
+++ b/heartbeat/nfsnotify
@@ -45,6 +45,9 @@ HA_STATD_PIDFILE_PREV="$NFSNOTIFY_TMP_DIR/rpc.statd_${OCF_RESOURCE_INSTANCE}.pid
 STATD_PATH="/var/lib/nfs/statd"
 SM_NOTIFY_BINARY="${sbindir}/sm-notify"
 IS_RENOTIFY=0
+OCF_RESKEY_start_grace_default=0
+
+: ${OCF_RESKEY_start_grace=${OCF_RESKEY_start_grace_default}}
 
 meta_data() {
 	cat <<END
@@ -81,6 +84,21 @@ arguments.
 </longdesc>
 <shortdesc lang="en">sm-notify arguments</shortdesc>
 <content type="string" default="false" />
+</parameter>
+
+<parameter name="start_grace" unique="0" required="0">
+<longdesc lang="en">
+If set to true, this will trigger a grace period before calling sm-notify,
+allowing the notified clients to reclaim their locks.  If you are running
+a multi-server configuration (where the nfs daemon is a clone resource or
+perhaps not even managed by the cluster) then this should be set to true.
+If you are running a single-server configuration (where the nfs daemon and
+all of the exports move as a single unit) then this should be set to false.
+</longdesc>
+<shortdesc lang="en">
+Trigger grace period before calling sm-notify?
+</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_start_grace_default}" />
 </parameter>
 
 </parameters>
@@ -233,6 +251,11 @@ v3notify_start()
 
 	statd_backup="$STATD_PATH/nfsnotify.bu"
 	copy_statd "$STATD_PATH" "$statd_backup"
+
+	if ocf_is_true ${OCF_RESKEY_start_grace}; then
+		pkill -KILL -x lockd
+		is_renotify=0
+	fi
 
 	if [ -z "$OCF_RESKEY_source_host" ]; then
 		if [ "$is_renotify" -eq 0 ]; then

--- a/heartbeat/nfsnotify
+++ b/heartbeat/nfsnotify
@@ -297,7 +297,11 @@ esac
 which restorecon > /dev/null 2>&1 && selinuxenabled
 SELINUX_ENABLED=$?
 if [ $SELINUX_ENABLED -eq 0 ]; then
-	export SELINUX_LABEL="$(ls -ldZ $STATD_PATH | cut -f4 -d' ')"
+	if [ $(ls -ldZ $STATD_PATH | awk '{ print NF }') -gt 5 ]; then
+		export SELINUX_LABEL="$(ls -ldZ $STATD_PATH | cut -f5 -d' ')"
+	else
+		export SELINUX_LABEL="$(ls -ldZ $STATD_PATH | cut -f4 -d' ')"
+	fi
 fi
 
 case $__OCF_ACTION in

--- a/heartbeat/nfsnotify
+++ b/heartbeat/nfsnotify
@@ -276,6 +276,9 @@ v3notify_start()
 	# do sm-notify for each ip
 	for ip in `echo ${OCF_RESKEY_source_host} | sed 's/,/ /g'`; do
 
+		# don't bother if we don't actually have the ip
+		$IP2UTIL addr show | grep -q $ip || continue
+
 		# have the first sm-notify use the actual statd directory so the
 		# notify list can be managed properly.
 		if [ "$is_renotify" -eq 0 ]; then


### PR DESCRIPTION
These changes allow NFS clusters to be configured for distributed NFS v3 exports (or more accurately they allow NFS v3 clients to reclaim their locks after the failover of an NFS v3 export on such a cluster).  

In this configuration, the nfsserver and root exportfs resources are configured as clones, and the remaining resources are configured in one or more groups of lvm+fs+export+ip+nfsnotify resources.  

The two main changes are:
1. Upon takeover of an export, it's necessary to merge any data about monitored clients from a hidden directory on the export into the local /var/lib/nfs/statd/sm directory.  This is necessary so that clients who may have had locks on the old node will be notified to reclaim their locks from the new node.  See note below about the creation of those monitor records.
2. Since the nfsserver resource is configured as a clone, then it won't enter a grace period after an individual export is moved, and clients attempting to reclaim locks in response to a notification would receive NFSERR_NO_GRACE.  Sending lockd a kill signal will cause it to drop its locks and and enter a grace period.  The most logical place to do this is right before sending out the notifications.

The other changes are bugfixes.

**Note**:  In order for there to be any monitor records to actually merge, it's necessary to run rpc.statd with an HA callout.  I'm using the clunfslock script from rgmanager with a few minor fixes.  Since rgmanager is no longer maintained (AFAIK) it might be a good idea to include the clunfslock script with the resource-agents.