### PR TITLE
Introduce the attribute_target function

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -68,6 +68,8 @@
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
 . ${OCF_FUNCTIONS_DIR}/mysql-common.sh
 
+NODENAME=$(ocf_attribute_target)
+
 # It is common for some galera instances to store
 # check user that can be used to query status
 # in this file
@@ -279,7 +281,7 @@ get_status_variable()
 
 set_bootstrap_node()
 {
-    local node=$1
+    local node=$(ocf_attribute_target $1)
 
     ${HA_SBIN_DIR}/crm_attribute -N $node -l reboot --name "${INSTANCE_ATTR_NAME}-bootstrap" -v "true"
 }
@@ -307,7 +309,7 @@ clear_no_grastate()
 
 is_no_grastate()
 {
-    local node=$1
+    local node=$(ocf_attribute_target $1)
     ${HA_SBIN_DIR}/crm_attribute -N $node -l reboot --name "${INSTANCE_ATTR_NAME}-no-grastate" -Q 2>/dev/null
 }
 
@@ -323,7 +325,7 @@ set_last_commit()
 
 get_last_commit()
 {
-    local node=$1
+    local node=$(ocf_attribute_target $1)
 
     if [ -z "$node" ]; then
        ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-last-committed" -Q 2>/dev/null
@@ -344,7 +346,7 @@ set_safe_to_bootstrap()
 
 get_safe_to_bootstrap()
 {
-    local node=$1
+    local node=$(ocf_attribute_target $1)
 
     if [ -z "$node" ]; then
         ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-safe-to-bootstrap" -Q 2>/dev/null
@@ -413,7 +415,7 @@ master_exists()
 
 clear_master_score()
 {
-    local node=$1
+    local node=$(ocf_attribute_target $1)
     if [ -z "$node" ]; then
         $CRM_MASTER -D
     else 
@@ -423,7 +425,7 @@ clear_master_score()
 
 set_master_score()
 {
-    local node=$1
+    local node=$(ocf_attribute_target $1)
 
     if [ -z "$node" ]; then
         $CRM_MASTER -v 100
@@ -542,7 +544,7 @@ detect_first_master()
 
         greater_than_equal_long "$last_commit" "$best_commit"
         if [ $? -eq 0 ]; then
-            best_node=$node
+            best_node=$(ocf_attribute_target $node)
             best_commit=$last_commit
         fi
 

--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -989,6 +989,44 @@ ocf_stop_trace() {
 	set +x
 }
 
+# Helper functions to map from nodename/bundle-name and physical hostname
+# list_index_for_word "node0 node1 node2 node3 node4 node5" node4 --> 5
+# list_word_at_index "NA host1 host2 host3 host4 host5" 3      --> host2
+
+# list_index_for_word "node1 node2 node3 node4 node5" node7 --> ""
+# list_word_at_index "host1 host2 host3 host4 host5" 8      --> ""
+
+# attribute_target node1                                    --> host1
+list_index_for_word() {
+	echo $1 | tr ' ' '\n' | awk -v x="$2" '$0~x {print NR}'
+}
+
+list_word_at_index() {
+	echo $1 | tr ' ' '\n' | awk -v n="$2" 'n == NR'
+}
+
+ocf_attribute_target() {
+	if [ x$1 = x ]; then
+		if [ x$OCF_RESKEY_CRM_meta_container_attribute_target = xhost -a x$OCF_RESKEY_CRM_meta_physical_host != x ]; then
+			echo $OCF_RESKEY_CRM_meta_physical_host
+		else
+			echo $OCF_RESKEY_CRM_meta_on_node
+		fi
+		return
+	elif [ x"$OCF_RESKEY_CRM_meta_notify_all_uname" != x ]; then
+		index=$(list_index_for_word "$OCF_RESKEY_CRM_meta_notify_all_uname" $1)
+		mapping=""
+		if [ x$index != x ]; then
+			mapping=$(list_word_at_index "$OCF_RESKEY_CRM_meta_notify_all_hosts" $index)
+		fi
+		if [ x$mapping != x -a x$mapping != xNA ]; then
+			echo $mapping
+			return
+		fi
+	fi
+	echo $1
+}
+
 __ocf_set_defaults "$@"
 
 : ${OCF_TRACE_RA:=$OCF_RESKEY_trace_ra}

--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -37,7 +37,7 @@ RMQ_DATA_DIR="/var/lib/rabbitmq/mnesia"
 RMQ_PID_DIR="/var/run/rabbitmq"
 RMQ_PID_FILE="/var/run/rabbitmq/rmq.pid"
 RMQ_LOG_DIR="/var/log/rabbitmq"
-NODENAME=$(ocf_local_nodename)
+NODENAME=$(ocf_attribute_target)
 
 # this attr represents the current active local rmq node name.
 # when rmq stops or the node is fenced, this attr disappears
@@ -340,7 +340,7 @@ rmq_notify() {
 
 	# forget each stopped rmq instance in the provided pcmk node in the list.
 	for node in $(echo "$node_list"); do
-		local rmq_node="$(${HA_SBIN_DIR}/crm_attribute -N $node -l forever --query --name $RMQ_CRM_ATTR_COOKIE_LAST_KNOWN -q)"
+		local rmq_node="$(${HA_SBIN_DIR}/crm_attribute -N $(ocf_attribute_target $node) -l forever --query --name $RMQ_CRM_ATTR_COOKIE_LAST_KNOWN -q)"
 		if [ -z "$rmq_node" ]; then
 			ocf_log warn "Unable to map pcmk node $node to a known rmq node."
 			continue	

--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -188,7 +188,8 @@ function last_known_master()
 }
 
 function crm_master_reboot() {
-	"${HA_SBIN_DIR}/crm_master" -l reboot "$@"
+	local node=$(ocf_attribute_target)
+	"${HA_SBIN_DIR}/crm_master" -N $node -l reboot "$@"
 }
 
 function calculate_score()
@@ -545,7 +546,7 @@ function validate() {
 	fi
 }
 
-NODENAME=$(ocf_local_nodename)
+NODENAME=$(ocf_attribute_target)
 if [ -f "$REDIS_CONFIG" ]; then
 	clientpasswd="$(cat $REDIS_CONFIG | sed -n -e  's/^\s*requirepass\s*\(.*\)\s*$/\1/p' | tail -n 1)"
 fi


### PR DESCRIPTION
This PR is split in two commits: the first one introduces the
shell function attribute_target() and the second one makes
redis, rabbitmq and galera use this new function.

Note that this function has simply no effect when this is run
against a pacemaker version that does not yet have the corresponding
changes for the container-attribute-target meta attribute.