### PR TITLE
Make ocf_is_ver() handle dist. specific versions

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -511,7 +511,7 @@ ocf_is_ms() {
 # letters and such are effectively ignored
 #
 ocf_is_ver() {
-	echo $1 | grep '^[0-9][0-9.-]*[0-9]$' >/dev/null 2>&1
+	echo $1 | grep '^[0-9][0-9.-]*[0-9]' >/dev/null 2>&1
 }
 ocf_ver2num() {
 	echo $1 | awk -F'[.-]' '


### PR DESCRIPTION
Comment on this function says letters are ignored, but that was not the case. 
For example: 1.1.14-8.el6_8.1