### PR TITLE
LVM: use vgscan --cache to update metadata during start/relocate

### DIFF
--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -431,7 +431,7 @@ LVM_start() {
 	if [ "$LVM_MAJOR" -eq "1" ]; then
 		ocf_run vgscan $vg
 	else
-		ocf_run vgscan
+		ocf_run vgscan --cache
 	fi
 
 	case $(get_vg_mode) in


### PR DESCRIPTION
--cache is not available for LVM 1.x.