### PR TITLE
rabbitmq-cluster: when containerized, use the host name rather than the bundle name

### DIFF
--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -37,7 +37,7 @@ RMQ_DATA_DIR="/var/lib/rabbitmq/mnesia"
 RMQ_PID_DIR="/var/run/rabbitmq"
 RMQ_PID_FILE="/var/run/rabbitmq/rmq.pid"
 RMQ_LOG_DIR="/var/log/rabbitmq"
-NODENAME=$(ocf_local_nodename)
+NODENAME=${OCF_RESKEY_CRM_meta_physical_host:-$(ocf_local_nodename)}
 
 # this attr represents the current active local rmq node name.
 # when rmq stops or the node is fenced, this attr disappears


### PR DESCRIPTION
The rabbitmq resource agent records various attributes in the CIB such
as rabbit cookies and permanent host list. When run in a bundle, the
host name used is that of the bundle, which is incorrect. One must use
the name of the host on which the bundle ran, because that's where the
RabbitMQ server's state is stored on disk.