### PR TITLE
[rabbitmq] Typo fix

### DIFF
--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -455,7 +455,7 @@ rmq_stop() {
 					{'EXIT', _} -> [];
 					Any -> Any
 				end,
-				Result /= [] andalso file:write_file(Filename, io_lib:fwrite(\"~p.~n\", [RuntimeParams]))
+				Result /= [] andalso file:write_file(Filename, io_lib:fwrite(\"~p.~n\", [Result]))
 			end,
 
 			%% Backup users


### PR DESCRIPTION
Unfortunately we introduced a regression with commit
1f57e26816d8148e0c77ff7573457b8d2599bf8b. This patch addresses it and
fixes #982.

Thanks @seabres for the heads up.

Signed-off-by: Peter Lemenkov <lemenkov@redhat.com>