### PR TITLE
Low: ocf-shellfuncs: Avoid printing empty INFO messages (bsc#1053621)

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -433,7 +433,7 @@ ocf_run() {
 
 	output=`"$@" 2>&1`
 	rc=$?
-	output=`echo "$output" | tr -s ' \t\r\n' ' '`
+	[ -n "$output" ] && output="$(echo "$output" | tr -s ' \t\r\n' ' ')"
 	if [ $rc -eq 0 ]; then 
 	    if [ "$verbose" -a ! -z "$output" ]; then
 		ocf_log info "$output"


### PR DESCRIPTION
When monitoring a pgsql database using `ocf:heartbeat:pgsql`,
each monitor produces two empty INFO messages in the ha logfile.

This is caused by a broken ocf_run in
`/usr/lib/ocf/lib/heartbeat/ocf-shellfuncs` which runs:

```
output=`echo "$output" | tr -s ' \t\r\n' ' '`
```

This causes output always being `' '`, even if the called
command has no output.

The following two tests for `! -z "$output"` are broken
and causes these empty messages to appear.

Proposed fix is to only run the tr command if `$output`
actually has content.