### PR TITLE
redis: when containerized, use the host name rather than the bundle name

### DIFF
--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -545,7 +545,7 @@ function validate() {
 	fi
 }
 
-NODENAME=$(ocf_local_nodename)
+NODENAME=${OCF_RESKEY_CRM_meta_physical_host:-$(ocf_local_nodename)}
 if [ -f "$REDIS_CONFIG" ]; then
 	clientpasswd="$(cat $REDIS_CONFIG | sed -n -e  's/^\s*requirepass\s*\(.*\)\s*$/\1/p' | tail -n 1)"
 fi


### PR DESCRIPTION
Redis records the last known master in the CIB. When run in a bundle,
the host name used is that of the bundle, which is incorrect. One must
use the name of the host on which the bundle ran, because that's where
the Redis server's state is stored on disk.