### PR TITLE
Mid: apache: Change stop loop and move stop judgment.

### DIFF
--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -278,17 +278,19 @@ kill_stop()
 	local pid=$1
 
 	ocf_log info "Killing apache PID $pid"
-	while
-		ProcessRunning $pid &&
-		[ $tries -lt 10 ]
-	do
-		if [ $tries -ne 0 ]; then
-			# don't sleep on the first try
-			sleep 1
-		fi
-		kill $pid >/dev/null 
-		tries=`expr $tries + 1`
-	done
+	if ProcessRunning $pid; then
+		kill $pid >/dev/null
+		while
+			[ $tries -lt 10 ]
+		do
+			if ProcessRunning $pid; then
+				tries=`expr $tries + 1`
+				sleep 1
+			else
+				break
+			fi
+		done
+	fi
 }
 
 apache_stop() {

--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -307,18 +307,19 @@ apache_stop() {
 	graceful_stop $pid
 	if [ $? -ne 0 ]; then
 		kill_stop $pid
+	fi
 
-		if ProcessRunning $pid; then
-			ocf_exit_reason "$CMD still running ($pid). Killing pid failed."
-			ret=$OCF_ERR_GENERIC
-		fi
+	signal_children
+
+	if ProcessRunning $pid; then
+		ocf_exit_reason "$CMD still running ($pid). Killing pid failed."
+		ret=$OCF_ERR_GENERIC
 	fi
 
 	if [ $ret -eq 0 ]; then
 		ocf_log info "$CMD stopped."
 	fi
 
-	signal_children
 	return $ret
 }
 


### PR DESCRIPTION
Hi All,

We propose two patches.

If a failure occurs while processing time-consuming accesses it will fail to determine apache's stop.
This takes 9 seconds to stop apache, but apache RA is due to the short wait time.

 - https://svn.apache.org/repos/asf/httpd/sandbox/replacelimit/server/mpm_unix.c

Also, there is no point in repeatedly sending a TERM signal in a loop.

Apparently, this problem seems to have entered with the next correction.

 - https://github.com/ClusterLabs/resource-agents/commit/62d35a05abb18db03255df519bceaaf98c3f5c0f#diff-c43424e68c05e396a15f6c9b257b36af


Also, the signnal_child process may terminate the apache process at the end.
Run the stop determination last, and correct it to correctly execute apache process stop.

We would like to include this fix in agents-4.1.0 if possible.

Best Regards,
Hideo Yamauchi.

