### PR TITLE
Prevent outdated/broken mysql slave being promoted as master

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -524,28 +524,10 @@ check_slave() {
 	fi
 
 	if ocf_is_true $OCF_RESKEY_evict_outdated_slaves; then
-		# We're supposed to bail out if we lag too far
-		# behind. Let's check our lag.
+		# We're supposed to bail out if we lag too far behind. Let's check our lag.
 		if [ "$Seconds_Behind_Master" = "NULL" ] || [ $Seconds_Behind_Master -gt $OCF_RESKEY_max_slave_lag ]; then
-			ocf_exit_reason "MySQL Slave is $Seconds_Behind_Master seconds behind master (allowed maximum: $OCF_RESKEY_max_slave_lag)."
-			ocf_log err "See $tmpfile for details"
-
-			# Remove reader vip
-			set_reader_attr 0
-
-			exit $OCF_ERR_INSTALLED
+			quit_on_error "Replication failed max_slave_lag: $OCF_RESKEY_max_slave_lag current_lag: $Seconds_Behind_Master" $OCF_ERR_INSTALLED
 		fi
-	elif ocf_is_ms; then
-		# Even if we're not set to evict lagging slaves, we can
-		# still use the seconds behind master value to set our
-		# master preference.
-		local master_pref
-		master_pref=$((${OCF_RESKEY_max_slave_lag}-${Seconds_Behind_Master}))
-		if [ $master_pref -lt 0 ]; then
-			# Sanitize a below-zero preference to just zero
-			master_pref=0
-		fi
-		$CRM_MASTER -v $master_pref
 	fi
 
 	# is the slave ok to have a VIP on it
@@ -555,8 +537,22 @@ check_slave() {
 		set_reader_attr 1
 	fi
 
+	# Even if we're not set to evict lagging slaves, we can still use the seconds behind master value to set our master preference.
+	local master_pref
+	master_pref=$((${OCF_RESKEY_max_slave_lag}-${Seconds_Behind_Master}))
+	if [ $master_pref -lt 0 ]; then
+		# Sanitize a below-zero preference to just zero
+		master_pref=0
+	fi
+
+	ocf_log debug "check_slave setting master preference to $master_pref via $CRM_MASTER -v $master_pref"
+	$CRM_MASTER -v $master_pref
+
 	ocf_log debug "MySQL instance running as a replication slave"
+
 	rm -f $tmpfile
+
+	return $OCF_SUCCESS
 }
 
 set_master() {

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -46,6 +46,7 @@
 #   OCF_RESKEY_evict_outdated_slaves
 #   OCF_RESKEY_reader_attribute
 #   OCF_RESKEY_mysql_master_lock_file
+#   OCF_RESKEY_ensure_follow_correct_master
 
 #######################################################################
 # Initialization:
@@ -299,6 +300,18 @@ is a running MySQL master. Usefull for external script.</shortdesc>
 <content type="string" default="${OCF_RESKEY_mysql_master_lock_file_default}" />
 </parameter>
 </parameters>
+
+<parameter name="ensure_follow_correct_master" unique="0" required="0">
+<longdesc lang="en">
+If set to true, we will double-check that current master host set on slave matches
+the master host which is elected by the crm. If replication was setup by ip
+this might return false positives. That's why default is false.
+</longdesc>
+<shortdesc lang="en">On slave disconnect check if slave is following correct master
+before START SLAVE is attempted.
+</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_ensure_follow_correct_master_default}" />
+</parameter>
 
 <actions>
 <action name="start" timeout="120" />

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -969,7 +969,7 @@ mysql_notify() {
 		'pre-demote')
 			demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
 			if [ $demote_host = ${NODENAME} ]; then
-				ocf_log info "post-demote notification for $demote_host"
+				ocf_log info "pre-demote notification for $demote_host"
 
                 ocf_log info "pre-demote Removing custom replication master marker."
                 rm -f "${OCF_RESKEY_mysql_master_lock_file}"
@@ -993,7 +993,7 @@ mysql_notify() {
 						-e "KILL ${thread}"
 				done
 			else
-			   ocf_log info "Ignoring post-demote notification execpt for my own demotion."
+			   ocf_log info "Ignoring pre-demote notification execpt for my own demotion."
 			fi
 			return $OCF_SUCCESS
 		;;

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -479,20 +479,22 @@ check_slave() {
 		quit_on_error "MYSQL_TOO_MANY_CONN_ERR ($MYSQL_TOO_MANY_CONN_ERR) ... check succeeded but node not suitable for failover/reader vip" 0
 	fi
 
-	# Did we receive an error other than max_connections?
-	if [ $Last_Errno -ne 0 -a $Last_Errno -ne "$MYSQL_TOO_MANY_CONN_ERR" ]; then
-		# Whoa. Replication ran into an error. This slave has
-		# diverged from its master. Make sure this resource
-		# doesn't restart in place.
-		ocf_exit_reason "MySQL instance configured for replication, but replication has failed."
-		ocf_log err "See $tmpfile for details"
-
-		# Just pull the reader VIP away, killing MySQL here would be pretty evil
-		# on a loaded server
-
-		set_reader_attr 0
-		exit $OCF_SUCCESS
-
+	# If any of these is set, non-blank and non-zero (0) replication ran into a serious issue and slave can NOT be trusted anymore to be suitable for
+	# - up2date readable vip
+	# - slave that can be elected as master
+	# If we promote such slave there is a huge chance of data loss. That's why we better:
+	# - remove read vip
+	# - remove master score
+	# - fail the check
+	if [ "${Last_SQL_Error}" != "" ] || [ "${Last_SQL_Errno}" != "0" ]; then
+		quit_on_error "Replication failed Last_SQL_Errno: $Last_SQL_Errno Last_SQL_Error: $Last_SQL_Error" $OCF_ERR_GENERIC
+	fi
+	if [ "${Last_IO_Error}" != "" ] || [ "${Last_IO_Errno}" != "0" ]; then
+		quit_on_error "Replication failed Last_IO_Errno: $Last_IO_Errno Last_IO_Error: $Last_IO_Error" $OCF_ERR_GENERIC
+	fi
+	if [ "${Last_Error}" != "" ] || [ "${Last_Errno}" != "0" ]; then
+		# Did we receive an error other than max_connections?
+		quit_on_error "Replication failed Last_Errno: $Last_Errno Last_Error: $Last_Error" $OCF_ERR_GENERIC
 	fi
 
 	if [ "$Slave_IO_Running" != 'Yes' ]; then

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -957,7 +957,7 @@ mysql_notify() {
 			master_host=`echo $OCF_RESKEY_CRM_meta_notify_promote_uname|tr -d " "`
 			if [ "$master_host" = ${NODENAME} ]; then
 				ocf_log info "This will be the new master, ignoring post-promote notification."
-                touch "${OCF_RESKEY_mysql_master_lock_file}"
+				touch "${OCF_RESKEY_mysql_master_lock_file}"
 			else
 				ocf_log info "Resetting replication"
 				unset_master
@@ -984,9 +984,9 @@ mysql_notify() {
 			if [ $demote_host = ${NODENAME} ]; then
 				ocf_log info "pre-demote notification for $demote_host"
 
-                ocf_log info "pre-demote Removing custom replication master marker."
-                rm -f "${OCF_RESKEY_mysql_master_lock_file}"
-                
+				ocf_log info "pre-demote Removing custom replication master marker."
+				rm -f "${OCF_RESKEY_mysql_master_lock_file}"
+				
 				set_read_only on
 				if [ $? -ne 0 ]; then
 					ocf_exit_reason "Failed to set read-only";

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -465,100 +465,7 @@ check_slave() {
 	get_slave_info
 	rc=$?
 
-	if [ $rc -eq 0 ]; then
-		# Did we receive an error other than max_connections?
-		if [ $Last_Errno -ne 0 -a $Last_Errno -ne "$MYSQL_TOO_MANY_CONN_ERR" ]; then
-			# Whoa. Replication ran into an error. This slave has
-			# diverged from its master. Make sure this resource
-			# doesn't restart in place.
-			ocf_exit_reason "MySQL instance configured for replication, but replication has failed."
-			ocf_log err "See $tmpfile for details"
-
-			# Just pull the reader VIP away, killing MySQL here would be pretty evil
-			# on a loaded server
-
-			set_reader_attr 0
-			exit $OCF_SUCCESS
-
-		fi
-
-		# If we got max_connections, let's remove the vip
-		if [ $Last_Errno -eq "$MYSQL_TOO_MANY_CONN_ERR" ]; then
-			set_reader_attr 0
-			exit $OCF_SUCCESS
-		fi
-
-		if [ "$Slave_IO_Running" != 'Yes' ]; then
-			# Not necessarily a bad thing. The master may have
-			# temporarily shut down, and the slave may just be
-			# reconnecting. A warning can't hurt, though.
-			ocf_log warn "MySQL Slave IO threads currently not running."
-
-			# Sanity check, are we at least on the right master
-			new_master=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f1`
-
-			if [ "$master_host" != "$new_master" ]; then
-			   # Not pointing to the right master, not good, removing the VIPs
-			   set_reader_attr 0
-
-			   exit $OCF_SUCCESS
-			fi
-
-		fi
-
-		if [ "$Slave_SQL_Running" != 'Yes' ]; then
-			# We don't have a replication SQL thread running. Not a
-			# good thing. Try to recoved by restarting the SQL thread
-			# and remove reader vip.  Prevent MySQL restart.
-			ocf_exit_reason "MySQL Slave SQL threads currently not running."
-			ocf_log err "See $tmpfile for details"
-
-			# Remove reader vip
-			set_reader_attr 0
-
-			# try to restart slave
-			ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-				-e "START SLAVE"
-
-			# Return success to prevent a restart
-			exit $OCF_SUCCESS
-		fi
-
-		if ocf_is_true $OCF_RESKEY_evict_outdated_slaves; then
-			# We're supposed to bail out if we lag too far
-			# behind. Let's check our lag.
-			if [ "$Seconds_Behind_Master" = "NULL" ] || [ $Seconds_Behind_Master -gt $OCF_RESKEY_max_slave_lag ]; then
-				ocf_exit_reason "MySQL Slave is $Seconds_Behind_Master seconds behind master (allowed maximum: $OCF_RESKEY_max_slave_lag)."
-				ocf_log err "See $tmpfile for details"
-
-				# Remove reader vip
-				set_reader_attr 0
-
-				exit $OCF_ERR_INSTALLED
-			fi
-		elif ocf_is_ms; then
-			# Even if we're not set to evict lagging slaves, we can
-			# still use the seconds behind master value to set our
-			# master preference.
-			local master_pref
-			master_pref=$((${OCF_RESKEY_max_slave_lag}-${Seconds_Behind_Master}))
-			if [ $master_pref -lt 0 ]; then
-				# Sanitize a below-zero preference to just zero
-				master_pref=0
-			fi
-			$CRM_MASTER -v $master_pref
-		fi
-
-		# is the slave ok to have a VIP on it
-		if [ "$Seconds_Behind_Master" = "NULL" ] || [ $Seconds_Behind_Master -gt $OCF_RESKEY_max_slave_lag ]; then
-			set_reader_attr 0
-		else
-			set_reader_attr 1
-		fi
-
-		ocf_log debug "MySQL instance running as a replication slave"
-		rm -f $tmpfile
-	else
+	if [ $rc -ne 0 ]; then
 		# Instance produced an empty "SHOW SLAVE STATUS" output --
 		# instance is not a slave
 		# TODO: Needs to handle when get_slave_info will return too many connections error
@@ -566,6 +473,99 @@ check_slave() {
 		ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
 		exit $OCF_ERR_GENERIC
 	fi
+
+	# Did we receive an error other than max_connections?
+	if [ $Last_Errno -ne 0 -a $Last_Errno -ne "$MYSQL_TOO_MANY_CONN_ERR" ]; then
+		# Whoa. Replication ran into an error. This slave has
+		# diverged from its master. Make sure this resource
+		# doesn't restart in place.
+		ocf_exit_reason "MySQL instance configured for replication, but replication has failed."
+		ocf_log err "See $tmpfile for details"
+
+		# Just pull the reader VIP away, killing MySQL here would be pretty evil
+		# on a loaded server
+
+		set_reader_attr 0
+		exit $OCF_SUCCESS
+
+	fi
+
+	# If we got max_connections, let's remove the vip
+	if [ $Last_Errno -eq "$MYSQL_TOO_MANY_CONN_ERR" ]; then
+		set_reader_attr 0
+		exit $OCF_SUCCESS
+	fi
+
+	if [ "$Slave_IO_Running" != 'Yes' ]; then
+		# Not necessarily a bad thing. The master may have
+		# temporarily shut down, and the slave may just be
+		# reconnecting. A warning can't hurt, though.
+		ocf_log warn "MySQL Slave IO threads currently not running."
+
+		# Sanity check, are we at least on the right master
+		new_master=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f1`
+
+		if [ "$master_host" != "$new_master" ]; then
+		   # Not pointing to the right master, not good, removing the VIPs
+		   set_reader_attr 0
+
+		   exit $OCF_SUCCESS
+		fi
+
+	fi
+
+	if [ "$Slave_SQL_Running" != 'Yes' ]; then
+		# We don't have a replication SQL thread running. Not a
+		# good thing. Try to recoved by restarting the SQL thread
+		# and remove reader vip.  Prevent MySQL restart.
+		ocf_exit_reason "MySQL Slave SQL threads currently not running."
+		ocf_log err "See $tmpfile for details"
+
+		# Remove reader vip
+		set_reader_attr 0
+
+		# try to restart slave
+		ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+			-e "START SLAVE"
+
+		# Return success to prevent a restart
+		exit $OCF_SUCCESS
+	fi
+
+	if ocf_is_true $OCF_RESKEY_evict_outdated_slaves; then
+		# We're supposed to bail out if we lag too far
+		# behind. Let's check our lag.
+		if [ "$Seconds_Behind_Master" = "NULL" ] || [ $Seconds_Behind_Master -gt $OCF_RESKEY_max_slave_lag ]; then
+			ocf_exit_reason "MySQL Slave is $Seconds_Behind_Master seconds behind master (allowed maximum: $OCF_RESKEY_max_slave_lag)."
+			ocf_log err "See $tmpfile for details"
+
+			# Remove reader vip
+			set_reader_attr 0
+
+			exit $OCF_ERR_INSTALLED
+		fi
+	elif ocf_is_ms; then
+		# Even if we're not set to evict lagging slaves, we can
+		# still use the seconds behind master value to set our
+		# master preference.
+		local master_pref
+		master_pref=$((${OCF_RESKEY_max_slave_lag}-${Seconds_Behind_Master}))
+		if [ $master_pref -lt 0 ]; then
+			# Sanitize a below-zero preference to just zero
+			master_pref=0
+		fi
+		$CRM_MASTER -v $master_pref
+	fi
+
+	# is the slave ok to have a VIP on it
+	if [ "$Seconds_Behind_Master" = "NULL" ] || [ $Seconds_Behind_Master -gt $OCF_RESKEY_max_slave_lag ]; then
+		set_reader_attr 0
+	else
+		set_reader_attr 1
+	fi
+
+	ocf_log debug "MySQL instance running as a replication slave"
+	rm -f $tmpfile
 }
 
 set_master() {

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -470,8 +470,7 @@ check_slave() {
 		# instance is not a slave
 		# TODO: Needs to handle when get_slave_info will return too many connections error
 		rm -f $tmpfile
-		ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
-		exit $OCF_ERR_GENERIC
+        quit_on_error "check_slave invoked on an instance that is not a replication slave: $rc" $OCF_ERR_GENERIC
 	fi
 
 	# Did we receive an error other than max_connections?

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -5,22 +5,22 @@
 #
 # Description:  Manages a MySQL database as Linux-HA resource
 #
-# Authors:  Alan Robertson:               DB2 Script
-#           Jakub Janczak:                rewrite as MySQL
-#           Andrew Beekhof:               cleanup and import
-#           Sebastian Reitenbach:         add OpenBSD defaults, more cleanup
-#           Narayan Newton:               add Gentoo/Debian defaults
-#           Marian Marinov, Florian Haas: add replication capability
-#           Yves Trudeau, Baron Schwartz: add VIP support and improve replication
+# Authors:  Alan Robertson:			   DB2 Script
+#		   Jakub Janczak:				rewrite as MySQL
+#		   Andrew Beekhof:			   cleanup and import
+#		   Sebastian Reitenbach:		 add OpenBSD defaults, more cleanup
+#		   Narayan Newton:			   add Gentoo/Debian defaults
+#		   Marian Marinov, Florian Haas: add replication capability
+#		   Yves Trudeau, Baron Schwartz: add VIP support and improve replication
 #
 # Support:  users@clusterlabs.org
 # License:  GNU General Public License (GPL)
 #
 # (c) 2002-2005 International Business Machines, Inc.
-#     2005-2010 Linux-HA contributors
+#	 2005-2010 Linux-HA contributors
 #
 # An example usage in /etc/ha.d/haresources:
-#       node1  10.0.0.170 mysql
+#	   node1  10.0.0.170 mysql
 #
 # See usage() function below for more details...
 #
@@ -303,371 +303,371 @@ END
 # Convenience functions
 
 set_read_only() {
-    # Sets or unsets read-only mode. Accepts one boolean as its
-    # optional argument. If invoked without any arguments, defaults to
-    # enabling read only mode. Should only be set in master/slave
-    # setups.
-    # Returns $OCF_SUCCESS if the operation succeeds, or
-    # $OCF_ERR_GENERIC if it fails.
-    local ro_val
-    if ocf_is_true $1; then
-        ro_val="on"
-    else
-        ro_val="off"
-    fi
-    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "SET GLOBAL read_only=${ro_val}"
+	# Sets or unsets read-only mode. Accepts one boolean as its
+	# optional argument. If invoked without any arguments, defaults to
+	# enabling read only mode. Should only be set in master/slave
+	# setups.
+	# Returns $OCF_SUCCESS if the operation succeeds, or
+	# $OCF_ERR_GENERIC if it fails.
+	local ro_val
+	if ocf_is_true $1; then
+		ro_val="on"
+	else
+		ro_val="off"
+	fi
+	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+		-e "SET GLOBAL read_only=${ro_val}"
 }
 
 get_read_only() {
-    # Check if read-only is set
-    local read_only_state
+	# Check if read-only is set
+	local read_only_state
 
-    read_only_state=`$MYSQL $MYSQL_OPTIONS_REPL \
-        --skip-column-names -e "SHOW VARIABLES LIKE 'read_only'" | awk '{print $2}'`
+	read_only_state=`$MYSQL $MYSQL_OPTIONS_REPL \
+		--skip-column-names -e "SHOW VARIABLES LIKE 'read_only'" | awk '{print $2}'`
 
-    if [ "$read_only_state" = "ON" ]; then
-        return 0
-    else
-        return 1
-    fi
+	if [ "$read_only_state" = "ON" ]; then
+		return 0
+	else
+		return 1
+	fi
 }
 
 is_slave() {
-    # Determine whether the machine is currently running as a MySQL
-    # slave, as determined per SHOW SLAVE STATUS. Returns 1 if SHOW
-    # SLAVE STATUS creates an empty result set, 0 otherwise.
-    local rc
-    local tmpfile
+	# Determine whether the machine is currently running as a MySQL
+	# slave, as determined per SHOW SLAVE STATUS. Returns 1 if SHOW
+	# SLAVE STATUS creates an empty result set, 0 otherwise.
+	local rc
+	local tmpfile
 
-    # Check whether this machine should be slave
-    if ! ocf_is_ms || ! get_read_only; then
-        return 1
-    fi
+	# Check whether this machine should be slave
+	if ! ocf_is_ms || ! get_read_only; then
+		return 1
+	fi
    
-    get_slave_info
-    rc=$?
-    rm -f $tmpfile
+	get_slave_info
+	rc=$?
+	rm -f $tmpfile
 
-    if [ $rc -eq 0 ]; then
-       # show slave status is not empty
-       # Is there a master_log_file defined?  (master_log_file is deleted 
-       # by reset slave
-       if [ "$master_log_file" ]; then
-          return 0
-       else
-          return 1
-       fi
-    else
-       # "SHOW SLAVE STATUS" returns an empty set if instance is not a
-       # replication slave
-       return 1
-    fi
-    
+	if [ $rc -eq 0 ]; then
+	   # show slave status is not empty
+	   # Is there a master_log_file defined?  (master_log_file is deleted 
+	   # by reset slave
+	   if [ "$master_log_file" ]; then
+		  return 0
+	   else
+		  return 1
+	   fi
+	else
+	   # "SHOW SLAVE STATUS" returns an empty set if instance is not a
+	   # replication slave
+	   return 1
+	fi
+	
 }
 
 parse_slave_info() {
-    # Extracts field $1 from result of "SHOW SLAVE STATUS\G" from file $2
-    sed -ne "s/^.* $1: \(.*\)$/\1/p" < $2
+	# Extracts field $1 from result of "SHOW SLAVE STATUS\G" from file $2
+	sed -ne "s/^.* $1: \(.*\)$/\1/p" < $2
 }
 
 get_slave_info() {
-    # Warning: this sets $tmpfile and LEAVE this file! You must delete it after use!
-    local mysql_options
-            
-    if [ "$master_log_file" -a "$master_host" ]; then
-        # variables are already defined, get_slave_info has been run before
-        return $OCF_SUCCESS
-    else
-        tmpfile=`mktemp ${HA_RSCTMP}/check_slave.${OCF_RESOURCE_INSTANCE}.XXXXXX`
+	# Warning: this sets $tmpfile and LEAVE this file! You must delete it after use!
+	local mysql_options
+			
+	if [ "$master_log_file" -a "$master_host" ]; then
+		# variables are already defined, get_slave_info has been run before
+		return $OCF_SUCCESS
+	else
+		tmpfile=`mktemp ${HA_RSCTMP}/check_slave.${OCF_RESOURCE_INSTANCE}.XXXXXX`
 
-        $MYSQL $MYSQL_OPTIONS_REPL \
-        -e 'SHOW SLAVE STATUS\G' > $tmpfile
+		$MYSQL $MYSQL_OPTIONS_REPL \
+		-e 'SHOW SLAVE STATUS\G' > $tmpfile
 
-        if [ -s $tmpfile ]; then
-            master_host=`parse_slave_info Master_Host $tmpfile`
-            master_user=`parse_slave_info Master_User $tmpfile`
-            master_port=`parse_slave_info Master_Port $tmpfile`
-            master_log_file=`parse_slave_info Master_Log_File $tmpfile`
-            master_log_pos=`parse_slave_info Read_Master_Log_Pos $tmpfile`
-            slave_sql=`parse_slave_info Slave_SQL_Running $tmpfile`
-            slave_io=`parse_slave_info Slave_IO_Running $tmpfile`
-            last_errno=`parse_slave_info Last_Errno $tmpfile`
-            secs_behind=`parse_slave_info Seconds_Behind_Master $tmpfile`
-            ocf_log debug "MySQL instance running as a replication slave"
-        else
-            # Instance produced an empty "SHOW SLAVE STATUS" output --
-            # instance is not a slave
-            ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
-            return $OCF_ERR_GENERIC
-        fi
+		if [ -s $tmpfile ]; then
+			master_host=`parse_slave_info Master_Host $tmpfile`
+			master_user=`parse_slave_info Master_User $tmpfile`
+			master_port=`parse_slave_info Master_Port $tmpfile`
+			master_log_file=`parse_slave_info Master_Log_File $tmpfile`
+			master_log_pos=`parse_slave_info Read_Master_Log_Pos $tmpfile`
+			slave_sql=`parse_slave_info Slave_SQL_Running $tmpfile`
+			slave_io=`parse_slave_info Slave_IO_Running $tmpfile`
+			last_errno=`parse_slave_info Last_Errno $tmpfile`
+			secs_behind=`parse_slave_info Seconds_Behind_Master $tmpfile`
+			ocf_log debug "MySQL instance running as a replication slave"
+		else
+			# Instance produced an empty "SHOW SLAVE STATUS" output --
+			# instance is not a slave
+			ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
+			return $OCF_ERR_GENERIC
+		fi
 
-        return $OCF_SUCCESS
-    fi
+		return $OCF_SUCCESS
+	fi
 }
 
 check_slave() {
-    # Checks slave status
-    local rc new_master
+	# Checks slave status
+	local rc new_master
 
-    get_slave_info
-    rc=$?
+	get_slave_info
+	rc=$?
 
-    if [ $rc -eq 0 ]; then
-        # Did we receive an error other than max_connections?
-        if [ $last_errno -ne 0 -a $last_errno -ne "$MYSQL_TOO_MANY_CONN_ERR" ]; then
-            # Whoa. Replication ran into an error. This slave has
-            # diverged from its master. Make sure this resource
-            # doesn't restart in place.
-            ocf_exit_reason "MySQL instance configured for replication, but replication has failed."
-            ocf_log err "See $tmpfile for details"
+	if [ $rc -eq 0 ]; then
+		# Did we receive an error other than max_connections?
+		if [ $last_errno -ne 0 -a $last_errno -ne "$MYSQL_TOO_MANY_CONN_ERR" ]; then
+			# Whoa. Replication ran into an error. This slave has
+			# diverged from its master. Make sure this resource
+			# doesn't restart in place.
+			ocf_exit_reason "MySQL instance configured for replication, but replication has failed."
+			ocf_log err "See $tmpfile for details"
 
-            # Just pull the reader VIP away, killing MySQL here would be pretty evil
-            # on a loaded server
+			# Just pull the reader VIP away, killing MySQL here would be pretty evil
+			# on a loaded server
 
-            set_reader_attr 0
-            exit $OCF_SUCCESS
+			set_reader_attr 0
+			exit $OCF_SUCCESS
 
-        fi
+		fi
 
-        # If we got max_connections, let's remove the vip
-        if [ $last_errno -eq "$MYSQL_TOO_MANY_CONN_ERR" ]; then
-            set_reader_attr 0
-            exit $OCF_SUCCESS
-        fi
+		# If we got max_connections, let's remove the vip
+		if [ $last_errno -eq "$MYSQL_TOO_MANY_CONN_ERR" ]; then
+			set_reader_attr 0
+			exit $OCF_SUCCESS
+		fi
 
-        if [ "$slave_io" != 'Yes' ]; then
-            # Not necessarily a bad thing. The master may have
-            # temporarily shut down, and the slave may just be
-            # reconnecting. A warning can't hurt, though.
-            ocf_log warn "MySQL Slave IO threads currently not running."
+		if [ "$slave_io" != 'Yes' ]; then
+			# Not necessarily a bad thing. The master may have
+			# temporarily shut down, and the slave may just be
+			# reconnecting. A warning can't hurt, though.
+			ocf_log warn "MySQL Slave IO threads currently not running."
 
-            # Sanity check, are we at least on the right master
-            new_master=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f1`
+			# Sanity check, are we at least on the right master
+			new_master=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f1`
 
-            if [ "$master_host" != "$new_master" ]; then
-               # Not pointing to the right master, not good, removing the VIPs
-               set_reader_attr 0
+			if [ "$master_host" != "$new_master" ]; then
+			   # Not pointing to the right master, not good, removing the VIPs
+			   set_reader_attr 0
 
-               exit $OCF_SUCCESS
-            fi
+			   exit $OCF_SUCCESS
+			fi
 
-        fi
+		fi
 
-        if [ "$slave_sql" != 'Yes' ]; then
-            # We don't have a replication SQL thread running. Not a
-            # good thing. Try to recoved by restarting the SQL thread
-            # and remove reader vip.  Prevent MySQL restart.
-            ocf_exit_reason "MySQL Slave SQL threads currently not running."
-            ocf_log err "See $tmpfile for details"
+		if [ "$slave_sql" != 'Yes' ]; then
+			# We don't have a replication SQL thread running. Not a
+			# good thing. Try to recoved by restarting the SQL thread
+			# and remove reader vip.  Prevent MySQL restart.
+			ocf_exit_reason "MySQL Slave SQL threads currently not running."
+			ocf_log err "See $tmpfile for details"
 
-            # Remove reader vip
-            set_reader_attr 0
+			# Remove reader vip
+			set_reader_attr 0
 
-            # try to restart slave
-            ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-                -e "START SLAVE"
+			# try to restart slave
+			ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+				-e "START SLAVE"
 
-            # Return success to prevent a restart
-            exit $OCF_SUCCESS
-        fi
+			# Return success to prevent a restart
+			exit $OCF_SUCCESS
+		fi
 
-        if ocf_is_true $OCF_RESKEY_evict_outdated_slaves; then
-            # We're supposed to bail out if we lag too far
-            # behind. Let's check our lag.
-            if [ "$secs_behind" = "NULL" ] || [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
-                ocf_exit_reason "MySQL Slave is $secs_behind seconds behind master (allowed maximum: $OCF_RESKEY_max_slave_lag)."
-                ocf_log err "See $tmpfile for details"
+		if ocf_is_true $OCF_RESKEY_evict_outdated_slaves; then
+			# We're supposed to bail out if we lag too far
+			# behind. Let's check our lag.
+			if [ "$secs_behind" = "NULL" ] || [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
+				ocf_exit_reason "MySQL Slave is $secs_behind seconds behind master (allowed maximum: $OCF_RESKEY_max_slave_lag)."
+				ocf_log err "See $tmpfile for details"
 
-                # Remove reader vip
-                set_reader_attr 0
+				# Remove reader vip
+				set_reader_attr 0
 
-                exit $OCF_ERR_INSTALLED
-            fi
-        elif ocf_is_ms; then
-            # Even if we're not set to evict lagging slaves, we can
-            # still use the seconds behind master value to set our
-            # master preference.
-            local master_pref
-            master_pref=$((${OCF_RESKEY_max_slave_lag}-${secs_behind}))
-            if [ $master_pref -lt 0 ]; then
-                # Sanitize a below-zero preference to just zero
-                master_pref=0
-            fi
-            $CRM_MASTER -v $master_pref
-        fi
+				exit $OCF_ERR_INSTALLED
+			fi
+		elif ocf_is_ms; then
+			# Even if we're not set to evict lagging slaves, we can
+			# still use the seconds behind master value to set our
+			# master preference.
+			local master_pref
+			master_pref=$((${OCF_RESKEY_max_slave_lag}-${secs_behind}))
+			if [ $master_pref -lt 0 ]; then
+				# Sanitize a below-zero preference to just zero
+				master_pref=0
+			fi
+			$CRM_MASTER -v $master_pref
+		fi
 
-        # is the slave ok to have a VIP on it
-        if [ "$secs_behind" = "NULL" ] || [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
-            set_reader_attr 0
-        else
-            set_reader_attr 1
-        fi
+		# is the slave ok to have a VIP on it
+		if [ "$secs_behind" = "NULL" ] || [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
+			set_reader_attr 0
+		else
+			set_reader_attr 1
+		fi
 
-        ocf_log debug "MySQL instance running as a replication slave"
-        rm -f $tmpfile
-    else
-        # Instance produced an empty "SHOW SLAVE STATUS" output --
-        # instance is not a slave
-        # TODO: Needs to handle when get_slave_info will return too many connections error
-        rm -f $tmpfile
-        ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
-        exit $OCF_ERR_GENERIC
-    fi
+		ocf_log debug "MySQL instance running as a replication slave"
+		rm -f $tmpfile
+	else
+		# Instance produced an empty "SHOW SLAVE STATUS" output --
+		# instance is not a slave
+		# TODO: Needs to handle when get_slave_info will return too many connections error
+		rm -f $tmpfile
+		ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
+		exit $OCF_ERR_GENERIC
+	fi
 }
 
 set_master() {
-    local new_master master_log_file master_log_pos
-    local master_params
+	local new_master master_log_file master_log_pos
+	local master_params
 
-    new_master=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f1`
+	new_master=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f1`
 
-    # Keep replication position
-    get_slave_info
+	# Keep replication position
+	get_slave_info
 
-    if [ "$master_log_file" -a "$new_master" = "$master_host" ]; then
-        #	master_params=", MASTER_LOG_FILE='$master_log_file', \
-        #	    MASTER_LOG_POS=$master_log_pos"
-        ocf_log info "Kept master pos for $master_host : $master_log_file:$master_log_pos"
-        rm -f $tmpfile
-        return
-    else
-        master_log_file=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f2`
-        master_log_pos=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f3`
-        if [ -n "$master_log_file" -a -n "$master_log_pos" ]; then
-            master_params=", MASTER_LOG_FILE='$master_log_file', \
-            MASTER_LOG_POS=$master_log_pos"
-            ocf_log info "Restored master pos for $new_master : $master_log_file:$master_log_pos"
-        fi
-    fi
+	if [ "$master_log_file" -a "$new_master" = "$master_host" ]; then
+		#	master_params=", MASTER_LOG_FILE='$master_log_file', \
+		#		MASTER_LOG_POS=$master_log_pos"
+		ocf_log info "Kept master pos for $master_host : $master_log_file:$master_log_pos"
+		rm -f $tmpfile
+		return
+	else
+		master_log_file=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f2`
+		master_log_pos=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f3`
+		if [ -n "$master_log_file" -a -n "$master_log_pos" ]; then
+			master_params=", MASTER_LOG_FILE='$master_log_file', \
+			MASTER_LOG_POS=$master_log_pos"
+			ocf_log info "Restored master pos for $new_master : $master_log_file:$master_log_pos"
+		fi
+	fi
 
-    # Informs the MySQL server of the master to replicate
-    # from. Accepts one mandatory argument which must contain the host
-    # name of the new master host. The master must either be unchanged
-    # from the laste master the slave replicated from, or freshly
-    # reset with RESET MASTER.
+	# Informs the MySQL server of the master to replicate
+	# from. Accepts one mandatory argument which must contain the host
+	# name of the new master host. The master must either be unchanged
+	# from the laste master the slave replicated from, or freshly
+	# reset with RESET MASTER.
 
-    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "CHANGE MASTER TO MASTER_HOST='$new_master', \
-        MASTER_PORT=$OCF_RESKEY_replication_port, \
-        MASTER_USER='$OCF_RESKEY_replication_user', \
-        MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $master_params"
-    rm -f $tmpfile
+	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+		-e "CHANGE MASTER TO MASTER_HOST='$new_master', \
+		MASTER_PORT=$OCF_RESKEY_replication_port, \
+		MASTER_USER='$OCF_RESKEY_replication_user', \
+		MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $master_params"
+	rm -f $tmpfile
 }
 
 unset_master(){
-    # Instructs the MySQL server to stop replicating from a master
-    # host.
+	# Instructs the MySQL server to stop replicating from a master
+	# host.
 
-    # If we're currently not configured to be replicating from any
-    # host, then there's nothing to do. But we do log a warning as
-    # no-one but the CRM should be touching the MySQL master/slave
-    # configuration.
-    if ! is_slave; then
-        ocf_log warn "Attempted to unset the replication master on an instance that is not configured as a replication slave"
-        return $OCF_SUCCESS
-    fi
+	# If we're currently not configured to be replicating from any
+	# host, then there's nothing to do. But we do log a warning as
+	# no-one but the CRM should be touching the MySQL master/slave
+	# configuration.
+	if ! is_slave; then
+		ocf_log warn "Attempted to unset the replication master on an instance that is not configured as a replication slave"
+		return $OCF_SUCCESS
+	fi
 
-    local tmpfile
-    tmpfile=`mktemp ${HA_RSCTMP}/unset_master.${OCF_RESOURCE_INSTANCE}.XXXXXX`
+	local tmpfile
+	tmpfile=`mktemp ${HA_RSCTMP}/unset_master.${OCF_RESOURCE_INSTANCE}.XXXXXX`
 
-    # At this point, the master is read only so there should not be much binlogs to transfer
-    # Let's wait for the last bits
-    while true; do
-        $MYSQL $MYSQL_OPTIONS_REPL \
-        -e 'SHOW PROCESSLIST\G' > $tmpfile
-        if grep -i 'Waiting for master to send event' $tmpfile >/dev/null; then
-            ocf_log info "MySQL slave has finished reading master binary log"
-            break
-        fi
-        if grep -i 'Reconnecting after a failed master event read' $tmpfile >/dev/null; then
-            ocf_log info "Master is down, no more binary logs to come"
-            break
-        fi
-        if grep -i 'Connecting to master' $tmpfile >/dev/null; then
-            ocf_log info "Master is down, no more binary logs to come"
-            break
-        fi
-        if ! grep 'system user' $tmpfile >/dev/null; then
-            ocf_log info "Slave is not running - not waiting to finish"
-            break
-        fi
+	# At this point, the master is read only so there should not be much binlogs to transfer
+	# Let's wait for the last bits
+	while true; do
+		$MYSQL $MYSQL_OPTIONS_REPL \
+		-e 'SHOW PROCESSLIST\G' > $tmpfile
+		if grep -i 'Waiting for master to send event' $tmpfile >/dev/null; then
+			ocf_log info "MySQL slave has finished reading master binary log"
+			break
+		fi
+		if grep -i 'Reconnecting after a failed master event read' $tmpfile >/dev/null; then
+			ocf_log info "Master is down, no more binary logs to come"
+			break
+		fi
+		if grep -i 'Connecting to master' $tmpfile >/dev/null; then
+			ocf_log info "Master is down, no more binary logs to come"
+			break
+		fi
+		if ! grep 'system user' $tmpfile >/dev/null; then
+			ocf_log info "Slave is not running - not waiting to finish"
+			break
+		fi
 
-        sleep 1
-    done
+		sleep 1
+	done
 
-    # Now, stop the slave I/O thread and wait for relay log
-    # processing to complete
-    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "STOP SLAVE IO_THREAD"
-    if [ $? -gt 0 ]; then
-        ocf_exit_reason "Error stopping slave IO thread"
-        exit $OCF_ERR_GENERIC
-    fi
+	# Now, stop the slave I/O thread and wait for relay log
+	# processing to complete
+	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+		-e "STOP SLAVE IO_THREAD"
+	if [ $? -gt 0 ]; then
+		ocf_exit_reason "Error stopping slave IO thread"
+		exit $OCF_ERR_GENERIC
+	fi
 
-    while true; do
-        $MYSQL $MYSQL_OPTIONS_REPL \
-            -e 'SHOW PROCESSLIST\G' > $tmpfile
-        if grep -i 'Has read all relay log' $tmpfile >/dev/null; then
-            ocf_log info "MySQL slave has finished processing relay log"
-            break
-        fi
-        if ! grep -q 'system user' $tmpfile; then
-            ocf_log info "Slave not runnig - not waiting to finish"
-            break
-        fi
-        ocf_log info "Waiting for MySQL slave to finish processing relay log"
-        sleep 1
-    done
-    rm -f $tmpfile
+	while true; do
+		$MYSQL $MYSQL_OPTIONS_REPL \
+			-e 'SHOW PROCESSLIST\G' > $tmpfile
+		if grep -i 'Has read all relay log' $tmpfile >/dev/null; then
+			ocf_log info "MySQL slave has finished processing relay log"
+			break
+		fi
+		if ! grep -q 'system user' $tmpfile; then
+			ocf_log info "Slave not runnig - not waiting to finish"
+			break
+		fi
+		ocf_log info "Waiting for MySQL slave to finish processing relay log"
+		sleep 1
+	done
+	rm -f $tmpfile
 
-    # Now, stop all slave activity and unset the master host
-    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "STOP SLAVE"
-    if [ $? -gt 0 ]; then
-        ocf_exit_reason "Error stopping rest slave threads"
-        exit $OCF_ERR_GENERIC
-    fi
+	# Now, stop all slave activity and unset the master host
+	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+		-e "STOP SLAVE"
+	if [ $? -gt 0 ]; then
+		ocf_exit_reason "Error stopping rest slave threads"
+		exit $OCF_ERR_GENERIC
+	fi
 
-    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "RESET SLAVE /*!50516 ALL */;"
-    if [ $? -gt 0 ]; then
-        ocf_exit_reason "Failed to reset slave"
-        exit $OCF_ERR_GENERIC
-    fi
+	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+		-e "RESET SLAVE /*!50516 ALL */;"
+	if [ $? -gt 0 ]; then
+		ocf_exit_reason "Failed to reset slave"
+		exit $OCF_ERR_GENERIC
+	fi
 }
 
 # Start replication as slave
 start_slave() {
 
-    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "START SLAVE"
+	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+		-e "START SLAVE"
 }
 
 # Set the attribute controlling the readers VIP
 set_reader_attr() {
-    local curr_attr_value
+	local curr_attr_value
 
-    curr_attr_value=$(get_reader_attr)
+	curr_attr_value=$(get_reader_attr)
 
-    if [ "$curr_attr_value" -ne "$1" ]; then
-        $CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} -v $1
-    fi
+	if [ "$curr_attr_value" -ne "$1" ]; then
+		$CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} -v $1
+	fi
 
 }
 
 # get the attribute controlling the readers VIP
 get_reader_attr() {
-    local attr_value
-    local rc
+	local attr_value
+	local rc
 
-    attr_value=`$CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} --query -q`
-    rc=$?
-    if [ "$rc" -eq "0" ]; then
-        echo $attr_value
-    else
-        echo -1
-    fi
+	attr_value=`$CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} --query -q`
+	rc=$?
+	if [ "$rc" -eq "0" ]; then
+		echo $attr_value
+	else
+		echo -1
+	fi
 
 }
 
@@ -699,9 +699,9 @@ get_local_ip() {
    local IP
    IP=`$CRM_ATTR -l forever -n ${INSTANCE_ATTR_NAME}_mysql_master_IP -q -G`
    if [ ! $? -eq 0 ]; then
-      uname -n
+	  uname -n
    else
-      echo $IP
+	  echo $IP
    fi
 }
 
@@ -710,285 +710,285 @@ get_local_ip() {
 # Functions invoked by resource manager actions
 
 mysql_monitor() {
-    local rc
-    local status_loglevel="err"
+	local rc
+	local status_loglevel="err"
 
-    # Set loglevel to info during probe
-    if ocf_is_probe; then
-        status_loglevel="info"
-    fi
+	# Set loglevel to info during probe
+	if ocf_is_probe; then
+		status_loglevel="info"
+	fi
  
-    mysql_common_status $status_loglevel
-    rc=$?
+	mysql_common_status $status_loglevel
+	rc=$?
 
-    # TODO: check max connections error
+	# TODO: check max connections error
 
-    # If status returned an error, return that immediately
-    if [ $rc -ne $OCF_SUCCESS ]; then
-        if ocf_is_ms ; then
-            # This is a master slave setup but monitored host returned some errors.
-            # Immediately remove it from the pool of possible masters by erasing its master-mysql key
-            # When new mysql master election is started and node got no or negative master-mysql attribute the following is logged
-            #   nodename.com pengine: debug: master_color: mysql:0 master score: -1
-            # If there are NO nodes with positive vaule election of mysql master will fail with
-            #   nodename.com pengine: info: master_color: ms_mysql: Promoted 0 instances of a possible 1 to master
-            $CRM_MASTER -D
-        fi
+	# If status returned an error, return that immediately
+	if [ $rc -ne $OCF_SUCCESS ]; then
+		if ocf_is_ms ; then
+			# This is a master slave setup but monitored host returned some errors.
+			# Immediately remove it from the pool of possible masters by erasing its master-mysql key
+			# When new mysql master election is started and node got no or negative master-mysql attribute the following is logged
+			#   nodename.com pengine: debug: master_color: mysql:0 master score: -1
+			# If there are NO nodes with positive vaule election of mysql master will fail with
+			#   nodename.com pengine: info: master_color: ms_mysql: Promoted 0 instances of a possible 1 to master
+			$CRM_MASTER -D
+		fi
 
-        return $rc
-    fi
+		return $rc
+	fi
 
-    if [ $OCF_CHECK_LEVEL -gt 0 -a -n "$OCF_RESKEY_test_table" ]; then
-        # Check if this instance is configured as a slave, and if so
-        # check slave status
-        if is_slave; then
-            check_slave
-        fi
+	if [ $OCF_CHECK_LEVEL -gt 0 -a -n "$OCF_RESKEY_test_table" ]; then
+		# Check if this instance is configured as a slave, and if so
+		# check slave status
+		if is_slave; then
+			check_slave
+		fi
 
-        # Check for test table
-        ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
-            -e "SELECT COUNT(*) FROM $OCF_RESKEY_test_table"
-        rc=$?
+		# Check for test table
+		ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
+			-e "SELECT COUNT(*) FROM $OCF_RESKEY_test_table"
+		rc=$?
 
-        if [ $rc -ne 0 ]; then
-            # We are master/slave and test failed. Delete master score for this node as it is considered unhealthy because of this particular failed check.
-            ocf_is_ms && $CRM_MASTER -D
-            ocf_exit_reason "Failed to select from $test_table";
-            return $OCF_ERR_GENERIC;
-        fi
-    else
-        # In case no exnteded tests are enabled and we are in master/slave mode _always_ set the master score to 1 if we reached this point
-        ocf_is_ms && $CRM_MASTER -v 1
-    fi
+		if [ $rc -ne 0 ]; then
+			# We are master/slave and test failed. Delete master score for this node as it is considered unhealthy because of this particular failed check.
+			ocf_is_ms && $CRM_MASTER -D
+			ocf_exit_reason "Failed to select from $test_table";
+			return $OCF_ERR_GENERIC;
+		fi
+	else
+		# In case no exnteded tests are enabled and we are in master/slave mode _always_ set the master score to 1 if we reached this point
+		ocf_is_ms && $CRM_MASTER -v 1
+	fi
 
-    if ocf_is_ms && ! get_read_only; then
-        ocf_log debug "MySQL monitor succeeded (master)";
-        # Always set master score for the master
-        $CRM_MASTER -v 2
-        return $OCF_RUNNING_MASTER
-    else
-        ocf_log debug "MySQL monitor succeeded";
-        return $OCF_SUCCESS
-    fi
+	if ocf_is_ms && ! get_read_only; then
+		ocf_log debug "MySQL monitor succeeded (master)";
+		# Always set master score for the master
+		$CRM_MASTER -v 2
+		return $OCF_RUNNING_MASTER
+	else
+		ocf_log debug "MySQL monitor succeeded";
+		return $OCF_SUCCESS
+	fi
 }
 
 mysql_start() {
-    local rc
+	local rc
 
-    if ocf_is_ms; then
-        # Initialize the ReaderVIP attribute, monitor will enable it
-        set_reader_attr 0
-    fi
+	if ocf_is_ms; then
+		# Initialize the ReaderVIP attribute, monitor will enable it
+		set_reader_attr 0
+	fi
 
-    mysql_common_status info
-    if [ $? = $OCF_SUCCESS ]; then
-        ocf_log info "MySQL already running"
-        return $OCF_SUCCESS
-    fi
+	mysql_common_status info
+	if [ $? = $OCF_SUCCESS ]; then
+		ocf_log info "MySQL already running"
+		return $OCF_SUCCESS
+	fi
 
-    mysql_common_prepare_dirs
+	mysql_common_prepare_dirs
 
-    # Uncomment to perform permission clensing
-    # - not convinced this should be enabled by default
-    #
-    #chmod 0755 $OCF_RESKEY_datadir
-    #chown -R $OCF_RESKEY_user $OCF_RESKEY_datadir
-    #chgrp -R $OCF_RESKEY_group $OCF_RESKEY_datadir
-    mysql_extra_params=
-    if ocf_is_ms; then
-        mysql_extra_params="--skip-slave-start"
-    fi
+	# Uncomment to perform permission clensing
+	# - not convinced this should be enabled by default
+	#
+	#chmod 0755 $OCF_RESKEY_datadir
+	#chown -R $OCF_RESKEY_user $OCF_RESKEY_datadir
+	#chgrp -R $OCF_RESKEY_group $OCF_RESKEY_datadir
+	mysql_extra_params=
+	if ocf_is_ms; then
+		mysql_extra_params="--skip-slave-start"
+	fi
 
-    mysql_common_start $mysql_extra_params
-    rc=$?
-    if [ $rc != $OCF_SUCCESS ]; then
-        return $rc
-    fi
+	mysql_common_start $mysql_extra_params
+	rc=$?
+	if [ $rc != $OCF_SUCCESS ]; then
+		return $rc
+	fi
 
-    if ocf_is_ms; then
-        # We're configured as a stateful resource. We must start as
-        # slave by default. At this point we don't know if the CRM has
-        # already promoted a master. So, we simply start in read only
-        # mode.
-        set_read_only on
+	if ocf_is_ms; then
+		# We're configured as a stateful resource. We must start as
+		# slave by default. At this point we don't know if the CRM has
+		# already promoted a master. So, we simply start in read only
+		# mode.
+		set_read_only on
 
-        # Now, let's see whether there is a master. We might be a new
-        # node that is just joining the cluster, and the CRM may have
-        # promoted a master before.
-        master_host=`echo $OCF_RESKEY_CRM_meta_notify_master_uname|tr -d " "`
-        if [ "$master_host" -a "$master_host" != ${NODENAME} ]; then
-            ocf_log info "Changing MySQL configuration to replicate from $master_host."
-            set_master
-            start_slave
-            if [ $? -ne 0 ]; then
-                ocf_exit_reason "Failed to start slave"
-                return $OCF_ERR_GENERIC
-            fi
-        else
-            ocf_log info "No MySQL master present - clearing replication state"
-            unset_master
-        fi
+		# Now, let's see whether there is a master. We might be a new
+		# node that is just joining the cluster, and the CRM may have
+		# promoted a master before.
+		master_host=`echo $OCF_RESKEY_CRM_meta_notify_master_uname|tr -d " "`
+		if [ "$master_host" -a "$master_host" != ${NODENAME} ]; then
+			ocf_log info "Changing MySQL configuration to replicate from $master_host."
+			set_master
+			start_slave
+			if [ $? -ne 0 ]; then
+				ocf_exit_reason "Failed to start slave"
+				return $OCF_ERR_GENERIC
+			fi
+		else
+			ocf_log info "No MySQL master present - clearing replication state"
+			unset_master
+		fi
 
-        # We also need to set a master preference, otherwise Pacemaker
-        # won't ever promote us in the absence of any explicit
-        # preference set by the administrator. We choose a low
-        # greater-than-zero preference.
-        $CRM_MASTER -v 1
+		# We also need to set a master preference, otherwise Pacemaker
+		# won't ever promote us in the absence of any explicit
+		# preference set by the administrator. We choose a low
+		# greater-than-zero preference.
+		$CRM_MASTER -v 1
 
-    fi
+	fi
 
-    # Initial monitor action
-    if [ -n "$OCF_RESKEY_test_table" -a -n "$OCF_RESKEY_test_user" -a -n "$OCF_RESKEY_test_passwd" ]; then
-        OCF_CHECK_LEVEL=10
-    fi
-    mysql_monitor
-    rc=$?
-    if [ $rc != $OCF_SUCCESS -a $rc != $OCF_RUNNING_MASTER ]; then
-        ocf_exit_reason "Failed initial monitor action"
-        return $rc
-    fi
+	# Initial monitor action
+	if [ -n "$OCF_RESKEY_test_table" -a -n "$OCF_RESKEY_test_user" -a -n "$OCF_RESKEY_test_passwd" ]; then
+		OCF_CHECK_LEVEL=10
+	fi
+	mysql_monitor
+	rc=$?
+	if [ $rc != $OCF_SUCCESS -a $rc != $OCF_RUNNING_MASTER ]; then
+		ocf_exit_reason "Failed initial monitor action"
+		return $rc
+	fi
 
-    ocf_log info "MySQL started"
-    return $OCF_SUCCESS
+	ocf_log info "MySQL started"
+	return $OCF_SUCCESS
 }
 
 mysql_stop() {
-    if ocf_is_ms; then
-        # clear preference for becoming master
-        $CRM_MASTER -D
+	if ocf_is_ms; then
+		# clear preference for becoming master
+		$CRM_MASTER -D
 
-        # Remove VIP capability
-        set_reader_attr 0
-    fi
+		# Remove VIP capability
+		set_reader_attr 0
+	fi
 
-    mysql_common_stop
+	mysql_common_stop
 }
 
 mysql_promote() {
-    local master_info
+	local master_info
 
-    if ( ! mysql_common_status err ); then
-        return $OCF_NOT_RUNNING
-    fi
-    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "STOP SLAVE"
+	if ( ! mysql_common_status err ); then
+		return $OCF_NOT_RUNNING
+	fi
+	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+		-e "STOP SLAVE"
 
-    # Set Master Info in CIB, cluster level attribute
-    update_data_master_status
-    master_info="$(get_local_ip)|$(get_master_status File)|$(get_master_status Position)"
-    ${CRM_ATTR_REPL_INFO} -v "$master_info"
-    rm -f $tmpfile
+	# Set Master Info in CIB, cluster level attribute
+	update_data_master_status
+	master_info="$(get_local_ip)|$(get_master_status File)|$(get_master_status Position)"
+	${CRM_ATTR_REPL_INFO} -v "$master_info"
+	rm -f $tmpfile
 
-    set_read_only off || return $OCF_ERR_GENERIC
+	set_read_only off || return $OCF_ERR_GENERIC
 
-    # Existing master gets a higher-than-default master preference, so
-    # the cluster manager does not shuffle the master role around
-    # unnecessarily
-    $CRM_MASTER -v $((${OCF_RESKEY_max_slave_lag}+1))
+	# Existing master gets a higher-than-default master preference, so
+	# the cluster manager does not shuffle the master role around
+	# unnecessarily
+	$CRM_MASTER -v $((${OCF_RESKEY_max_slave_lag}+1))
 
-    # A master can accept reads
-    set_reader_attr 1
+	# A master can accept reads
+	set_reader_attr 1
 
-    return $OCF_SUCCESS
+	return $OCF_SUCCESS
 }
 
 mysql_demote() {
-    if ! mysql_common_status err; then
-        return $OCF_NOT_RUNNING
-    fi
+	if ! mysql_common_status err; then
+		return $OCF_NOT_RUNNING
+	fi
 
-    # Return master preference to default, so the cluster manager gets
-    # a chance to select a new master
-    $CRM_MASTER -v 1
+	# Return master preference to default, so the cluster manager gets
+	# a chance to select a new master
+	$CRM_MASTER -v 1
 }
 
 mysql_notify() {
-    # If not configured as a Stateful resource, we make no sense of
-    # notifications.
-    if ! ocf_is_ms; then
-        ocf_log info "This agent makes no use of notifications unless running in master/slave mode."
-        return $OCF_SUCCESS
-    fi
+	# If not configured as a Stateful resource, we make no sense of
+	# notifications.
+	if ! ocf_is_ms; then
+		ocf_log info "This agent makes no use of notifications unless running in master/slave mode."
+		return $OCF_SUCCESS
+	fi
 
-    local type_op
-    type_op="${OCF_RESKEY_CRM_meta_notify_type}-${OCF_RESKEY_CRM_meta_notify_operation}"
+	local type_op
+	type_op="${OCF_RESKEY_CRM_meta_notify_type}-${OCF_RESKEY_CRM_meta_notify_operation}"
 
-    ocf_log debug "Received $type_op notification."
+	ocf_log debug "Received $type_op notification."
 
-    case "$type_op" in
-        'pre-promote')
-            # Nothing to do now here, new replication info not yet published
+	case "$type_op" in
+		'pre-promote')
+			# Nothing to do now here, new replication info not yet published
 
-        ;;
-        'post-promote')
-            # The master has completed its promotion. Now is a good
-            # time to check whether our replication slave is working
-            # correctly.
-            master_host=`echo $OCF_RESKEY_CRM_meta_notify_promote_uname|tr -d " "`
-            if [ "$master_host" = ${NODENAME} ]; then
-                ocf_log info "This will be the new master, ignoring post-promote notification."
-            else
-                ocf_log info "Resetting replication"
-                unset_master
-                if [ $? -ne 0 ]; then
-                    return $OCF_ERR_GENERIC
-                fi
+		;;
+		'post-promote')
+			# The master has completed its promotion. Now is a good
+			# time to check whether our replication slave is working
+			# correctly.
+			master_host=`echo $OCF_RESKEY_CRM_meta_notify_promote_uname|tr -d " "`
+			if [ "$master_host" = ${NODENAME} ]; then
+				ocf_log info "This will be the new master, ignoring post-promote notification."
+			else
+				ocf_log info "Resetting replication"
+				unset_master
+				if [ $? -ne 0 ]; then
+					return $OCF_ERR_GENERIC
+				fi
 
-                ocf_log info "Changing MySQL configuration to replicate from $master_host"
-                set_master
-                if [ $? -ne 0 ]; then
-                    return $OCF_ERR_GENERIC
-                fi
+				ocf_log info "Changing MySQL configuration to replicate from $master_host"
+				set_master
+				if [ $? -ne 0 ]; then
+					return $OCF_ERR_GENERIC
+				fi
 
-                start_slave
-                if [ $? -ne 0 ]; then
-                    ocf_exit_reason "Failed to start slave"
-                    return $OCF_ERR_GENERIC
-                fi
-            fi
-            return $OCF_SUCCESS
-        ;;
-        'pre-demote')
-            demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
-            if [ $demote_host = ${NODENAME} ]; then
-                ocf_log info "post-demote notification for $demote_host"
-                set_read_only on
-                if [ $? -ne 0 ]; then
-                    ocf_exit_reason "Failed to set read-only";
-                    return $OCF_ERR_GENERIC;
-                fi
+				start_slave
+				if [ $? -ne 0 ]; then
+					ocf_exit_reason "Failed to start slave"
+					return $OCF_ERR_GENERIC
+				fi
+			fi
+			return $OCF_SUCCESS
+		;;
+		'pre-demote')
+			demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
+			if [ $demote_host = ${NODENAME} ]; then
+				ocf_log info "post-demote notification for $demote_host"
+				set_read_only on
+				if [ $? -ne 0 ]; then
+					ocf_exit_reason "Failed to set read-only";
+					return $OCF_ERR_GENERIC;
+				fi
 
-                # Must kill all existing user threads because they are still Read/write
-                # in order for the slaves to complete the read of binlogs
-                local tmpfile
-                tmpfile=`mktemp ${HA_RSCTMP}/threads.${OCF_RESOURCE_INSTANCE}.XXXXXX`
-                $MYSQL $MYSQL_OPTIONS_REPL \
-                -e "SHOW PROCESSLIST" > $tmpfile
+				# Must kill all existing user threads because they are still Read/write
+				# in order for the slaves to complete the read of binlogs
+				local tmpfile
+				tmpfile=`mktemp ${HA_RSCTMP}/threads.${OCF_RESOURCE_INSTANCE}.XXXXXX`
+				$MYSQL $MYSQL_OPTIONS_REPL \
+				-e "SHOW PROCESSLIST" > $tmpfile
 
-                for thread in `awk '$0 !~ /Binlog Dump|system user|event_scheduler|SHOW PROCESSLIST/ && $0 ~ /^[0-9]/ {print $1}' $tmpfile`
-                do
-                    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-                        -e "KILL ${thread}"
-                done
-            else
-               ocf_log info "Ignoring post-demote notification execpt for my own demotion."
-            fi
-            return $OCF_SUCCESS
-        ;;
-        'post-demote')
-            demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
-            if [ $demote_host = ${NODENAME} ]; then
-                ocf_log info "Ignoring post-demote notification for my own demotion."
-                return $OCF_SUCCESS
-            fi
-            ocf_log info "post-demote notification for $demote_host."
-            # The former master has just been gracefully demoted.
-            unset_master
-        ;;
-        *)
-            return $OCF_SUCCESS
-        ;;
-    esac
+				for thread in `awk '$0 !~ /Binlog Dump|system user|event_scheduler|SHOW PROCESSLIST/ && $0 ~ /^[0-9]/ {print $1}' $tmpfile`
+				do
+					ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+						-e "KILL ${thread}"
+				done
+			else
+			   ocf_log info "Ignoring post-demote notification execpt for my own demotion."
+			fi
+			return $OCF_SUCCESS
+		;;
+		'post-demote')
+			demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
+			if [ $demote_host = ${NODENAME} ]; then
+				ocf_log info "Ignoring post-demote notification for my own demotion."
+				return $OCF_SUCCESS
+			fi
+			ocf_log info "post-demote notification for $demote_host."
+			# The former master has just been gracefully demoted.
+			unset_master
+		;;
+		*)
+			return $OCF_SUCCESS
+		;;
+	esac
 }
 
 #######################################################################
