### PR TITLE
Medium: Raid1: Handle case when mddev is a symlink

### DIFF
--- a/heartbeat/Raid1
+++ b/heartbeat/Raid1
@@ -371,7 +371,6 @@ raid1_monitor_one() {
 			return $OCF_NOT_RUNNING
 		fi
 	fi
-
 	if ! grep -e "^$md[ \t:]" /proc/mdstat >/dev/null ; then
 		ocf_log info "$md not found in /proc/mdstat"
 		return $OCF_NOT_RUNNING

--- a/heartbeat/Raid1
+++ b/heartbeat/Raid1
@@ -353,17 +353,25 @@ raid1_stop() {
 #
 raid1_monitor_one() {
 	local mddev=$1
-	local md=`echo $mddev | sed 's,/dev/,,'`
+	local md=
 	local rc
 	local TRY_READD=0
 	local pbsize
+
 	# check if the md device exists first
 	# but not if we are in the stop operation
 	# device existence is important only for the running arrays
-	if [ "$__OCF_ACTION" != "stop" -a ! -b $mddev ]; then
-		ocf_log info "$mddev is not a block device"
-		return $OCF_NOT_RUNNING
+	if [ "$__OCF_ACTION" != "stop" ]; then
+		if [ -h "$mddev" ]; then
+			md=$(ls $mddev -l | awk -F'/' '{print $NF}')
+		elif [ -b "$mddev" ]; then
+			md=$(echo $mddev | sed 's,/dev/,,')
+		else
+			ocf_log info "$mddev is not a block device"
+			return $OCF_NOT_RUNNING
+		fi
 	fi
+
 	if ! grep -e "^$md[ \t:]" /proc/mdstat >/dev/null ; then
 		ocf_log info "$md not found in /proc/mdstat"
 		return $OCF_NOT_RUNNING


### PR DESCRIPTION
from mdadm rule, it would create a symlink to /dev/md(default as 127, likely used "int name--" until find a valid number) if user specify cluster-md name like /dev/md/xxxx, thus the function raid1_monitor_one() should parse whether or not the $mddev is a symlink.