### PR TITLE
Add support for LIO-T SCSI tpu,3pc and caw emulation attributes

### DIFF
--- a/heartbeat/iSCSILogicalUnit
+++ b/heartbeat/iSCSILogicalUnit
@@ -147,6 +147,33 @@ The default is a hash of the resource name, truncated to 8 bytes.
 <content type="string" default="${OCF_RESKEY_scsi_sn_default}"/>
 </parameter>
 
+<parameter name="emulate_tpu" required="0" unique="0">
+<longdesc lang="en">
+The SCSI UNMAP command to be configured for this Logical Unit.
+Setting this integer to 1 will enable TPU IOCTL emulation.
+</longdesc>
+<shortdesc lang="en">SCSI UNMAP (for TRIM / DISCARD)</shortdesc>
+<content type="integer" />
+</parameter>
+
+<parameter name="emulate_3pc" required="0" unique="0">
+<longdesc lang="en">
+The SCSI EXTENDED COPY command to be configured for this Logical Unit.
+Setting this integer to 1 will enable 3PC IOCTL emulation.
+</longdesc>
+<shortdesc lang="en">SCSI extended write</shortdesc>
+<content type="integer" />
+</parameter>
+
+<parameter name="emulate_caw" required="0" unique="0">
+<longdesc lang="en">
+The SCSI Compare and Write command to be configured for this Logical Unit.
+Setting this integer to 1 will enable CAW IOCTL emulation.
+</longdesc>
+<shortdesc lang="en">SCSI compare and write</shortdesc>
+<content type="integer" />
+</parameter>
+
 <parameter name="vendor_id" required="0" unique="0">
 <longdesc lang="en">
 The SCSI vendor ID to be configured for this Logical Unit.
@@ -375,6 +402,7 @@ iSCSILogicalUnit_start() {
 	lio-t)
 		ocf_take_lock $TARGETLOCKFILE
 		ocf_release_lock_on_exit $TARGETLOCKFILE
+		iblock_attrib_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/attrib"
 		# For lio, we first have to create a target device, then
 		# add it to the Target Portal Group as an LU.
 		ocf_run targetcli /backstores/block create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
@@ -393,6 +421,16 @@ iSCSILogicalUnit_start() {
 				ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls create ${initiator} add_mapped_luns=False || exit $OCF_ERR_GENERIC
 				ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/acls/${initiator} create ${OCF_RESKEY_lun} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
 			done
+		fi
+
+		if [ -n "${OCF_RESKEY_emulate_tpu}" ]; then
+			echo ${OCF_RESKEY_emulate_tpu} > ${iblock_attrib_path}/emulate_tpu || exit $OCF_ERR_GENERIC
+		fi
+		if [ -n "${OCF_RESKEY_emulate_3pc}" ]; then
+			echo ${OCF_RESKEY_emulate_3pc} > ${iblock_attrib_path}/emulate_3pc || exit $OCF_ERR_GENERIC
+		fi
+		if [ -n "${OCF_RESKEY_emulate_caw}" ]; then
+			echo ${OCF_RESKEY_emulate_caw} > ${iblock_attrib_path}/emulate_caw || exit $OCF_ERR_GENERIC
 		fi
 		;;
 	esac
@@ -605,13 +643,13 @@ iSCSILogicalUnit_validate() {
 	iet)
 		# IET does not support setting the vendor and product ID
 		# (it always uses "IET" and "VIRTUAL-DISK")
-		unsupported_params="vendor_id product_id allowed_initiators lio_iblock tgt_bstype tgt_bsoflags tgt_bsopts tgt_device_type"
+		unsupported_params="vendor_id product_id allowed_initiators lio_iblock tgt_bstype tgt_bsoflags tgt_bsopts tgt_device_type emulate_tpu emulate_3pc emulate_caw"
 		;;
 	tgt)
-		unsupported_params="allowed_initiators lio_iblock"
+		unsupported_params="allowed_initiators lio_iblock emulate_tpu emulate_3pc emulate_caw"
 		;;
 	lio)
-		unsupported_params="scsi_id vendor_id product_id tgt_bstype tgt_bsoflags tgt_bsopts tgt_device_type"
+		unsupported_params="scsi_id vendor_id product_id tgt_bstype tgt_bsoflags tgt_bsopts tgt_device_type emulate_tpu emulate_3pc emulate_caw"
 		;;
 	lio-t)
 		unsupported_params="scsi_id vendor_id product_id tgt_bstype tgt_bsoflags tgt_bsopts tgt_device_type lio_iblock"


### PR DESCRIPTION
Fixes #610 

Ideally I'd make it work for all iSCSI subsystems that can support them, but that's a bit beyond the time I'm currently able spend on.