### PR TITLE
pgsql: fix regex in set async mode

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1479,7 +1479,7 @@ set_async_mode_all() {
 }
 
 set_async_mode() {
-    cat $REP_MODE_CONF |  grep -q -e "[,' ]$1[,' ]"
+    cat $REP_MODE_CONF |  grep -q -E "(\"$1\")|([,' ]$1[,' ])"
     if [ $? -eq 0 ]; then
         ocf_log info "Setup $1 into async mode."
         runasowner -q err "echo \"synchronous_standby_names = ''\" > \"$REP_MODE_CONF\""


### PR DESCRIPTION
This will fix a bug where pgsql resource agent can't switch a node from sync to async mode because of wrong check.
Bug introduced in commit 6e91193