### PR TITLE
sapdb.sh: add nameserver to the HANA default monitor services

### DIFF
--- a/heartbeat/sapdb.sh
+++ b/heartbeat/sapdb.sh
@@ -360,7 +360,7 @@ then
          ;;
     SYB) export OCF_RESKEY_MONITOR_SERVICES="Server"
          ;;
-    HDB) export OCF_RESKEY_MONITOR_SERVICES="hdbindexserver"
+    HDB) export OCF_RESKEY_MONITOR_SERVICES="hdbindexserver|hdbnameserver"
          ;;
   esac
 fi


### PR DESCRIPTION
We found that only monitoring '**hdbindexserver**' on many SAP HANA installations you get during the resource start, because SAPDatabase does not find any service to be monitored. A workaround is to set  **MONITOR_SERVICES="hdbindexserver|hdbnameserver"**. The proposed change will take the monitoring of the indexserver OR nameserver as **default**.