@@ -1002,51 +1002,51 @@ mysql_notify() {
 ##########################################################################
 DEBUG_LOG="/tmp/mysql.ocf.ra.debug/log"
 if [ "${DEBUG_LOG}" -a -w "${DEBUG_LOG}" -a ! -L "${DEBUG_LOG}" ]; then
-    DEBUG_LOG_DIR="${DEBUG_LOG%/*}"
-    if [ -d "${DEBUG_LOG_DIR}" ]; then
-        exec 9>>"$DEBUG_LOG"
-        exec 2>&9
-        date >&9
-        echo "$*" >&9
-        env | grep OCF_ | sort >&9
-        set -x
-    else
-        exec 9>/dev/null
-    fi
+	DEBUG_LOG_DIR="${DEBUG_LOG%/*}"
+	if [ -d "${DEBUG_LOG_DIR}" ]; then
+		exec 9>>"$DEBUG_LOG"
+		exec 2>&9
+		date >&9
+		echo "$*" >&9
+		env | grep OCF_ | sort >&9
+		set -x
+	else
+		exec 9>/dev/null
+	fi
 fi
 
 case "$1" in
-  meta-data)    meta_data
-        exit $OCF_SUCCESS;;
+  meta-data)	meta_data
+		exit $OCF_SUCCESS;;
   usage|help)   usage
