### PR TITLE
Refactor ocf-shellfuncs.in/ocf_run

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -438,15 +438,15 @@ ocf_run() {
 	    if [ "$verbose" -a ! -z "$output" ]; then
 		ocf_log info "$output"
 	    fi
-	    return $OCF_SUCCESS
 	else
 	    if [ ! -z "$output" ]; then
 		ocf_log $loglevel "$output"
 	    else
 		ocf_log $loglevel "command failed: $*"
 	    fi
-	    return $rc
 	fi
+
+	return $rc
 }
 
 ocf_pidfile_status() {


### PR DESCRIPTION
When calling `ocf_run` people expect that the function returns with the
exit status of the subprocess. In case of 0 exit code we returned
$OCF_SUCCESS which is 0 as well, but that doesn't read well. Refactoring
the return statements, so it is evident that the function always returns
with the exit code of the subprocess.