### PR TITLE
Revert "LVM: use vgscan --cache to update metadata during start/relocate"

### DIFF
--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -226,7 +226,7 @@ LVM_start() {
 	if [ "$LVM_MAJOR" -eq "1" ]; then
 		ocf_run vgscan $vg
 	else
-		ocf_run vgscan --cache
+		ocf_run vgscan
 	fi
 
 	lvm_pre_activate || exit


### PR DESCRIPTION
Reverts ClusterLabs/resource-agents#980

Reverting due to --cache failing on older 2.x when lvmetad isnt running.