### PR TITLE
rabbitmq-cluster: typo fix

### DIFF
--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -398,7 +398,7 @@ rmq_start() {
 				case file:consult(Filename) of
 					{error, _} ->
 						ok;
-					{ok, [Result]) ->
+					{ok, [Result]} ->
 						lists:foreach(fun(X) -> mnesia:dirty_write(Table, PostprocessFun(X)) end, Result),
 						file:delete(Filename)
 				end


### PR DESCRIPTION
fix a small typo which causes errors in corosync.log e.g.
Jun 08 09:00:14 [6504] overcloud-controller-1.localdomain       lrmd:   notice: operation_finished:     rabbitmq_start_0:7504:stderr [ Error: syntax error before: ')' ]