### PR TITLE
CTDB: Add new possible location for CTDB_SYSCONFIG

### DIFF
--- a/heartbeat/CTDB
+++ b/heartbeat/CTDB
@@ -361,6 +361,8 @@ elif [ -f /etc/default/ctdb ]; then
 	CTDB_SYSCONFIG=/etc/default/ctdb
 elif [ -f "$OCF_RESKEY_ctdb_config_dir/ctdb" ]; then
 	CTDB_SYSCONFIG=$OCF_RESKEY_ctdb_config_dir/ctdb
+elif [ -f "$OCF_RESKEY_ctdb_config_dir/ctdbd.conf" ]; then
+	CTDB_SYSCONFIG=$OCF_RESKEY_ctdb_config_dir/ctdbd.conf
 fi
 
 # Backup paths


### PR DESCRIPTION
When upgrading from Red Hat 7.3 to 7.4 the script stated that the location of the
configuration file had moved from /etc/sysconfig/ctdb to /etc/ctdb/ctdbd.conf.