### PR TITLE
Fix fallback name for ocf_attribute_target

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -1010,7 +1010,11 @@ ocf_attribute_target() {
 		if [ x$OCF_RESKEY_CRM_meta_container_attribute_target = xhost -a x$OCF_RESKEY_CRM_meta_physical_host != x ]; then
 			echo $OCF_RESKEY_CRM_meta_physical_host
 		else
-			echo $OCF_RESKEY_CRM_meta_on_node
+			if [ x$OCF_RESKEY_CRM_meta_on_node != x ]; then
+				echo $OCF_RESKEY_CRM_meta_on_node
+			else
+				ocf_local_nodename
+			fi
 		fi
 		return
 	elif [ x"$OCF_RESKEY_CRM_meta_notify_all_uname" != x ]; then


### PR DESCRIPTION
For bundles, various resource agents now use ocf_attribute_target to
get the name of the pacemaker node to store attributes on.

If a recent version of the resource agent is being run on a pacemaker
version which does not support bundles, ocf_attribute_target will
return an empty string as hostname.

Provide a fallback path so the resource agent gets a valid name when
the resource is not containerized.