-        exit $OCF_SUCCESS;;
+		exit $OCF_SUCCESS;;
 esac
 
 mysql_common_validate
 rc=$?
 LSB_STATUS_STOPPED=3
 if [ $rc -ne 0 ]; then
-    case "$1" in
-        stop) ;;
-        monitor)
-            mysql_common_status "info"
-            if [ $? -eq $OCF_SUCCESS ]; then
-                # if validatation fails and pid is active, always treat this as an error
-                ocf_exit_reason "environment validation failed, active pid is in unknown state."
-                exit $OCF_ERR_GENERIC
-            fi
-            # validation failed and pid is not active, it's safe to say this instance is inactive.
-            exit $OCF_NOT_RUNNING;;
+	case "$1" in
+		stop) ;;
+		monitor)
+			mysql_common_status "info"
+			if [ $? -eq $OCF_SUCCESS ]; then
+				# if validatation fails and pid is active, always treat this as an error
+				ocf_exit_reason "environment validation failed, active pid is in unknown state."
+				exit $OCF_ERR_GENERIC
+			fi
+			# validation failed and pid is not active, it's safe to say this instance is inactive.
+			exit $OCF_NOT_RUNNING;;
 
-        status) exit $LSB_STATUS_STOPPED;;
-        *) exit $rc;;
-    esac
+		status) exit $LSB_STATUS_STOPPED;;
+		*) exit $rc;;
+	esac
 fi
 
 # What kind of method was invoked?
 case "$1" in
