### PR TITLE
fs.sh: fix builds when srcdir and builddir are seperated

### DIFF
--- a/rgmanager/src/resources/Makefile.am
+++ b/rgmanager/src/resources/Makefile.am
@@ -68,7 +68,7 @@ rngdir			= ${CLUSTERDATA}/relaxng
 rng_DATA		= $(DTD) $(XSL) $(RESRNG)
 
 $(TARGET):
-	cat $@.in | sed \
+	cat $(abs_srcdir)/$@.in | sed \
 		-e 's#@''LOGDIR@#${LOGDIR}#g' \
 	> $@.out
 	chmod +x $@.out


### PR DESCRIPTION
It fails to find fs.sh.in when srddir and builddir are not the same:

make[5]: Entering directory '/path/to/builddir/rgmanager/src/resources'
cat fs.sh.in | sed \
    -e 's#@''LOGDIR@#/var/log/cluster#g' \
    > fs.sh.out
    cat: fs.sh.in: No such file or directorychmod +x fs.sh.out
    mv fs.sh.out fs.sh

Add abs_srcdir to fix this.

Signed-off-by: Jackie Huang <jackie.huang@windriver.com>