### PR TITLE
systemd: add resource-agents-deps target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,7 @@ RGMANAGER = with
 endif
 
 if BUILD_LINUX_HA
-SUBDIRS	+= include heartbeat tools ldirectord doc
+SUBDIRS	+= include heartbeat tools ldirectord doc systemd
 LINUX_HA = without
 else
 LINUX_HA = with

--- a/configure.ac
+++ b/configure.ac
@@ -864,6 +864,7 @@ heartbeat/Makefile						\
    heartbeat/ocf-directories					\
    heartbeat/ocf-shellfuncs					\
    heartbeat/shellfuncs						\
+systemd/Makefile						\
 tools/Makefile							\
    tools/ocf-tester						\
    tools/ocft/Makefile						\

--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -426,6 +426,12 @@ LVM_start() {
 	local vg=$1
 	local clvmd=0
 
+	# systemd drop-in to stop process before storage services during
+	# shutdown/reboot
+	if ps -p 1 | grep -q systemd ; then
+		systemd_drop_in "99-LVM" "After" "blk-availability.service"
+	fi
+
 	# TODO: This MUST run vgimport as well
 	ocf_log info "Activating volume group $vg"
 	if [ "$LVM_MAJOR" -eq "1" ]; then

--- a/heartbeat/clvm
+++ b/heartbeat/clvm
@@ -361,6 +361,12 @@ clvmd_start()
 		return $?
 	fi
 
+	# systemd drop-in to stop process before storage services during
+	# shutdown/reboot
+	if ps -p 1 | grep -q systemd ; then
+		systemd_drop_in "99-clvmd" "After" "blk-availability.service"
+	fi
+
 	clvmd_status
 	if [ $? -eq $OCF_SUCCESS ]; then
 		ocf_log debug "$DAEMON already started"

--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -606,6 +606,22 @@ dirname()
 	return 0
 }
 
+# usage: systemd_drop_in <name> <After|Before> <dependency.service>
+systemd_drop_in()
+{
+	if [ $# -ne 3 ]; then
+          ocf_log err "Incorrect number of arguments [$#] for systemd_drop_in."
+        fi
+
+	systemdrundir="/run/systemd/system/resource-agents-deps.target.d"
+	mkdir "$systemdrundir"
+	cat > "$systemdrundir/$1.conf" <<EOF
+[Unit]
+$2=$3
+EOF
+	systemctl daemon-reload
+}
+
 #
 # pseudo_resource status tracking function...
 #

--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -253,6 +253,10 @@ rm -rf %{buildroot}
 /usr/lib/ocf/resource.d/redhat
 %endif
 
+%if %{defined _unitdir}
+%{_unitdir}/resource-agents-deps.target
+%endif
+
 %dir %{_datadir}/%{name}
 %dir %{_datadir}/%{name}/ocft
 %{_datadir}/%{name}/ocft/configs

--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2017 Oyvind Albrigtsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#
+
+MAINTAINERCLEANFILES    = Makefile.in
+
+if HAVE_SYSTEMD
+dist_systemdsystemunit_DATA = resource-agents-deps.target
+endif

--- a/systemd/resource-agents-deps.target
+++ b/systemd/resource-agents-deps.target
@@ -1,0 +1,2 @@
+[Unit]
+Description=resource-agents dependencies


### PR DESCRIPTION
clvmd and LVM will create drop-ins on start to avoid nodes being fence during shutdown or reboot.