-  start)    mysql_start;;
-  stop)     mysql_stop;;
+  start)	mysql_start;;
+  stop)	 mysql_stop;;
   status)   mysql_common_status err;;
   monitor)  mysql_monitor;;
   promote)  mysql_promote;;
@@ -1054,8 +1054,8 @@ case "$1" in
   notify)   mysql_notify;;
   validate-all) exit $OCF_SUCCESS;;
 
- *)     usage
-        exit $OCF_ERR_UNIMPLEMENTED;;
+ *)	 usage
+		exit $OCF_ERR_UNIMPLEMENTED;;
 esac
 
 # vi:sw=4:ts=4:et:

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -332,6 +332,23 @@ END
 
 # Convenience functions
 
+quit_on_error() {
+	local error_message="$1"
+	local exit_code="$2"
+
+	if ocf_is_ms; then
+		# Clear master-mysql score so we don't get promoted to master ever
+		$CRM_MASTER -D
+		# Removing reader vip
+		set_reader_attr 0
+	fi
+
+	# Log the error
+	ocf_log err "error_message: ${error_message} exit_code: ${exit_code}"
+
+	exit $exit_code
+}
+
 set_read_only() {
 	# Sets or unsets read-only mode. Accepts one boolean as its
 	# optional argument. If invoked without any arguments, defaults to

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -5,22 +5,22 @@
 #
 # Description:  Manages a MySQL database as Linux-HA resource
 #
-# Authors:  Alan Robertson:			   DB2 Script
-#		   Jakub Janczak:				rewrite as MySQL
-#		   Andrew Beekhof:			   cleanup and import
-#		   Sebastian Reitenbach:		 add OpenBSD defaults, more cleanup
-#		   Narayan Newton:			   add Gentoo/Debian defaults
-#		   Marian Marinov, Florian Haas: add replication capability
-#		   Yves Trudeau, Baron Schwartz: add VIP support and improve replication
+# Authors:  Alan Robertson:               DB2 Script
+#           Jakub Janczak:                rewrite as MySQL
+#           Andrew Beekhof:               cleanup and import
+#           Sebastian Reitenbach:         add OpenBSD defaults, more cleanup
+#           Narayan Newton:               add Gentoo/Debian defaults
+#           Marian Marinov, Florian Haas: add replication capability
+#           Yves Trudeau, Baron Schwartz: add VIP support and improve replication
 #
 # Support:  users@clusterlabs.org
 # License:  GNU General Public License (GPL)
 #
 # (c) 2002-2005 International Business Machines, Inc.
-#	 2005-2010 Linux-HA contributors
+#     2005-2010 Linux-HA contributors
 #
 # An example usage in /etc/ha.d/haresources:
-#	   node1  10.0.0.170 mysql
+#       node1  10.0.0.170 mysql
 #
 # See usage() function below for more details...
 #
@@ -333,380 +333,380 @@ END
 # Convenience functions
 
 quit_on_error() {
-	local error_message="$1"
-	local exit_code="$2"
+    local error_message="$1"
+    local exit_code="$2"
 
-	if ocf_is_ms; then
-		# Clear master-mysql score so we don't get promoted to master ever
-		$CRM_MASTER -D
-		# Removing reader vip
-		set_reader_attr 0
-	fi
+    if ocf_is_ms; then
+        # Clear master-mysql score so we don't get promoted to master ever
+        $CRM_MASTER -D
+        # Removing reader vip
+        set_reader_attr 0
+    fi
 
-	# Log the error
-	ocf_log err "error_message: ${error_message} exit_code: ${exit_code}"
+    # Log the error
+    ocf_log err "error_message: ${error_message} exit_code: ${exit_code}"
 
-	exit $exit_code
+    exit $exit_code
 }
 
 set_read_only() {
-	# Sets or unsets read-only mode. Accepts one boolean as its
-	# optional argument. If invoked without any arguments, defaults to
-	# enabling read only mode. Should only be set in master/slave
-	# setups.
-	# Returns $OCF_SUCCESS if the operation succeeds, or
-	# $OCF_ERR_GENERIC if it fails.
-	local ro_val
-	if ocf_is_true $1; then
-		ro_val="on"
-	else
-		ro_val="off"
-	fi
-	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-		-e "SET GLOBAL read_only=${ro_val}"
+    # Sets or unsets read-only mode. Accepts one boolean as its
+    # optional argument. If invoked without any arguments, defaults to
+    # enabling read only mode. Should only be set in master/slave
+    # setups.
+    # Returns $OCF_SUCCESS if the operation succeeds, or
+    # $OCF_ERR_GENERIC if it fails.
+    local ro_val
+    if ocf_is_true $1; then
+        ro_val="on"
+    else
+        ro_val="off"
+    fi
+    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+        -e "SET GLOBAL read_only=${ro_val}"
 }
 
 get_read_only() {
-	# Check if read-only is set
-	local read_only_state
+    # Check if read-only is set
+    local read_only_state
 
-	read_only_state=`$MYSQL $MYSQL_OPTIONS_REPL \
-		--skip-column-names -e "SHOW VARIABLES LIKE 'read_only'" | awk '{print $2}'`
+    read_only_state=`$MYSQL $MYSQL_OPTIONS_REPL \
+        --skip-column-names -e "SHOW VARIABLES LIKE 'read_only'" | awk '{print $2}'`
 
-	if [ "$read_only_state" = "ON" ]; then
-		return 0
-	else
-		return 1
-	fi
+    if [ "$read_only_state" = "ON" ]; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 is_slave() {
-	# Determine whether the machine is currently running as a MySQL
-	# slave, as determined per SHOW SLAVE STATUS. Returns 1 if SHOW
-	# SLAVE STATUS creates an empty result set, 0 otherwise.
-	local rc
-	local tmpfile
+    # Determine whether the machine is currently running as a MySQL
+    # slave, as determined per SHOW SLAVE STATUS. Returns 1 if SHOW
+    # SLAVE STATUS creates an empty result set, 0 otherwise.
+    local rc
+    local tmpfile
 
-	# Check whether this machine should be slave
-	if ! ocf_is_ms || ! get_read_only; then
-		return 1
-	fi
+    # Check whether this machine should be slave
+    if ! ocf_is_ms || ! get_read_only; then
+        return 1
+    fi
    
-	get_slave_info
-	rc=$?
-	rm -f $tmpfile
+    get_slave_info
+    rc=$?
+    rm -f $tmpfile
 
-	if [ $rc -eq 0 ]; then
-	   # show slave status is not empty
-	   # Is there a master_log_file defined?  (master_log_file is deleted 
-	   # by reset slave
-	   if [ "$master_log_file" ]; then
-		  return 0
-	   else
-		  return 1
-	   fi
-	else
-	   # "SHOW SLAVE STATUS" returns an empty set if instance is not a
-	   # replication slave
-	   return 1
-	fi
-	
+    if [ $rc -eq 0 ]; then
+       # show slave status is not empty
+       # Is there a master_log_file defined?  (master_log_file is deleted 
+       # by reset slave
+       if [ "$master_log_file" ]; then
+          return 0
+       else
+          return 1
+       fi
+    else
+       # "SHOW SLAVE STATUS" returns an empty set if instance is not a
+       # replication slave
+       return 1
+    fi
+    
 }
 
 parse_slave_info() {
-	# Extracts field $1 from result of "SHOW SLAVE STATUS\G" from file $2
-	sed -ne "s/^.* $1: \(.*\)$/\1/p" < $2
+    # Extracts field $1 from result of "SHOW SLAVE STATUS\G" from file $2
+    sed -ne "s/^.* $1: \(.*\)$/\1/p" < $2
 }
 
 get_slave_info() {
-	# Warning: this sets $tmpfile and LEAVE this file! You must delete it after use!
-	local mysql_options
-			
-	if [ "$master_log_file" -a "$master_host" ]; then
-		# variables are already defined, get_slave_info has been run before
-		return $OCF_SUCCESS
-	fi
+    # Warning: this sets $tmpfile and LEAVE this file! You must delete it after use!
+    local mysql_options
+            
+    if [ "$master_log_file" -a "$master_host" ]; then
+        # variables are already defined, get_slave_info has been run before
+        return $OCF_SUCCESS
+    fi
 
-	tmpfile=`mktemp ${HA_RSCTMP}/check_slave.${OCF_RESOURCE_INSTANCE}.XXXXXX`
+    tmpfile=`mktemp ${HA_RSCTMP}/check_slave.${OCF_RESOURCE_INSTANCE}.XXXXXX`
 
-	$MYSQL $MYSQL_OPTIONS_REPL \
-	-e 'SHOW SLAVE STATUS\G' > $tmpfile
+    $MYSQL $MYSQL_OPTIONS_REPL \
+    -e 'SHOW SLAVE STATUS\G' > $tmpfile
 
-	if [ ! -s $tmpfile ]; then
-		# Instance produced an empty "SHOW SLAVE STATUS" output --
-		# instance is not a slave
-		ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
-		return $OCF_ERR_GENERIC
-	fi
+    if [ ! -s $tmpfile ]; then
+        # Instance produced an empty "SHOW SLAVE STATUS" output --
+        # instance is not a slave
+        ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
+        return $OCF_ERR_GENERIC
+    fi
 
-	master_host=`parse_slave_info Master_Host $tmpfile`
-	master_user=`parse_slave_info Master_User $tmpfile`
-	master_port=`parse_slave_info Master_Port $tmpfile`
-	master_log_file=`parse_slave_info Master_Log_File $tmpfile`
-	master_log_pos=`parse_slave_info Read_Master_Log_Pos $tmpfile`
-	Slave_SQL_Running=`parse_slave_info Slave_SQL_Running $tmpfile`
-	Slave_IO_Running=`parse_slave_info Slave_IO_Running $tmpfile`
-	Seconds_Behind_Master=`parse_slave_info Seconds_Behind_Master $tmpfile`
-	Last_Errno=`parse_slave_info Last_Errno $tmpfile`
-	Last_Error=`parse_slave_info Last_Error $tmpfile`
-	Last_IO_Errno=`parse_slave_info Last_IO_Errno $tmpfile`
-	Last_IO_Error=`parse_slave_info Last_IO_Error $tmpfile`
-	Last_SQL_Errno=`parse_slave_info Last_SQL_Errno $tmpfile`
-	Last_SQL_Error=`parse_slave_info Last_SQL_Error $tmpfile`
-	ocf_log debug "MySQL instance running as a replication slave"
+    master_host=`parse_slave_info Master_Host $tmpfile`
+    master_user=`parse_slave_info Master_User $tmpfile`
+    master_port=`parse_slave_info Master_Port $tmpfile`
+    master_log_file=`parse_slave_info Master_Log_File $tmpfile`
+    master_log_pos=`parse_slave_info Read_Master_Log_Pos $tmpfile`
+    Slave_SQL_Running=`parse_slave_info Slave_SQL_Running $tmpfile`
+    Slave_IO_Running=`parse_slave_info Slave_IO_Running $tmpfile`
+    Seconds_Behind_Master=`parse_slave_info Seconds_Behind_Master $tmpfile`
+    Last_Errno=`parse_slave_info Last_Errno $tmpfile`
+    Last_Error=`parse_slave_info Last_Error $tmpfile`
+    Last_IO_Errno=`parse_slave_info Last_IO_Errno $tmpfile`
+    Last_IO_Error=`parse_slave_info Last_IO_Error $tmpfile`
+    Last_SQL_Errno=`parse_slave_info Last_SQL_Errno $tmpfile`
+    Last_SQL_Error=`parse_slave_info Last_SQL_Error $tmpfile`
+    ocf_log debug "MySQL instance running as a replication slave"
 
-	return $OCF_SUCCESS
+    return $OCF_SUCCESS
 }
 
 check_slave() {
-	# Checks slave status
-	local rc new_master
+    # Checks slave status
+    local rc new_master
 
-	get_slave_info
-	rc=$?
+    get_slave_info
+    rc=$?
 
-	if [ $rc -ne 0 ]; then
-		# Instance produced an empty "SHOW SLAVE STATUS" output --
-		# instance is not a slave
-		# TODO: Needs to handle when get_slave_info will return too many connections error
-		rm -f $tmpfile
-		quit_on_error "check_slave invoked on an instance that is not a replication slave: $rc" $OCF_ERR_GENERIC
-	fi
+    if [ $rc -ne 0 ]; then
+        # Instance produced an empty "SHOW SLAVE STATUS" output --
+        # instance is not a slave
+        # TODO: Needs to handle when get_slave_info will return too many connections error
+        rm -f $tmpfile
+        quit_on_error "check_slave invoked on an instance that is not a replication slave: $rc" $OCF_ERR_GENERIC
+    fi
 
-	if [ "${Last_Errno}" == "$MYSQL_TOO_MANY_CONN_ERR" ]; then
-		# If we got max_connections, let's remove master score used by the failover and reader vip.
-		# However finish check nicely (0) to avoid restarting slave bussy with reading
-		quit_on_error "MYSQL_TOO_MANY_CONN_ERR ($MYSQL_TOO_MANY_CONN_ERR) ... check succeeded but node not suitable for failover/reader vip" 0
-	fi
+    if [ "${Last_Errno}" == "$MYSQL_TOO_MANY_CONN_ERR" ]; then
+        # If we got max_connections, let's remove master score used by the failover and reader vip.
+        # However finish check nicely (0) to avoid restarting slave bussy with reading
+        quit_on_error "MYSQL_TOO_MANY_CONN_ERR ($MYSQL_TOO_MANY_CONN_ERR) ... check succeeded but node not suitable for failover/reader vip" 0
+    fi
 
-	# If any of these is set, non-blank and non-zero (0) replication ran into a serious issue and slave can NOT be trusted anymore to be suitable for
-	# - up2date readable vip
-	# - slave that can be elected as master
-	# If we promote such slave there is a huge chance of data loss. That's why we better:
-	# - remove read vip
-	# - remove master score
-	# - fail the check
-	if [ "${Last_SQL_Error}" != "" ] || [ "${Last_SQL_Errno}" != "0" ]; then
-		quit_on_error "Replication failed Last_SQL_Errno: $Last_SQL_Errno Last_SQL_Error: $Last_SQL_Error" $OCF_ERR_GENERIC
-	fi
-	if [ "${Last_IO_Error}" != "" ] || [ "${Last_IO_Errno}" != "0" ]; then
-		quit_on_error "Replication failed Last_IO_Errno: $Last_IO_Errno Last_IO_Error: $Last_IO_Error" $OCF_ERR_GENERIC
-	fi
-	if [ "${Last_Error}" != "" ] || [ "${Last_Errno}" != "0" ]; then
-		# Did we receive an error other than max_connections?
-		quit_on_error "Replication failed Last_Errno: $Last_Errno Last_Error: $Last_Error" $OCF_ERR_GENERIC
-	fi
+    # If any of these is set, non-blank and non-zero (0) replication ran into a serious issue and slave can NOT be trusted anymore to be suitable for
+    # - up2date readable vip
+    # - slave that can be elected as master
+    # If we promote such slave there is a huge chance of data loss. That's why we better:
+    # - remove read vip
+    # - remove master score
+    # - fail the check
+    if [ "${Last_SQL_Error}" != "" ] || [ "${Last_SQL_Errno}" != "0" ]; then
+        quit_on_error "Replication failed Last_SQL_Errno: $Last_SQL_Errno Last_SQL_Error: $Last_SQL_Error" $OCF_ERR_GENERIC
+    fi
+    if [ "${Last_IO_Error}" != "" ] || [ "${Last_IO_Errno}" != "0" ]; then
+        quit_on_error "Replication failed Last_IO_Errno: $Last_IO_Errno Last_IO_Error: $Last_IO_Error" $OCF_ERR_GENERIC
+    fi
+    if [ "${Last_Error}" != "" ] || [ "${Last_Errno}" != "0" ]; then
+        # Did we receive an error other than max_connections?
+        quit_on_error "Replication failed Last_Errno: $Last_Errno Last_Error: $Last_Error" $OCF_ERR_GENERIC
+    fi
 
-	if [ "$Slave_SQL_Running" != 'Yes' ] || [ "$Slave_IO_Running" != 'Yes' ]; then
-		# We dont have a replication SQL thread running. Not a good thing but not so bad thing too.
-		# Not necessarily a bad thing. The master may have temporarily shut down, and the slave may just be reconnecting. A warning can't hurt, though.
-		# Try to recoved by restarting the SQL thread and remove reader vip.
+    if [ "$Slave_SQL_Running" != 'Yes' ] || [ "$Slave_IO_Running" != 'Yes' ]; then
+        # We dont have a replication SQL thread running. Not a good thing but not so bad thing too.
+        # Not necessarily a bad thing. The master may have temporarily shut down, and the slave may just be reconnecting. A warning can't hurt, though.
+        # Try to recoved by restarting the SQL thread and remove reader vip.
 
-		ocf_log warn "Slave_SQL_Running ($Slave_SQL_Running) or Slave_IO_Running ($Slave_IO_Running) currently NOT running"
+        ocf_log warn "Slave_SQL_Running ($Slave_SQL_Running) or Slave_IO_Running ($Slave_IO_Running) currently NOT running"
 
-		# Sanity check, are we at least on the right master
-		new_master=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f1`
+        # Sanity check, are we at least on the right master
+        new_master=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f1`
 
-		if ocf_is_true $OCF_RESKEY_ensure_follow_correct_master; then
-			if [ "$master_host" != "$new_master" ]; then
-				quit_on_error "Replication failed node master: $master_host cluster master: $new_master" $OCF_ERR_GENERIC
-			fi
-		fi
+        if ocf_is_true $OCF_RESKEY_ensure_follow_correct_master; then
+            if [ "$master_host" != "$new_master" ]; then
+                quit_on_error "Replication failed node master: $master_host cluster master: $new_master" $OCF_ERR_GENERIC
+            fi
+        fi
 
-		ocf_log warn "Attempting START SLAVE"
-		# try to restart slave
-		ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-			-e "START SLAVE"
+        ocf_log warn "Attempting START SLAVE"
+        # try to restart slave
+        ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+            -e "START SLAVE"
 
-		# quit_on_error should always quit with success here
-		# If further errors occur after this start slave they will be cought by the checks above
-		quit_on_error "Replication failed Slave_SQL_Running ($Slave_SQL_Running) Slave_IO_Running ($Slave_IO_Running) ... start slave was attempted" 0
-	fi
+        # quit_on_error should always quit with success here
+        # If further errors occur after this start slave they will be cought by the checks above
+        quit_on_error "Replication failed Slave_SQL_Running ($Slave_SQL_Running) Slave_IO_Running ($Slave_IO_Running) ... start slave was attempted" 0
+    fi
 
-	if ocf_is_true $OCF_RESKEY_evict_outdated_slaves; then
-		# We're supposed to bail out if we lag too far behind. Let's check our lag.
-		if [ "$Seconds_Behind_Master" = "NULL" ] || [ $Seconds_Behind_Master -gt $OCF_RESKEY_max_slave_lag ]; then
-			quit_on_error "Replication failed max_slave_lag: $OCF_RESKEY_max_slave_lag current_lag: $Seconds_Behind_Master" $OCF_ERR_INSTALLED
-		fi
-	fi
+    if ocf_is_true $OCF_RESKEY_evict_outdated_slaves; then
+        # We're supposed to bail out if we lag too far behind. Let's check our lag.
+        if [ "$Seconds_Behind_Master" = "NULL" ] || [ $Seconds_Behind_Master -gt $OCF_RESKEY_max_slave_lag ]; then
+            quit_on_error "Replication failed max_slave_lag: $OCF_RESKEY_max_slave_lag current_lag: $Seconds_Behind_Master" $OCF_ERR_INSTALLED
+        fi
+    fi
 
-	# is the slave ok to have a VIP on it
-	if [ "$Seconds_Behind_Master" = "NULL" ] || [ $Seconds_Behind_Master -gt $OCF_RESKEY_max_slave_lag ]; then
-		set_reader_attr 0
-	else
-		set_reader_attr 1
-	fi
+    # is the slave ok to have a VIP on it
+    if [ "$Seconds_Behind_Master" = "NULL" ] || [ $Seconds_Behind_Master -gt $OCF_RESKEY_max_slave_lag ]; then
+        set_reader_attr 0
+    else
+        set_reader_attr 1
+    fi
 
-	# Even if we're not set to evict lagging slaves, we can still use the seconds behind master value to set our master preference.
-	local master_pref
-	master_pref=$((${OCF_RESKEY_max_slave_lag}-${Seconds_Behind_Master}))
-	if [ $master_pref -lt 0 ]; then
-		# Sanitize a below-zero preference to just zero
-		master_pref=0
-	fi
+    # Even if we're not set to evict lagging slaves, we can still use the seconds behind master value to set our master preference.
+    local master_pref
+    master_pref=$((${OCF_RESKEY_max_slave_lag}-${Seconds_Behind_Master}))
+    if [ $master_pref -lt 0 ]; then
+        # Sanitize a below-zero preference to just zero
+        master_pref=0
+    fi
 
-	ocf_log debug "check_slave setting master preference to $master_pref via $CRM_MASTER -v $master_pref"
-	$CRM_MASTER -v $master_pref
+    ocf_log debug "check_slave setting master preference to $master_pref via $CRM_MASTER -v $master_pref"
+    $CRM_MASTER -v $master_pref
 
-	ocf_log debug "MySQL instance running as a replication slave"
+    ocf_log debug "MySQL instance running as a replication slave"
 
-	rm -f $tmpfile
+    rm -f $tmpfile
 
-	return $OCF_SUCCESS
+    return $OCF_SUCCESS
 }
 
 set_master() {
-	local new_master master_log_file master_log_pos
-	local master_params
+    local new_master master_log_file master_log_pos
+    local master_params
 
-	new_master=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f1`
+    new_master=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f1`
 
-	# Keep replication position
-	get_slave_info
+    # Keep replication position
+    get_slave_info
 
-	if [ "$master_log_file" -a "$new_master" = "$master_host" ]; then
-		#	master_params=", MASTER_LOG_FILE='$master_log_file', \
-		#		MASTER_LOG_POS=$master_log_pos"
-		ocf_log info "Kept master pos for $master_host : $master_log_file:$master_log_pos"
-		rm -f $tmpfile
-		return
-	else
-		master_log_file=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f2`
-		master_log_pos=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f3`
-		if [ -n "$master_log_file" -a -n "$master_log_pos" ]; then
-			master_params=", MASTER_LOG_FILE='$master_log_file', \
-			MASTER_LOG_POS=$master_log_pos"
-			ocf_log info "Restored master pos for $new_master : $master_log_file:$master_log_pos"
-		fi
-	fi
+    if [ "$master_log_file" -a "$new_master" = "$master_host" ]; then
+        #    master_params=", MASTER_LOG_FILE='$master_log_file', \
+        #        MASTER_LOG_POS=$master_log_pos"
+        ocf_log info "Kept master pos for $master_host : $master_log_file:$master_log_pos"
+        rm -f $tmpfile
+        return
+    else
+        master_log_file=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f2`
+        master_log_pos=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f3`
+        if [ -n "$master_log_file" -a -n "$master_log_pos" ]; then
+            master_params=", MASTER_LOG_FILE='$master_log_file', \
+            MASTER_LOG_POS=$master_log_pos"
+            ocf_log info "Restored master pos for $new_master : $master_log_file:$master_log_pos"
+        fi
+    fi
 
-	# Informs the MySQL server of the master to replicate
-	# from. Accepts one mandatory argument which must contain the host
-	# name of the new master host. The master must either be unchanged
-	# from the laste master the slave replicated from, or freshly
-	# reset with RESET MASTER.
+    # Informs the MySQL server of the master to replicate
+    # from. Accepts one mandatory argument which must contain the host
+    # name of the new master host. The master must either be unchanged
+    # from the laste master the slave replicated from, or freshly
+    # reset with RESET MASTER.
 
-	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-		-e "CHANGE MASTER TO MASTER_HOST='$new_master', \
-		MASTER_PORT=$OCF_RESKEY_replication_port, \
-		MASTER_USER='$OCF_RESKEY_replication_user', \
-		MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $master_params"
-	rm -f $tmpfile
+    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+        -e "CHANGE MASTER TO MASTER_HOST='$new_master', \
+        MASTER_PORT=$OCF_RESKEY_replication_port, \
+        MASTER_USER='$OCF_RESKEY_replication_user', \
+        MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $master_params"
+    rm -f $tmpfile
 }
 
 unset_master(){
-	# Instructs the MySQL server to stop replicating from a master
-	# host.
+    # Instructs the MySQL server to stop replicating from a master
+    # host.
 
-	# If we're currently not configured to be replicating from any
-	# host, then there's nothing to do. But we do log a warning as
-	# no-one but the CRM should be touching the MySQL master/slave
-	# configuration.
-	if ! is_slave; then
-		ocf_log warn "Attempted to unset the replication master on an instance that is not configured as a replication slave"
-		return $OCF_SUCCESS
-	fi
+    # If we're currently not configured to be replicating from any
+    # host, then there's nothing to do. But we do log a warning as
+    # no-one but the CRM should be touching the MySQL master/slave
+    # configuration.
+    if ! is_slave; then
+        ocf_log warn "Attempted to unset the replication master on an instance that is not configured as a replication slave"
+        return $OCF_SUCCESS
+    fi
 
-	local tmpfile
-	tmpfile=`mktemp ${HA_RSCTMP}/unset_master.${OCF_RESOURCE_INSTANCE}.XXXXXX`
+    local tmpfile
+    tmpfile=`mktemp ${HA_RSCTMP}/unset_master.${OCF_RESOURCE_INSTANCE}.XXXXXX`
 
-	# At this point, the master is read only so there should not be much binlogs to transfer
-	# Let's wait for the last bits
-	while true; do
-		$MYSQL $MYSQL_OPTIONS_REPL \
-		-e 'SHOW PROCESSLIST\G' > $tmpfile
-		if grep -i 'Waiting for master to send event' $tmpfile >/dev/null; then
-			ocf_log info "MySQL slave has finished reading master binary log"
-			break
-		fi
-		if grep -i 'Reconnecting after a failed master event read' $tmpfile >/dev/null; then
-			ocf_log info "Master is down, no more binary logs to come"
-			break
-		fi
-		if grep -i 'Connecting to master' $tmpfile >/dev/null; then
-			ocf_log info "Master is down, no more binary logs to come"
-			break
-		fi
-		if ! grep 'system user' $tmpfile >/dev/null; then
-			ocf_log info "Slave is not running - not waiting to finish"
-			break
-		fi
+    # At this point, the master is read only so there should not be much binlogs to transfer
+    # Let's wait for the last bits
+    while true; do
+        $MYSQL $MYSQL_OPTIONS_REPL \
+        -e 'SHOW PROCESSLIST\G' > $tmpfile
+        if grep -i 'Waiting for master to send event' $tmpfile >/dev/null; then
+            ocf_log info "MySQL slave has finished reading master binary log"
+            break
+        fi
+        if grep -i 'Reconnecting after a failed master event read' $tmpfile >/dev/null; then
+            ocf_log info "Master is down, no more binary logs to come"
+            break
+        fi
+        if grep -i 'Connecting to master' $tmpfile >/dev/null; then
+            ocf_log info "Master is down, no more binary logs to come"
+            break
+        fi
+        if ! grep 'system user' $tmpfile >/dev/null; then
+            ocf_log info "Slave is not running - not waiting to finish"
+            break
+        fi
 
-		sleep 1
-	done
+        sleep 1
+    done
 
-	# Now, stop the slave I/O thread and wait for relay log
-	# processing to complete
-	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-		-e "STOP SLAVE IO_THREAD"
-	if [ $? -gt 0 ]; then
-		ocf_exit_reason "Error stopping slave IO thread"
-		exit $OCF_ERR_GENERIC
-	fi
+    # Now, stop the slave I/O thread and wait for relay log
+    # processing to complete
+    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+        -e "STOP SLAVE IO_THREAD"
+    if [ $? -gt 0 ]; then
+        ocf_exit_reason "Error stopping slave IO thread"
+        exit $OCF_ERR_GENERIC
+    fi
 
-	while true; do
-		$MYSQL $MYSQL_OPTIONS_REPL \
-			-e 'SHOW PROCESSLIST\G' > $tmpfile
-		if grep -i 'Has read all relay log' $tmpfile >/dev/null; then
-			ocf_log info "MySQL slave has finished processing relay log"
-			break
-		fi
-		if ! grep -q 'system user' $tmpfile; then
-			ocf_log info "Slave not runnig - not waiting to finish"
-			break
-		fi
-		ocf_log info "Waiting for MySQL slave to finish processing relay log"
-		sleep 1
-	done
-	rm -f $tmpfile
+    while true; do
+        $MYSQL $MYSQL_OPTIONS_REPL \
+            -e 'SHOW PROCESSLIST\G' > $tmpfile
+        if grep -i 'Has read all relay log' $tmpfile >/dev/null; then
+            ocf_log info "MySQL slave has finished processing relay log"
+            break
+        fi
+        if ! grep -q 'system user' $tmpfile; then
+            ocf_log info "Slave not runnig - not waiting to finish"
+            break
+        fi
+        ocf_log info "Waiting for MySQL slave to finish processing relay log"
+        sleep 1
+    done
+    rm -f $tmpfile
 
-	# Now, stop all slave activity and unset the master host
-	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-		-e "STOP SLAVE"
-	if [ $? -gt 0 ]; then
-		ocf_exit_reason "Error stopping rest slave threads"
-		exit $OCF_ERR_GENERIC
-	fi
+    # Now, stop all slave activity and unset the master host
+    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+        -e "STOP SLAVE"
+    if [ $? -gt 0 ]; then
+        ocf_exit_reason "Error stopping rest slave threads"
+        exit $OCF_ERR_GENERIC
+    fi
 
-	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-		-e "RESET SLAVE /*!50516 ALL */;"
-	if [ $? -gt 0 ]; then
-		ocf_exit_reason "Failed to reset slave"
-		exit $OCF_ERR_GENERIC
-	fi
+    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+        -e "RESET SLAVE /*!50516 ALL */;"
+    if [ $? -gt 0 ]; then
+        ocf_exit_reason "Failed to reset slave"
+        exit $OCF_ERR_GENERIC
+    fi
 }
 
 # Start replication as slave
 start_slave() {
 
-	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-		-e "START SLAVE"
+    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+        -e "START SLAVE"
 }
 
 # Set the attribute controlling the readers VIP
 set_reader_attr() {
-	local curr_attr_value
+    local curr_attr_value
 
-	curr_attr_value=$(get_reader_attr)
+    curr_attr_value=$(get_reader_attr)
 
-	if [ "$curr_attr_value" -ne "$1" ]; then
-		$CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} -v $1
-	fi
+    if [ "$curr_attr_value" -ne "$1" ]; then
+        $CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} -v $1
+    fi
 
 }
 
 # get the attribute controlling the readers VIP
 get_reader_attr() {
-	local attr_value
-	local rc
+    local attr_value
+    local rc
 
-	attr_value=`$CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} --query -q`
-	rc=$?
-	if [ "$rc" -eq "0" ]; then
-		echo $attr_value
-	else
-		echo -1
-	fi
+    attr_value=`$CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} --query -q`
+    rc=$?
+    if [ "$rc" -eq "0" ]; then
+        echo $attr_value
+    else
+        echo -1
+    fi
 
 }
 
