### PR TITLE
Route: Configurable address family

### DIFF
--- a/heartbeat/Route
+++ b/heartbeat/Route
@@ -318,8 +318,6 @@ case $OCF_RESKEY_family in
         esac ;;
     *) ocf_exit_reason "Address family '${OCF_RESKEY_family}' not recognized." ;;
 esac
-echo "addr_family: $addr_family" >> /tmp/log
-echo "RESKEY_family: $OCF_RESKEY_family" >> /tmp/log
 
 case $__OCF_ACTION in
 start)		route_start;;

--- a/heartbeat/Route
+++ b/heartbeat/Route
@@ -31,6 +31,11 @@
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
 
+# Default values
+OCF_RESKEY_family_default="detect"
+
+: ${OCF_RESKEY_family=${OCF_RESKEY_family_default}}
+
 #######################################################################
 
 meta_data() {
@@ -117,6 +122,17 @@ The routing table to be configured for the route.
 </longdesc>
 <shortdesc lang="en">Routing table</shortdesc>
 <content type="string" default="" />
+</parameter>
+
+<parameter name="family" unique="0" required="1">
+<longdesc lang="en">
+The address family to be used for the route
+ip4      IP version 4
+ip6      IP version 6
+detect   Detect from 'destination' address.
+</longdesc>
+<shortdesc lang="en">Address Family</shortdesc>
+<content type="string" default="${OCF_RESKEY_family}" />
 </parameter>
 
 </parameters>
@@ -291,10 +307,19 @@ done
 
 route_validate || exit $?
 
-case $OCF_RESKEY_destination in
-*:*) addr_family="-6" ;;
-  *) addr_family="-4" ;;
+case $OCF_RESKEY_family in
+    ip4) addr_family="-4" ;;
+    ip6) addr_family="-6" ;;
+    detect)
+        case $OCF_RESKEY_destination in
+            *:*)     addr_family="-6" ;;
+            *.*)     addr_family="-4" ;;
+              *) ocf_exit_reason "Address family detection requires a numeric destination address." ;;
+        esac ;;
+    *) ocf_exit_reason "Address family '${OCF_RESKEY_family}' not recognized." ;;
 esac
+echo "addr_family: $addr_family" >> /tmp/log
+echo "RESKEY_family: $OCF_RESKEY_family" >> /tmp/log
 
 case $__OCF_ACTION in
 start)		route_start;;


### PR DESCRIPTION
Make the address family for routes configurable. This is required because it is not always possible to auto-detect the correct family, eg 'ip route add default eth0' is valid for both IPv4 and IPv6.
Falls back to the old (fallible) behaviour when not specified.

Fixes #996