### PR TITLE
galera: Fix instance name in master_exists()

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -386,7 +386,7 @@ master_exists()
         return 1
     fi
     # determine if a master instance is already up and is healthy
-    crm_mon --as-xml | grep "resource.*id=\"${OCF_RESOURCE_INSTANCE}\".*role=\"Master\".*active=\"true\".*orphaned=\"false\".*failed=\"false\"" > /dev/null 2>&1
+    crm_mon --as-xml | grep "resource.*id=\"${INSTANCE_ATTR_NAME}\".*role=\"Master\".*active=\"true\".*orphaned=\"false\".*failed=\"false\"" > /dev/null 2>&1
     return $?
 }
 


### PR DESCRIPTION
Under certain circumstances $OCF_RESOURCE_INSTANCE as passed to the
resource agent contains and instance number (e.g. "galera:0"). This
happens e.g. when using "crm_resource --force-stop/--force-start". In
those cases "master_exists()" doesn't work correctly.

Use $INSTANCE_ATTR_NAME which is set in "mysql-common.sh", based on
$OCF_RESOURCE_INSTANCE with the instance number stripped.