@@ -738,9 +738,9 @@ get_local_ip() {
    local IP
    IP=`$CRM_ATTR -l forever -n ${INSTANCE_ATTR_NAME}_mysql_master_IP -q -G`
    if [ ! $? -eq 0 ]; then
-	  uname -n
+      uname -n
    else
-	  echo $IP
+      echo $IP
    fi
 }
 
@@ -749,273 +749,273 @@ get_local_ip() {
 # Functions invoked by resource manager actions
 
 mysql_monitor() {
-	local rc
-	local status_loglevel="err"
+    local rc
+    local status_loglevel="err"
 
-	# Set loglevel to info during probe
-	if ocf_is_probe; then
-		status_loglevel="info"
-	fi
+    # Set loglevel to info during probe
+    if ocf_is_probe; then
+        status_loglevel="info"
+    fi
  
-	mysql_common_status $status_loglevel
-	rc=$?
+    mysql_common_status $status_loglevel
+    rc=$?
 
-	# TODO: check max connections error
+    # TODO: check max connections error
 
-	# If status returned an error, return that immediately
-	if [ $rc -ne $OCF_SUCCESS ]; then
-		quit_on_error "mysql_status returned error: $rc" $rc
-	fi
+    # If status returned an error, return that immediately
+    if [ $rc -ne $OCF_SUCCESS ]; then
+        quit_on_error "mysql_status returned error: $rc" $rc
+    fi
 
-	if [ $OCF_CHECK_LEVEL -gt 0 -a -n "$OCF_RESKEY_test_table" ]; then
-		# Check for test table
-		if ! ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST -e "SELECT COUNT(*) FROM $OCF_RESKEY_test_table"; then
-			quit_on_error "Failed to select from $test_table" $OCF_ERR_GENERIC
-		fi
-	fi
+    if [ $OCF_CHECK_LEVEL -gt 0 -a -n "$OCF_RESKEY_test_table" ]; then
+        # Check for test table
+        if ! ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST -e "SELECT COUNT(*) FROM $OCF_RESKEY_test_table"; then
+            quit_on_error "Failed to select from $test_table" $OCF_ERR_GENERIC
+        fi
+    fi
 
-	if ocf_is_ms; then
-		if is_slave; then
-			# Check slave replication status in details
-			check_slave
-			ocf_log debug "MySQL monitor succeeded (slave) ... returning $OCF_SUCCESS";
-			return $OCF_SUCCESS
-		else
-			# master is always readable and always with highest scores
-			$CRM_MASTER -v $((${OCF_RESKEY_max_slave_lag}+1))
-			set_reader_attr 1
-			ocf_log debug "MySQL monitor succeeded (master) ... returning $OCF_RUNNING_MASTER";
-			return $OCF_RUNNING_MASTER
-		fi
-	else
-		ocf_log debug "MySQL monitor succeeded ... returning $OCF_SUCCESS";
-		return $OCF_SUCCESS
-	fi
+    if ocf_is_ms; then
+        if is_slave; then
+            # Check slave replication status in details
+            check_slave
+            ocf_log debug "MySQL monitor succeeded (slave) ... returning $OCF_SUCCESS";
+            return $OCF_SUCCESS
+        else
+            # master is always readable and always with highest scores
+            $CRM_MASTER -v $((${OCF_RESKEY_max_slave_lag}+1))
+            set_reader_attr 1
+            ocf_log debug "MySQL monitor succeeded (master) ... returning $OCF_RUNNING_MASTER";
+            return $OCF_RUNNING_MASTER
+        fi
+    else
+        ocf_log debug "MySQL monitor succeeded ... returning $OCF_SUCCESS";
+        return $OCF_SUCCESS
+    fi
 
 }
 
 mysql_start() {
-	local rc
+    local rc
 
-	if ocf_is_ms; then
-		# Initialize the ReaderVIP attribute, monitor will enable it
-		set_reader_attr 0
-	fi
+    if ocf_is_ms; then
+        # Initialize the ReaderVIP attribute, monitor will enable it
+        set_reader_attr 0
+    fi
 
-	mysql_common_status info
-	if [ $? = $OCF_SUCCESS ]; then
-		ocf_log info "MySQL already running"
-		return $OCF_SUCCESS
-	fi
+    mysql_common_status info
+    if [ $? = $OCF_SUCCESS ]; then
+        ocf_log info "MySQL already running"
+        return $OCF_SUCCESS
+    fi
 
-	mysql_common_prepare_dirs
+    mysql_common_prepare_dirs
 
-	# Uncomment to perform permission clensing
-	# - not convinced this should be enabled by default
-	#
-	#chmod 0755 $OCF_RESKEY_datadir
-	#chown -R $OCF_RESKEY_user $OCF_RESKEY_datadir
-	#chgrp -R $OCF_RESKEY_group $OCF_RESKEY_datadir
-	mysql_extra_params=
-	if ocf_is_ms; then
-		mysql_extra_params="--skip-slave-start"
-	fi
+    # Uncomment to perform permission clensing
+    # - not convinced this should be enabled by default
+    #
+    #chmod 0755 $OCF_RESKEY_datadir
+    #chown -R $OCF_RESKEY_user $OCF_RESKEY_datadir
+    #chgrp -R $OCF_RESKEY_group $OCF_RESKEY_datadir
+    mysql_extra_params=
+    if ocf_is_ms; then
+        mysql_extra_params="--skip-slave-start"
+    fi
 
-	mysql_common_start $mysql_extra_params
-	rc=$?
-	if [ $rc != $OCF_SUCCESS ]; then
-		return $rc
-	fi
+    mysql_common_start $mysql_extra_params
+    rc=$?
+    if [ $rc != $OCF_SUCCESS ]; then
+        return $rc
+    fi
 
-	if ocf_is_ms; then
-		# We're configured as a stateful resource. We must start as
-		# slave by default. At this point we don't know if the CRM has
-		# already promoted a master. So, we simply start in read only
-		# mode.
-		set_read_only on
+    if ocf_is_ms; then
+        # We're configured as a stateful resource. We must start as
+        # slave by default. At this point we don't know if the CRM has
+        # already promoted a master. So, we simply start in read only
+        # mode.
+        set_read_only on
 
-		# Now, let's see whether there is a master. We might be a new
-		# node that is just joining the cluster, and the CRM may have
-		# promoted a master before.
-		master_host=`echo $OCF_RESKEY_CRM_meta_notify_master_uname|tr -d " "`
-		if [ "$master_host" -a "$master_host" != ${NODENAME} ]; then
-			ocf_log info "Changing MySQL configuration to replicate from $master_host."
-			set_master
-			start_slave
-			if [ $? -ne 0 ]; then
-				ocf_exit_reason "Failed to start slave"
-				return $OCF_ERR_GENERIC
-			fi
-		else
-			ocf_log info "No MySQL master present - clearing replication state"
-			unset_master
-		fi
+        # Now, let's see whether there is a master. We might be a new
+        # node that is just joining the cluster, and the CRM may have
+        # promoted a master before.
+        master_host=`echo $OCF_RESKEY_CRM_meta_notify_master_uname|tr -d " "`
+        if [ "$master_host" -a "$master_host" != ${NODENAME} ]; then
+            ocf_log info "Changing MySQL configuration to replicate from $master_host."
+            set_master
+            start_slave
+            if [ $? -ne 0 ]; then
+                ocf_exit_reason "Failed to start slave"
+                return $OCF_ERR_GENERIC
+            fi
+        else
+            ocf_log info "No MySQL master present - clearing replication state"
+            unset_master
+        fi
 
-		# We also need to set a master preference, otherwise Pacemaker
-		# won't ever promote us in the absence of any explicit
-		# preference set by the administrator. We choose a low
-		# greater-than-zero preference.
-		$CRM_MASTER -v 1
+        # We also need to set a master preference, otherwise Pacemaker
+        # won't ever promote us in the absence of any explicit
+        # preference set by the administrator. We choose a low
+        # greater-than-zero preference.
+        $CRM_MASTER -v 1
 
-	fi
+    fi
 
-	# Initial monitor action
-	if [ -n "$OCF_RESKEY_test_table" -a -n "$OCF_RESKEY_test_user" -a -n "$OCF_RESKEY_test_passwd" ]; then
-		OCF_CHECK_LEVEL=10
-	fi
-	mysql_monitor
-	rc=$?
-	if [ $rc != $OCF_SUCCESS -a $rc != $OCF_RUNNING_MASTER ]; then
-		ocf_exit_reason "Failed initial monitor action"
-		return $rc
-	fi
+    # Initial monitor action
+    if [ -n "$OCF_RESKEY_test_table" -a -n "$OCF_RESKEY_test_user" -a -n "$OCF_RESKEY_test_passwd" ]; then
+        OCF_CHECK_LEVEL=10
+    fi
+    mysql_monitor
+    rc=$?
+    if [ $rc != $OCF_SUCCESS -a $rc != $OCF_RUNNING_MASTER ]; then
+        ocf_exit_reason "Failed initial monitor action"
+        return $rc
+    fi
 
-	ocf_log info "MySQL started"
-	return $OCF_SUCCESS
+    ocf_log info "MySQL started"
+    return $OCF_SUCCESS
 }
 
 mysql_stop() {
-	if ocf_is_ms; then
-		# clear preference for becoming master
-		$CRM_MASTER -D
+    if ocf_is_ms; then
+        # clear preference for becoming master
+        $CRM_MASTER -D
 
-		# Remove VIP capability
-		set_reader_attr 0
-	fi
+        # Remove VIP capability
+        set_reader_attr 0
+    fi
 
-	mysql_common_stop
+    mysql_common_stop
 }
 
 mysql_promote() {
-	local master_info
+    local master_info
 
-	if ( ! mysql_common_status err ); then
-		return $OCF_NOT_RUNNING
-	fi
-	ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-		-e "STOP SLAVE"
+    if ( ! mysql_common_status err ); then
+        return $OCF_NOT_RUNNING
+    fi
+    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+        -e "STOP SLAVE"
 
-	# Set Master Info in CIB, cluster level attribute
-	update_data_master_status
-	master_info="$(get_local_ip)|$(get_master_status File)|$(get_master_status Position)"
-	${CRM_ATTR_REPL_INFO} -v "$master_info"
-	rm -f $tmpfile
+    # Set Master Info in CIB, cluster level attribute
+    update_data_master_status
+    master_info="$(get_local_ip)|$(get_master_status File)|$(get_master_status Position)"
+    ${CRM_ATTR_REPL_INFO} -v "$master_info"
+    rm -f $tmpfile
 
-	set_read_only off || return $OCF_ERR_GENERIC
+    set_read_only off || return $OCF_ERR_GENERIC
 
-	# Existing master gets a higher-than-default master preference, so
-	# the cluster manager does not shuffle the master role around
-	# unnecessarily
-	$CRM_MASTER -v $((${OCF_RESKEY_max_slave_lag}+1))
+    # Existing master gets a higher-than-default master preference, so
+    # the cluster manager does not shuffle the master role around
+    # unnecessarily
+    $CRM_MASTER -v $((${OCF_RESKEY_max_slave_lag}+1))
 
-	# A master can accept reads
-	set_reader_attr 1
+    # A master can accept reads
+    set_reader_attr 1
 
-	return $OCF_SUCCESS
+    return $OCF_SUCCESS
 }
 
 mysql_demote() {
-	if ! mysql_common_status err; then
-		return $OCF_NOT_RUNNING
-	fi
+    if ! mysql_common_status err; then
+        return $OCF_NOT_RUNNING
+    fi
 
-	# Return master preference to default, so the cluster manager gets
-	# a chance to select a new master
-	$CRM_MASTER -v 1
+    # Return master preference to default, so the cluster manager gets
+    # a chance to select a new master
+    $CRM_MASTER -v 1
 }
 
 mysql_notify() {
-	# If not configured as a Stateful resource, we make no sense of
-	# notifications.
-	if ! ocf_is_ms; then
-		ocf_log info "This agent makes no use of notifications unless running in master/slave mode."
-		return $OCF_SUCCESS
-	fi
+    # If not configured as a Stateful resource, we make no sense of
+    # notifications.
+    if ! ocf_is_ms; then
+        ocf_log info "This agent makes no use of notifications unless running in master/slave mode."
+        return $OCF_SUCCESS
+    fi
 
-	local type_op
-	type_op="${OCF_RESKEY_CRM_meta_notify_type}-${OCF_RESKEY_CRM_meta_notify_operation}"
+    local type_op
+    type_op="${OCF_RESKEY_CRM_meta_notify_type}-${OCF_RESKEY_CRM_meta_notify_operation}"
 
-	ocf_log debug "Received $type_op notification."
+    ocf_log debug "Received $type_op notification."
 
-	case "$type_op" in
-		'pre-promote')
-			# Nothing to do now here, new replication info not yet published
+    case "$type_op" in
+        'pre-promote')
+            # Nothing to do now here, new replication info not yet published
 
