### PR TITLE
Fix alter user syntax for set_mon_user_profile

### DIFF
--- a/heartbeat/oracle
+++ b/heartbeat/oracle
@@ -388,7 +388,7 @@ show_mon_user_profile() {
 	echo "select PROFILE from dba_users where USERNAME='$MONUSR';"
 }
 set_mon_user_profile() {
-	echo "alter user "$MONUSR" profile '$MONPROFILE';"
+	echo "alter user "$MONUSR" profile "$MONPROFILE";"
 }
 reset_mon_user_password() {
 	echo "alter user "$MONUSR" identified by "$MONPWD";"


### PR DESCRIPTION
after modify users on oracle, the alter user not works.
This is the error:
 ERROR: sqlplus output: alter user MONRHCS profile 'OCFMONPROFILE'#012*#012ERRORE alla riga 1:#012ORA-00931: identificativo mancante( DEFAULT )
The corrrect query have not the '
https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_4003.htm