### PR TITLE
pgsql: allow dynamic membership

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -614,6 +614,15 @@ pgsql_real_start() {
         ocf_log debug "PostgreSQL still hasn't started yet. Waiting..."
     done
 
+    # delete replication slots on all nodes. On master node will be created during promotion.
+    if use_replication_slot; then
+        delete_replication_slots
+        if [ $? -eq $OCF_ERR_GENERIC ]; then
+            ocf_exit_reason "PostgreSQL can't clean up replication_slot."
+            return $OCF_ERR_GENERIC
+        fi
+    fi
+
     ocf_log info "PostgreSQL is started."
     return $rc
 }
@@ -678,7 +687,7 @@ pgsql_promote() {
 
     # create replication slots on master before promotion
     if use_replication_slot; then
-        create_replication_slot
+        create_replication_slots
         if [ $? -eq $OCF_ERR_GENERIC ]; then
             ocf_exit_reason "PostgreSQL can't create replication_slot."
             return $OCF_ERR_GENERIC
@@ -1348,7 +1357,34 @@ create_replication_slot_name() {
     echo $replication_slot_name_list
 }
 
-create_replication_slot() {
+delete_replication_slot(){
+    DELETE_REPLICATION_SLOT_sql="SELECT pg_drop_replication_slot('$1');"
+    output=`exec_sql "$DELETE_REPLICATION_SLOT_sql"`
+    return $?
+}
+
+delete_replication_slots() {
+    local replication_slot_name_list
+    local replication_slot_name
+
+    replication_slot_name_list=`create_replication_slot_name`
+    ocf_log debug "replication slot names are $replication_slot_name_list."
+
+    for replication_slot_name in $replication_slot_name_list
+    do
+        if [ `check_replication_slot $replication_slot_name` = "1" ]; then
+            delete_replication_slot $replication_slot_name
+            if [ $? -eq 0 ]; then
+                ocf_log info "PostgreSQL delete the replication slot($replication_slot_name)."
+            else
+                ocf_exit_reason "$output"
+                return $OCF_ERR_GENERIC
+            fi
+        fi
+    done
+}
+
+create_replication_slots() {
     local replication_slot_name
     local replication_slot_name_list
     local output
@@ -1363,11 +1399,8 @@ create_replication_slot() {
     do
         # If the same name slot is already exists, initialize(delete and create) the slot.
         if [ `check_replication_slot $replication_slot_name` = "1" ]; then
-            DELETE_REPLICATION_SLOT_sql="SELECT pg_drop_replication_slot('$replication_slot_name');"
-            output=`exec_sql "$DELETE_REPLICATION_SLOT_sql"`
-            rc=$?
-
-            if [ $rc -eq 0 ]; then
+            delete_replication_slot $replication_slot_name
+            if [ $? -eq 0 ]; then
                 ocf_log info "PostgreSQL delete the replication slot($replication_slot_name)."
             else
                 ocf_exit_reason "$output"

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -299,7 +299,7 @@ It requires master_ip restore_command parameters.
 <parameter name="node_list" unique="0" required="0">
 <longdesc lang="en">
 All node names. Please separate each node name with a space.
-This is required for replication.
+This is optional for replication. Defaults to all nodes in the cluster
 </longdesc>
 <shortdesc lang="en">node list</shortdesc>
 <content type="string" default="${OCF_RESKEY_node_list_default}" />
@@ -615,16 +615,6 @@ pgsql_real_start() {
         ocf_log debug "PostgreSQL still hasn't started yet. Waiting..."
     done
 
-    # create replication slot on the master and slave nodes.
-    # creating slot on the slave node is in preparation for failover.
-    if use_replication_slot; then
-        create_replication_slot
-        if [ $? -eq $OCF_ERR_GENERIC ]; then
-            ocf_exit_reason "PostgreSQL can't create replication_slot."
-            return $OCF_ERR_GENERIC
-        fi
-    fi
-
     ocf_log info "PostgreSQL is started."
     return $rc
 }
@@ -686,6 +676,15 @@ pgsql_promote() {
     ocf_log info "Creating $PGSQL_LOCK."
     touch $PGSQL_LOCK
     show_master_baseline
+
+    # create replication slots on master before promotion
+    if use_replication_slot; then
+        create_replication_slot
+        if [ $? -eq $OCF_ERR_GENERIC ]; then
+            ocf_exit_reason "PostgreSQL can't create replication_slot."
+            return $OCF_ERR_GENERIC
+        fi
+    fi
 
     if ocf_is_true ${OCF_RESKEY_restart_on_promote}; then
         ocf_log info "Restarting PostgreSQL instead of promote."
@@ -1997,7 +1996,12 @@ if is_replication; then
     PGSQL_XLOG_LOC_NAME="${RESOURCE_NAME}-xlog-loc"
     PGSQL_MASTER_BASELINE="${RESOURCE_NAME}-master-baseline"
 
-    NODE_LIST=`echo $OCF_RESKEY_node_list | tr '[A-Z]' '[a-z]'`
+    if [ $(echo $e | wc -w) -eq 0 ]; then
+        # defaulting nodelist to all nodes in the cluster if not specified
+        NODE_LIST=$(crm_node --list | cut -d ' ' -f 2)
+    else
+        NODE_LIST=`echo $OCF_RESKEY_node_list | tr '[A-Z]' '[a-z]'`
+    fi
     RE_CONTROL_SLAVE="false"
 fi
 

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -2019,7 +2019,7 @@ if is_replication; then
     PGSQL_XLOG_LOC_NAME="${RESOURCE_NAME}-xlog-loc"
     PGSQL_MASTER_BASELINE="${RESOURCE_NAME}-master-baseline"
 
-    if [ $(echo $e | wc -w) -eq 0 ]; then
+    if [ $(echo $OCF_RESKEY_node_list | wc -w) -eq 0 ]; then
         # defaulting nodelist to all nodes in the cluster if not specified
         NODE_LIST=$(crm_node --list | cut -d ' ' -f 2)
     else

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -377,8 +377,7 @@ This is optional for replication.
 Set this option when using replication slots.
 Can only use lower case letters, numbers and underscore for replication_slot_name.
 
-When the master node has 1 slave node,one replication slot would be created with the name "replication_slot_name".
-When the master node has 2 or more slave nodes,the replication slots would be created for each node, with the name adding the node name as postfix.
+The replication slots would be created for each node, with the name adding the node name as postfix.
 For example, replication_slot_name is "sample" and 2 slaves which are "node1" and "node2" connect to
 their slots, the slots names are "sample_node1" and "sample_node2".
 If the node name contains a upper case letter, hyphen and dot, those characters will be converted to a lower case letter or an underscore.
@@ -1325,12 +1324,9 @@ create_replication_slot_name() {
         number_of_nodes=`echo $NODE_LIST | wc -w`
     fi
 
-    # If the number of nodes 2 or less, Master node has 1 or less Slave node.
-    # The Master node should have 1 slot for the Slave, which is named "$OCF_RES_KEY_replication_slot_name".
-    if [ $number_of_nodes -le 2 ]; then
-        replication_slot_name_list="$OCF_RESKEY_replication_slot_name"
+    if [ $number_of_nodes -le 0 ]; then
+        replication_slot_name_list=""
 
-    # If the number of nodes 3 or more, the Master has some Slave nodes.
     # The Master node should have some slots equal to the number of Slaves, and
     # the Slave nodes connect to their dedicated slot on the Master.
     # To ensuring that the slots name are each unique, add postfix to $OCF_RESKEY_replication_slot.
@@ -1517,7 +1513,6 @@ reload_conf() {
 }
 
 user_recovery_conf() {
-    local number_of_nodes
     local nodename_tmp
 
     # put archive_cleanup_command and recovery_end_command only when defined by user
@@ -1529,13 +1524,8 @@ user_recovery_conf() {
     fi
 
     if use_replication_slot; then
-        number_of_nodes=`echo $NODE_LIST | wc -w`
-        if [ $number_of_nodes -le 2 ]; then
-            echo "primary_slot_name = '${OCF_RESKEY_replication_slot_name}'"
-        else
-            nodename_tmp=`echo "$NODENAME" | tr 'A-Z.-' 'a-z__'`
-            echo "primary_slot_name = '${OCF_RESKEY_replication_slot_name}_$nodename_tmp'"
-        fi
+        nodename_tmp=`echo "$NODENAME" | tr 'A-Z.-' 'a-z__'`
+        echo "primary_slot_name = '${OCF_RESKEY_replication_slot_name}_$nodename_tmp'"
     fi
 }
 


### PR DESCRIPTION
You can now add new nodes to the cluster and they will be automatically included in the resource management.
Allowing to specify parameter node_list in the resource creation to keep compatibility with older version.

changes:
- node_list parameter is now optional: if not specified nodes list is asked to cluster itself
- replication slots are created on master during promotion rather than on all nodes during resource's starting
- RA only use qualified replication slot