-		;;
-		'post-promote')
-			# The master has completed its promotion. Now is a good
-			# time to check whether our replication slave is working
-			# correctly.
-			master_host=`echo $OCF_RESKEY_CRM_meta_notify_promote_uname|tr -d " "`
-			if [ "$master_host" = ${NODENAME} ]; then
-				ocf_log info "This will be the new master, ignoring post-promote notification."
-				touch "${OCF_RESKEY_mysql_master_lock_file}"
-			else
-				ocf_log info "Resetting replication"
-				unset_master
-				if [ $? -ne 0 ]; then
-					return $OCF_ERR_GENERIC
-				fi
+        ;;
+        'post-promote')
+            # The master has completed its promotion. Now is a good
+            # time to check whether our replication slave is working
+            # correctly.
+            master_host=`echo $OCF_RESKEY_CRM_meta_notify_promote_uname|tr -d " "`
+            if [ "$master_host" = ${NODENAME} ]; then
+                ocf_log info "This will be the new master, ignoring post-promote notification."
+                touch "${OCF_RESKEY_mysql_master_lock_file}"
+            else
+                ocf_log info "Resetting replication"
+                unset_master
+                if [ $? -ne 0 ]; then
+                    return $OCF_ERR_GENERIC
+                fi
 
-				ocf_log info "Changing MySQL configuration to replicate from $master_host"
-				set_master
-				if [ $? -ne 0 ]; then
-					return $OCF_ERR_GENERIC
-				fi
+                ocf_log info "Changing MySQL configuration to replicate from $master_host"
+                set_master
+                if [ $? -ne 0 ]; then
+                    return $OCF_ERR_GENERIC
+                fi
 
