### PR TITLE
targetcli 3.x support

### DIFF
--- a/heartbeat/iSCSILogicalUnit
+++ b/heartbeat/iSCSILogicalUnit
@@ -402,19 +402,25 @@ iSCSILogicalUnit_start() {
 	lio-t)
 		ocf_take_lock $TARGETLOCKFILE
 		ocf_release_lock_on_exit $TARGETLOCKFILE
-		iblock_attrib_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/attrib"
 		# For lio, we first have to create a target device, then
 		# add it to the Target Portal Group as an LU.
-		ocf_run targetcli /backstores/block create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
+		wwn=""
 		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
-			echo ${OCF_RESKEY_scsi_sn} > /sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/wwn/vpd_unit_serial
+			wwn="wwn=${OCF_RESKEY_scsi_sn} "
 		fi
-		ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns create /backstores/block/${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
+		ocf_run targetcli /backstores/iblock create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} ${wwn} || exit $OCF_ERR_GENERIC
 
-		if $(ip a | grep -q inet6); then
-			ocf_run -q targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/portals delete 0.0.0.0 3260
-			ocf_run -q targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/portals create ::0
+		if [ -n "${OCF_RESKEY_emulate_tpu}" ]; then
+			ocf_run targetcli /backstores/iblock/${OCF_RESOURCE_INSTANCE} set attribute emulate_tpu=1
 		fi
+		if [ -n "${OCF_RESKEY_emulate_3pc}" ]; then
+			ocf_run targetcli /backstores/iblock/${OCF_RESOURCE_INSTANCE} set attribute emulate_3pc=1
+		fi
+		if [ -n "${OCF_RESKEY_emulate_caw}" ]; then
+			ocf_run targetcli /backstores/iblock/${OCF_RESOURCE_INSTANCE} set attribute emulate_caw=1
+		fi
+
+		ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns create /backstores/iblock/${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
 
 		if [ -n "${OCF_RESKEY_allowed_initiators}" ]; then
 			for initiator in ${OCF_RESKEY_allowed_initiators}; do
@@ -423,15 +429,6 @@ iSCSILogicalUnit_start() {
 			done
 		fi
 
-		if [ -n "${OCF_RESKEY_emulate_tpu}" ]; then
-			echo ${OCF_RESKEY_emulate_tpu} > ${iblock_attrib_path}/emulate_tpu || exit $OCF_ERR_GENERIC
-		fi
-		if [ -n "${OCF_RESKEY_emulate_3pc}" ]; then
-			echo ${OCF_RESKEY_emulate_3pc} > ${iblock_attrib_path}/emulate_3pc || exit $OCF_ERR_GENERIC
-		fi
-		if [ -n "${OCF_RESKEY_emulate_caw}" ]; then
-			echo ${OCF_RESKEY_emulate_caw} > ${iblock_attrib_path}/emulate_caw || exit $OCF_ERR_GENERIC
-		fi
 		;;
 	esac
 
@@ -504,7 +501,7 @@ iSCSILogicalUnit_stop() {
 		# delete the backstore, then something is seriously
 		# wrong and we need to fail the stop operation
 		# (potentially causing fencing)
-		ocf_run targetcli /backstores/block delete ${OCF_RESOURCE_INSTANCE} || exit $OCF_ERR_GENERIC
+		ocf_run targetcli /backstores/iblock delete ${OCF_RESOURCE_INSTANCE} || exit $OCF_ERR_GENERIC
 		;;
 	esac
 

--- a/heartbeat/iSCSITarget
+++ b/heartbeat/iSCSITarget
@@ -347,6 +347,12 @@ iSCSITarget_start() {
 				ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/portals create "${sep_portal[0]}" "${sep_portal[1]}" || exit $OCF_ERR_GENERIC
 			else
 				ocf_run targetcli /iscsi create ${OCF_RESKEY_iqn} || exit $OCF_ERR_GENERIC
+				if [ ${OCF_RESKEY_portals_default} = "0.0.0.0:3260" ]; then
+					if $(ip a | grep -q inet6); then
+						ocf_run -q targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/portals delete 0.0.0.0 3260
+						ocf_run -q targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/portals create ::0 3260
+					fi
+				fi
 			fi
 		done
 		# in lio, we can set target parameters by manipulating


### PR DESCRIPTION
iSCSILogicalUnit fixups for lio-t to support targetcli 3.x, and remove target adjustments
iSCSITarget add the ipv6 support that was removed from iSCSILogicalUnit, with conditional test