### PR TITLE
Low: IPsrcaddr: Only check for ifconfig on BSD/solaris

### DIFF
--- a/heartbeat/IPsrcaddr
+++ b/heartbeat/IPsrcaddr
@@ -400,7 +400,11 @@ srca_validate_all() {
 	fi
 
 	check_binary $AWK
-	check_binary $IFCONFIG
+	case "$SYSTYPE" in
+		*BSD|SunOS)
+			check_binary $IFCONFIG
+			;;
+	esac
 
 #	The IP address should be in good shape
 	if CheckIP "$ipaddress"; then


### PR DESCRIPTION
`ifconfig` is deprecated on Linuxes, so only check for it where it is actually used.