-				start_slave
-				if [ $? -ne 0 ]; then
-					ocf_exit_reason "Failed to start slave"
-					return $OCF_ERR_GENERIC
-				fi
-			fi
-			return $OCF_SUCCESS
-		;;
-		'pre-demote')
-			demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
-			if [ $demote_host = ${NODENAME} ]; then
-				ocf_log info "pre-demote notification for $demote_host"
+                start_slave
+                if [ $? -ne 0 ]; then
+                    ocf_exit_reason "Failed to start slave"
+                    return $OCF_ERR_GENERIC
+                fi
+            fi
+            return $OCF_SUCCESS
+        ;;
+        'pre-demote')
+            demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
+            if [ $demote_host = ${NODENAME} ]; then
+                ocf_log info "pre-demote notification for $demote_host"
 
-				ocf_log info "pre-demote Removing custom replication master marker."
-				rm -f "${OCF_RESKEY_mysql_master_lock_file}"
-				
-				set_read_only on
-				if [ $? -ne 0 ]; then
-					ocf_exit_reason "Failed to set read-only";
-					return $OCF_ERR_GENERIC;
-				fi
+                ocf_log info "pre-demote Removing custom replication master marker."
+                rm -f "${OCF_RESKEY_mysql_master_lock_file}"
+                
+                set_read_only on
+                if [ $? -ne 0 ]; then
+                    ocf_exit_reason "Failed to set read-only";
+                    return $OCF_ERR_GENERIC;
+                fi
 
-				# Must kill all existing user threads because they are still Read/write
-				# in order for the slaves to complete the read of binlogs
-				local tmpfile
-				tmpfile=`mktemp ${HA_RSCTMP}/threads.${OCF_RESOURCE_INSTANCE}.XXXXXX`
-				$MYSQL $MYSQL_OPTIONS_REPL \
-				-e "SHOW PROCESSLIST" > $tmpfile
+                # Must kill all existing user threads because they are still Read/write
+                # in order for the slaves to complete the read of binlogs
+                local tmpfile
+                tmpfile=`mktemp ${HA_RSCTMP}/threads.${OCF_RESOURCE_INSTANCE}.XXXXXX`
+                $MYSQL $MYSQL_OPTIONS_REPL \
+                -e "SHOW PROCESSLIST" > $tmpfile
 
-				for thread in `awk '$0 !~ /Binlog Dump|system user|event_scheduler|SHOW PROCESSLIST/ && $0 ~ /^[0-9]/ {print $1}' $tmpfile`
-				do
-					ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-						-e "KILL ${thread}"
-				done
-			else
-			   ocf_log info "Ignoring pre-demote notification execpt for my own demotion."
-			fi
-			return $OCF_SUCCESS
-		;;
-		'post-demote')
-			demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
-			if [ $demote_host = ${NODENAME} ]; then
-				ocf_log info "Ignoring post-demote notification for my own demotion."
-				return $OCF_SUCCESS
-			fi
-			ocf_log info "post-demote notification for $demote_host."
-			# The former master has just been gracefully demoted.
-			unset_master
-		;;
-		*)
-			return $OCF_SUCCESS
-		;;
-	esac
+                for thread in `awk '$0 !~ /Binlog Dump|system user|event_scheduler|SHOW PROCESSLIST/ && $0 ~ /^[0-9]/ {print $1}' $tmpfile`
+                do
+                    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+                        -e "KILL ${thread}"
+                done
+            else
+               ocf_log info "Ignoring pre-demote notification execpt for my own demotion."
+            fi
+            return $OCF_SUCCESS
+        ;;
+        'post-demote')
+            demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
+            if [ $demote_host = ${NODENAME} ]; then
+                ocf_log info "Ignoring post-demote notification for my own demotion."
+                return $OCF_SUCCESS
+            fi
+            ocf_log info "post-demote notification for $demote_host."
+            # The former master has just been gracefully demoted.
+            unset_master
+        ;;
+        *)
+            return $OCF_SUCCESS
+        ;;
+    esac
 }
 
 #######################################################################
@@ -1029,51 +1029,51 @@ mysql_notify() {
 ##########################################################################
 DEBUG_LOG="/tmp/mysql.ocf.ra.debug/log"
 if [ "${DEBUG_LOG}" -a -w "${DEBUG_LOG}" -a ! -L "${DEBUG_LOG}" ]; then
-	DEBUG_LOG_DIR="${DEBUG_LOG%/*}"
-	if [ -d "${DEBUG_LOG_DIR}" ]; then
-		exec 9>>"$DEBUG_LOG"
-		exec 2>&9
-		date >&9
-		echo "$*" >&9
-		env | grep OCF_ | sort >&9
-		set -x
-	else
-		exec 9>/dev/null
-	fi
+    DEBUG_LOG_DIR="${DEBUG_LOG%/*}"
+    if [ -d "${DEBUG_LOG_DIR}" ]; then
+        exec 9>>"$DEBUG_LOG"
+        exec 2>&9
+        date >&9
+        echo "$*" >&9
+        env | grep OCF_ | sort >&9
+        set -x
+    else
+        exec 9>/dev/null
+    fi
 fi
 
 case "$1" in
-  meta-data)	meta_data
-		exit $OCF_SUCCESS;;
+  meta-data)    meta_data
+        exit $OCF_SUCCESS;;
   usage|help)   usage
-		exit $OCF_SUCCESS;;
+        exit $OCF_SUCCESS;;
 esac
 
 mysql_common_validate
 rc=$?
 LSB_STATUS_STOPPED=3
 if [ $rc -ne 0 ]; then
-	case "$1" in
-		stop) ;;
-		monitor)
-			mysql_common_status "info"
-			if [ $? -eq $OCF_SUCCESS ]; then
-				# if validatation fails and pid is active, always treat this as an error
-				ocf_exit_reason "environment validation failed, active pid is in unknown state."
-				exit $OCF_ERR_GENERIC
-			fi
-			# validation failed and pid is not active, it's safe to say this instance is inactive.
-			exit $OCF_NOT_RUNNING;;
+    case "$1" in
+        stop) ;;
+        monitor)
+            mysql_common_status "info"
+            if [ $? -eq $OCF_SUCCESS ]; then
+                # if validatation fails and pid is active, always treat this as an error
+                ocf_exit_reason "environment validation failed, active pid is in unknown state."
+                exit $OCF_ERR_GENERIC
+            fi
+            # validation failed and pid is not active, it's safe to say this instance is inactive.
+            exit $OCF_NOT_RUNNING;;
 
-		status) exit $LSB_STATUS_STOPPED;;
-		*) exit $rc;;
-	esac
+        status) exit $LSB_STATUS_STOPPED;;
+        *) exit $rc;;
+    esac
 fi
 
 # What kind of method was invoked?
 case "$1" in
-  start)	mysql_start;;
-  stop)	 mysql_stop;;
+  start)    mysql_start;;
+  stop)     mysql_stop;;
   status)   mysql_common_status err;;
   monitor)  mysql_monitor;;
   promote)  mysql_promote;;
@@ -1081,8 +1081,8 @@ case "$1" in
   notify)   mysql_notify;;
   validate-all) exit $OCF_SUCCESS;;
 
