### PR TITLE
Add hdbnameserver to monitor services

### DIFF
--- a/heartbeat/sapdb.sh
+++ b/heartbeat/sapdb.sh
@@ -360,7 +360,7 @@ then
          ;;
     SYB) export OCF_RESKEY_MONITOR_SERVICES="Server"
          ;;
-    HDB) export OCF_RESKEY_MONITOR_SERVICES="hdbindexserver"
+    HDB) export OCF_RESKEY_MONITOR_SERVICES="hdbindexserver|hdbnameserver"
          ;;
   esac
 fi


### PR DESCRIPTION
Adding hdbnameserver to the list of monitor services for HANA databases (dbtype HDB/hdb). The goal is to change the default to address older and newer HANA versions. In newer HANA versions the hdbindexserver is typically not listed as an own service.