### PR TITLE
Low: sg_persist: Read empty value when when no attribute exists

### DIFF
--- a/heartbeat/sg_persist
+++ b/heartbeat/sg_persist
@@ -415,10 +415,10 @@ sg_persist_action_stop() {
 
 sg_persist_action_monitor() {
 
-    ACT_MASTER_SCORE=`$MASTER_SCORE_ATTRIBUTE --query --quiet 2>&1`
+    ACT_MASTER_SCORE=`$MASTER_SCORE_ATTRIBUTE --query --quiet 2>/dev/null`
     ocf_log debug "$RESOURCE monitor: ACT_MASTER_SCORE=$ACT_MASTER_SCORE"
     
-    ACT_PENDING=`$PENDING_ATTRIBUTE --query --quiet 2>&1`
+    ACT_PENDING=`$PENDING_ATTRIBUTE --query --quiet 2>/dev/null`
     ocf_log debug "$RESOURCE monitor: ACT_PENDING=$ACT_PENDING"
 
     sg_persist_parse_act_pending


### PR DESCRIPTION
bsc#1048288

Tested on local cluster, happens only when in probe monitor operations.