- *)	 usage
-		exit $OCF_ERR_UNIMPLEMENTED;;
+ *)     usage
+        exit $OCF_ERR_UNIMPLEMENTED;;
 esac
 
 # vi:sw=4:ts=4:et:

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -777,41 +777,34 @@ mysql_monitor() {
 
 	# If status returned an error, return that immediately
 	if [ $rc -ne $OCF_SUCCESS ]; then
-        quit_on_error "mysql_status returned error: $rc" $rc
+		quit_on_error "mysql_status returned error: $rc" $rc
 	fi
 
 	if [ $OCF_CHECK_LEVEL -gt 0 -a -n "$OCF_RESKEY_test_table" ]; then
-		# Check if this instance is configured as a slave, and if so
-		# check slave status
-		if is_slave; then
-			check_slave
-		fi
-
 		# Check for test table
-		ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
-			-e "SELECT COUNT(*) FROM $OCF_RESKEY_test_table"
-		rc=$?
-
-		if [ $rc -ne 0 ]; then
-			# We are master/slave and test failed. Delete master score for this node as it is considered unhealthy because of this particular failed check.
-			ocf_is_ms && $CRM_MASTER -D
-			ocf_exit_reason "Failed to select from $test_table";
-			return $OCF_ERR_GENERIC;
+		if ! ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST -e "SELECT COUNT(*) FROM $OCF_RESKEY_test_table"; then
+			quit_on_error "Failed to select from $test_table" $OCF_ERR_GENERIC
 		fi
-	else
-		# In case no exnteded tests are enabled and we are in master/slave mode _always_ set the master score to 1 if we reached this point
-		ocf_is_ms && $CRM_MASTER -v 1
 	fi
 
-	if ocf_is_ms && ! get_read_only; then
-		ocf_log debug "MySQL monitor succeeded (master)";
-		# Always set master score for the master
-		$CRM_MASTER -v 2
-		return $OCF_RUNNING_MASTER
+	if ocf_is_ms; then
+		if is_slave; then
+			# Check slave replication status in details
+			check_slave
+			ocf_log debug "MySQL monitor succeeded (slave) ... returning $OCF_SUCCESS";
+			return $OCF_SUCCESS
+		else
+			# master is always readable and always with highest scores
+			$CRM_MASTER -v $((${OCF_RESKEY_max_slave_lag}+1))
+			set_reader_attr 1
+			ocf_log debug "MySQL monitor succeeded (master) ... returning $OCF_RUNNING_MASTER";
+			return $OCF_RUNNING_MASTER
+		fi
 	else
-		ocf_log debug "MySQL monitor succeeded";
+		ocf_log debug "MySQL monitor succeeded ... returning $OCF_SUCCESS";
 		return $OCF_SUCCESS
 	fi
+
 }
 
 mysql_start() {

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -497,40 +497,30 @@ check_slave() {
 		quit_on_error "Replication failed Last_Errno: $Last_Errno Last_Error: $Last_Error" $OCF_ERR_GENERIC
 	fi
 
-	if [ "$Slave_IO_Running" != 'Yes' ]; then
-		# Not necessarily a bad thing. The master may have
-		# temporarily shut down, and the slave may just be
-		# reconnecting. A warning can't hurt, though.
-		ocf_log warn "MySQL Slave IO threads currently not running."
+	if [ "$Slave_SQL_Running" != 'Yes' ] || [ "$Slave_IO_Running" != 'Yes' ]; then
+		# We dont have a replication SQL thread running. Not a good thing but not so bad thing too.
+		# Not necessarily a bad thing. The master may have temporarily shut down, and the slave may just be reconnecting. A warning can't hurt, though.
+		# Try to recoved by restarting the SQL thread and remove reader vip.
+
+		ocf_log warn "Slave_SQL_Running ($Slave_SQL_Running) or Slave_IO_Running ($Slave_IO_Running) currently NOT running"
 
 		# Sanity check, are we at least on the right master
 		new_master=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f1`
 
-		if [ "$master_host" != "$new_master" ]; then
-		   # Not pointing to the right master, not good, removing the VIPs
-		   set_reader_attr 0
-
-		   exit $OCF_SUCCESS
+		if ocf_is_true $OCF_RESKEY_ensure_follow_correct_master; then
+			if [ "$master_host" != "$new_master" ]; then
+				quit_on_error "Replication failed node master: $master_host cluster master: $new_master" $OCF_ERR_GENERIC
+			fi
 		fi
 
-	fi
-
-	if [ "$Slave_SQL_Running" != 'Yes' ]; then
-		# We don't have a replication SQL thread running. Not a
-		# good thing. Try to recoved by restarting the SQL thread
-		# and remove reader vip.  Prevent MySQL restart.
-		ocf_exit_reason "MySQL Slave SQL threads currently not running."
-		ocf_log err "See $tmpfile for details"
-
-		# Remove reader vip
-		set_reader_attr 0
-
+		ocf_log warn "Attempting START SLAVE"
 		# try to restart slave
 		ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
 			-e "START SLAVE"
 
-		# Return success to prevent a restart
-		exit $OCF_SUCCESS
+		# quit_on_error should always quit with success here
+		# If further errors occur after this start slave they will be cought by the checks above
+		quit_on_error "Replication failed Slave_SQL_Running ($Slave_SQL_Running) Slave_IO_Running ($Slave_IO_Running) ... start slave was attempted" 0
 	fi
 
 	if ocf_is_true $OCF_RESKEY_evict_outdated_slaves; then

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -777,17 +777,7 @@ mysql_monitor() {
 
 	# If status returned an error, return that immediately
 	if [ $rc -ne $OCF_SUCCESS ]; then
-		if ocf_is_ms ; then
-			# This is a master slave setup but monitored host returned some errors.
-			# Immediately remove it from the pool of possible masters by erasing its master-mysql key
-			# When new mysql master election is started and node got no or negative master-mysql attribute the following is logged
-			#   nodename.com pengine: debug: master_color: mysql:0 master score: -1
-			# If there are NO nodes with positive vaule election of mysql master will fail with
-			#   nodename.com pengine: info: master_color: ms_mysql: Promoted 0 instances of a possible 1 to master
-			$CRM_MASTER -D
-		fi
-
-		return $rc
+        quit_on_error "mysql_status returned error: $rc" $rc
 	fi
 
 	if [ $OCF_CHECK_LEVEL -gt 0 -a -n "$OCF_RESKEY_test_table" ]; then

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -444,10 +444,10 @@ get_slave_info() {
 	master_port=`parse_slave_info Master_Port $tmpfile`
 	master_log_file=`parse_slave_info Master_Log_File $tmpfile`
 	master_log_pos=`parse_slave_info Read_Master_Log_Pos $tmpfile`
-	slave_sql=`parse_slave_info Slave_SQL_Running $tmpfile`
-	slave_io=`parse_slave_info Slave_IO_Running $tmpfile`
-	last_errno=`parse_slave_info Last_Errno $tmpfile`
-	secs_behind=`parse_slave_info Seconds_Behind_Master $tmpfile`
+	Slave_SQL_Running=`parse_slave_info Slave_SQL_Running $tmpfile`
+	Slave_IO_Running=`parse_slave_info Slave_IO_Running $tmpfile`
+	Last_Errno=`parse_slave_info Last_Errno $tmpfile`
+	Seconds_Behind_Master=`parse_slave_info Seconds_Behind_Master $tmpfile`
 	ocf_log debug "MySQL instance running as a replication slave"
 
 	return $OCF_SUCCESS
@@ -462,7 +462,7 @@ check_slave() {
 
 	if [ $rc -eq 0 ]; then
 		# Did we receive an error other than max_connections?
-		if [ $last_errno -ne 0 -a $last_errno -ne "$MYSQL_TOO_MANY_CONN_ERR" ]; then
+		if [ $Last_Errno -ne 0 -a $Last_Errno -ne "$MYSQL_TOO_MANY_CONN_ERR" ]; then
 			# Whoa. Replication ran into an error. This slave has
 			# diverged from its master. Make sure this resource
 			# doesn't restart in place.
@@ -478,12 +478,12 @@ check_slave() {
 		fi
 
 		# If we got max_connections, let's remove the vip
-		if [ $last_errno -eq "$MYSQL_TOO_MANY_CONN_ERR" ]; then
+		if [ $Last_Errno -eq "$MYSQL_TOO_MANY_CONN_ERR" ]; then
 			set_reader_attr 0
 			exit $OCF_SUCCESS
 		fi
 
-		if [ "$slave_io" != 'Yes' ]; then
+		if [ "$Slave_IO_Running" != 'Yes' ]; then
 			# Not necessarily a bad thing. The master may have
 			# temporarily shut down, and the slave may just be
 			# reconnecting. A warning can't hurt, though.
@@ -501,7 +501,7 @@ check_slave() {
 
 		fi
 
-		if [ "$slave_sql" != 'Yes' ]; then
+		if [ "$Slave_SQL_Running" != 'Yes' ]; then
 			# We don't have a replication SQL thread running. Not a
 			# good thing. Try to recoved by restarting the SQL thread
 			# and remove reader vip.  Prevent MySQL restart.
@@ -522,8 +522,8 @@ check_slave() {
 		if ocf_is_true $OCF_RESKEY_evict_outdated_slaves; then
 			# We're supposed to bail out if we lag too far
 			# behind. Let's check our lag.
-			if [ "$secs_behind" = "NULL" ] || [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
-				ocf_exit_reason "MySQL Slave is $secs_behind seconds behind master (allowed maximum: $OCF_RESKEY_max_slave_lag)."
+			if [ "$Seconds_Behind_Master" = "NULL" ] || [ $Seconds_Behind_Master -gt $OCF_RESKEY_max_slave_lag ]; then
+				ocf_exit_reason "MySQL Slave is $Seconds_Behind_Master seconds behind master (allowed maximum: $OCF_RESKEY_max_slave_lag)."
 				ocf_log err "See $tmpfile for details"
 
 				# Remove reader vip
@@ -536,7 +536,7 @@ check_slave() {
 			# still use the seconds behind master value to set our
 			# master preference.
 			local master_pref
-			master_pref=$((${OCF_RESKEY_max_slave_lag}-${secs_behind}))
+			master_pref=$((${OCF_RESKEY_max_slave_lag}-${Seconds_Behind_Master}))
 			if [ $master_pref -lt 0 ]; then
 				# Sanitize a below-zero preference to just zero
 				master_pref=0
@@ -545,7 +545,7 @@ check_slave() {
 		fi
 
 		# is the slave ok to have a VIP on it
-		if [ "$secs_behind" = "NULL" ] || [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
+		if [ "$Seconds_Behind_Master" = "NULL" ] || [ $Seconds_Behind_Master -gt $OCF_RESKEY_max_slave_lag ]; then
 			set_reader_attr 0
 		else
 			set_reader_attr 1

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -425,32 +425,32 @@ get_slave_info() {
 	if [ "$master_log_file" -a "$master_host" ]; then
 		# variables are already defined, get_slave_info has been run before
 		return $OCF_SUCCESS
-	else
-		tmpfile=`mktemp ${HA_RSCTMP}/check_slave.${OCF_RESOURCE_INSTANCE}.XXXXXX`
+    fi
 
-		$MYSQL $MYSQL_OPTIONS_REPL \
-		-e 'SHOW SLAVE STATUS\G' > $tmpfile
+	tmpfile=`mktemp ${HA_RSCTMP}/check_slave.${OCF_RESOURCE_INSTANCE}.XXXXXX`
 
-		if [ -s $tmpfile ]; then
-			master_host=`parse_slave_info Master_Host $tmpfile`
-			master_user=`parse_slave_info Master_User $tmpfile`
-			master_port=`parse_slave_info Master_Port $tmpfile`
-			master_log_file=`parse_slave_info Master_Log_File $tmpfile`
-			master_log_pos=`parse_slave_info Read_Master_Log_Pos $tmpfile`
-			slave_sql=`parse_slave_info Slave_SQL_Running $tmpfile`
-			slave_io=`parse_slave_info Slave_IO_Running $tmpfile`
-			last_errno=`parse_slave_info Last_Errno $tmpfile`
-			secs_behind=`parse_slave_info Seconds_Behind_Master $tmpfile`
-			ocf_log debug "MySQL instance running as a replication slave"
-		else
-			# Instance produced an empty "SHOW SLAVE STATUS" output --
-			# instance is not a slave
-			ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
-			return $OCF_ERR_GENERIC
-		fi
+	$MYSQL $MYSQL_OPTIONS_REPL \
+	-e 'SHOW SLAVE STATUS\G' > $tmpfile
 
-		return $OCF_SUCCESS
-	fi
+	if [ ! -s $tmpfile ]; then
+		# Instance produced an empty "SHOW SLAVE STATUS" output --
+		# instance is not a slave
+		ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
+		return $OCF_ERR_GENERIC
+    fi
+
+	master_host=`parse_slave_info Master_Host $tmpfile`
+	master_user=`parse_slave_info Master_User $tmpfile`
+	master_port=`parse_slave_info Master_Port $tmpfile`
+	master_log_file=`parse_slave_info Master_Log_File $tmpfile`
+	master_log_pos=`parse_slave_info Read_Master_Log_Pos $tmpfile`
+	slave_sql=`parse_slave_info Slave_SQL_Running $tmpfile`
+	slave_io=`parse_slave_info Slave_IO_Running $tmpfile`
+	last_errno=`parse_slave_info Last_Errno $tmpfile`
+	secs_behind=`parse_slave_info Seconds_Behind_Master $tmpfile`
+	ocf_log debug "MySQL instance running as a replication slave"
+
+	return $OCF_SUCCESS
 }
 
 check_slave() {

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -470,7 +470,13 @@ check_slave() {
 		# instance is not a slave
 		# TODO: Needs to handle when get_slave_info will return too many connections error
 		rm -f $tmpfile
-        quit_on_error "check_slave invoked on an instance that is not a replication slave: $rc" $OCF_ERR_GENERIC
+		quit_on_error "check_slave invoked on an instance that is not a replication slave: $rc" $OCF_ERR_GENERIC
+	fi
+
+	if [ "${Last_Errno}" == "$MYSQL_TOO_MANY_CONN_ERR" ]; then
+		# If we got max_connections, let's remove master score used by the failover and reader vip.
+		# However finish check nicely (0) to avoid restarting slave bussy with reading
+		quit_on_error "MYSQL_TOO_MANY_CONN_ERR ($MYSQL_TOO_MANY_CONN_ERR) ... check succeeded but node not suitable for failover/reader vip" 0
 	fi
 
 	# Did we receive an error other than max_connections?
@@ -487,12 +493,6 @@ check_slave() {
 		set_reader_attr 0
 		exit $OCF_SUCCESS
 
-	fi
-
-	# If we got max_connections, let's remove the vip
-	if [ $Last_Errno -eq "$MYSQL_TOO_MANY_CONN_ERR" ]; then
-		set_reader_attr 0
-		exit $OCF_SUCCESS
 	fi
 
 	if [ "$Slave_IO_Running" != 'Yes' ]; then

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -425,7 +425,7 @@ get_slave_info() {
 	if [ "$master_log_file" -a "$master_host" ]; then
 		# variables are already defined, get_slave_info has been run before
 		return $OCF_SUCCESS
-    fi
+	fi
 
 	tmpfile=`mktemp ${HA_RSCTMP}/check_slave.${OCF_RESOURCE_INSTANCE}.XXXXXX`
 
@@ -437,7 +437,7 @@ get_slave_info() {
 		# instance is not a slave
 		ocf_exit_reason "check_slave invoked on an instance that is not a replication slave."
 		return $OCF_ERR_GENERIC
-    fi
+	fi
 
 	master_host=`parse_slave_info Master_Host $tmpfile`
 	master_user=`parse_slave_info Master_User $tmpfile`
@@ -446,8 +446,13 @@ get_slave_info() {
 	master_log_pos=`parse_slave_info Read_Master_Log_Pos $tmpfile`
 	Slave_SQL_Running=`parse_slave_info Slave_SQL_Running $tmpfile`
 	Slave_IO_Running=`parse_slave_info Slave_IO_Running $tmpfile`
-	Last_Errno=`parse_slave_info Last_Errno $tmpfile`
 	Seconds_Behind_Master=`parse_slave_info Seconds_Behind_Master $tmpfile`
+	Last_Errno=`parse_slave_info Last_Errno $tmpfile`
+	Last_Error=`parse_slave_info Last_Error $tmpfile`
+	Last_IO_Errno=`parse_slave_info Last_IO_Errno $tmpfile`
+	Last_IO_Error=`parse_slave_info Last_IO_Error $tmpfile`
+	Last_SQL_Errno=`parse_slave_info Last_SQL_Errno $tmpfile`
+	Last_SQL_Error=`parse_slave_info Last_SQL_Error $tmpfile`
 	ocf_log debug "MySQL instance running as a replication slave"
 
 	return $OCF_SUCCESS

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -45,6 +45,7 @@
 #   OCF_RESKEY_max_slave_lag
 #   OCF_RESKEY_evict_outdated_slaves
 #   OCF_RESKEY_reader_attribute
+#   OCF_RESKEY_mysql_master_lock_file
 
 #######################################################################
 # Initialization:
@@ -280,6 +281,22 @@ This parameter is only meaningful in master/slave set configurations.
 <shortdesc lang="en">Sets the node attribute that determines
 whether a node is usable for clients to read from.</shortdesc>
 <content type="string" default="${OCF_RESKEY_reader_attribute_default}" />
+</parameter>
+</parameters>
+
+<parameter name="mysql_master_lock_file" unique="1" required="0">
+<longdesc lang="en">
+This is a lock file that is created whenever instance is
+promoted as MySQL master in ms configuration
+
+Lock file is removed whenever machine is no longer MySQL master.
+
+It is intended to be used by helper scripts that should be running
+only on master host.
+</longdesc>
+<shortdesc lang="en">Create helper file to identify if current server
+is a running MySQL master. Usefull for external script.</shortdesc>
+<content type="string" default="${OCF_RESKEY_mysql_master_lock_file_default}" />
 </parameter>
 </parameters>
 
@@ -927,6 +944,7 @@ mysql_notify() {
 			master_host=`echo $OCF_RESKEY_CRM_meta_notify_promote_uname|tr -d " "`
 			if [ "$master_host" = ${NODENAME} ]; then
 				ocf_log info "This will be the new master, ignoring post-promote notification."
+                touch "${OCF_RESKEY_mysql_master_lock_file}"
 			else
 				ocf_log info "Resetting replication"
 				unset_master
@@ -952,6 +970,10 @@ mysql_notify() {
 			demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
 			if [ $demote_host = ${NODENAME} ]; then
 				ocf_log info "post-demote notification for $demote_host"
+
+                ocf_log info "pre-demote Removing custom replication master marker."
+                rm -f "${OCF_RESKEY_mysql_master_lock_file}"
+                
 				set_read_only on
 				if [ $? -ne 0 ]; then
 					ocf_exit_reason "Failed to set read-only";

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -46,6 +46,7 @@ OCF_RESKEY_max_slave_lag_default="3600"
 OCF_RESKEY_evict_outdated_slaves_default="false"
 OCF_RESKEY_reader_attribute_default="readable"
 OCF_RESKEY_mysql_master_lock_file_default="/var/lock/replication_master"
+OCF_RESKEY_ensure_follow_correct_master_default="false"
 
 : ${OCF_RESKEY_binary=${OCF_RESKEY_binary_default}}
 MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
@@ -79,6 +80,7 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 : ${OCF_RESKEY_reader_attribute=${OCF_RESKEY_reader_attribute_default}}
 
 : ${OCF_RESKEY_mysql_master_lock_file=${OCF_RESKEY_mysql_master_lock_file_default}}
+: ${OCF_RESKEY_ensure_follow_correct_master=${OCF_RESKEY_ensure_follow_correct_master_default}}
 
 #######################################################################
 # Convenience variables

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -45,6 +45,7 @@ OCF_RESKEY_replication_port_default="3306"
 OCF_RESKEY_max_slave_lag_default="3600"
 OCF_RESKEY_evict_outdated_slaves_default="false"
 OCF_RESKEY_reader_attribute_default="readable"
+OCF_RESKEY_mysql_master_lock_file_default="/var/lock/replication_master"
 
 : ${OCF_RESKEY_binary=${OCF_RESKEY_binary_default}}
 MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
@@ -76,6 +77,8 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 : ${OCF_RESKEY_evict_outdated_slaves=${OCF_RESKEY_evict_outdated_slaves_default}}
 
 : ${OCF_RESKEY_reader_attribute=${OCF_RESKEY_reader_attribute_default}}
+
+: ${OCF_RESKEY_mysql_master_lock_file=${OCF_RESKEY_mysql_master_lock_file_default}}
 
 #######################################################################
 # Convenience variables


### PR DESCRIPTION
* This merge request greatly enhance mysql resource stability. It tries to address cases that happened in live environments:

- broken/outdated slave promoted as mysql master due to insufficient error checking in mysql monitor for slaves

- broken/outdated slave promoted as mysql master due to specific (not-so-smart default) configuration requirements unrelated to check_slave state (test_table set and OCF_CHECK_LEVEL > 0)

- broken/outdated slave promoted as mysql master due to master scores not being reclaimed/removed from slaves that have serious replication errors or are in state unsuitable for master promotion.

* This merge request is a result of multiple hours spent during on-call and out-of-call firefighting, manual out-of-sync master-merging, postmortem writing, debugging crm and its default mysql resource agent.

* IMPORTANT changes

- check_slave is now ALWAYS called on slave in ms mode - Previously it was called only if test_table was set, which I assume to be due to an error. To prevent stale/broken slave from being promoted as master I strongly recommend calling check_slave by default on slaves.

- in check_slave $Slave_SQL_Running/$Slave_IO_Running == 'NO' verify slave vs cluster master before START SLAVE is now performed only if ensure_follow_correct_master=true (new var. default is false)

- Create empty file mysql_master_lock_file=/var/lock/replication_master (new var.) on master promote, erase it on master demote. Useful for for external scripts.

* Introducing new function quit_on_error that is used across monitor:

- uses common function to terminate with success or error - quit_on_error
- quit_on_error always clear reader vip so erroneous slave does not receive reads
- quit_on_error always delete master score so erroneous does not get promoted as master
- quit_on_error log the error
- quit_on_error can terminate with the desired error code

* Enhanced check_slave to detect failed or stale slaves:

- Consider slave as failed if Last_SQL_Error/Last_SQL_Errno
- Consider slave as failed if Last_IO_Error/Last_IO_Errno
- Consider slave as failed if Last_Error/Last_Errno
- Attempt to start slave $Slave_SQL_Running/$Slave_IO_Running NO
- Code simplification for evict_outdated_slaves handling
- Code simplification for slave master score handling

* Code readability greatly simplified.