### PR TITLE
Properly Detect read_only State

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -324,7 +324,7 @@ get_read_only() {
     local read_only_state
 
     read_only_state=`$MYSQL $MYSQL_OPTIONS_REPL \
-        -e "SHOW VARIABLES" | grep -w read_only | awk '{print $2}'`
+        --skip-column-names -e "SHOW VARIABLES LIKE 'read_only'" | awk '{print $2}'`
 
     if [ "$read_only_state" = "ON" ]; then
         return 0


### PR DESCRIPTION
Many MySQL system variables include "read_only" in their names. Use a
stricter query in get_read_only() to ensure that the value of read_only
is obtained, not innodb_read_only, tx_read_only, or some other
similarly-named variable.