### PR TITLE
Rename LXDInfo to lxd-info and MachineInfo to machine-info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
     #  - debian-sid
     packages:
       - libxml2-utils
+      - xsltproc
       - shellcheck
 script:
   - ./ci/build.sh

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -71,8 +71,6 @@ man_MANS	       = ocf_heartbeat_AoEtarget.7 \
                           ocf_heartbeat_LVM.7 \
                           ocf_heartbeat_LVM-activate.7 \
                           ocf_heartbeat_LinuxSCSI.7 \
-                          ocf_heartbeat_LXCInfo.7 \
-                          ocf_heartbeat_MachineInfo.7 \
                           ocf_heartbeat_MailTo.7 \
                           ocf_heartbeat_ManageRAID.7 \
                           ocf_heartbeat_ManageVE.7 \
@@ -127,6 +125,8 @@ man_MANS	       = ocf_heartbeat_AoEtarget.7 \
                           ocf_heartbeat_kamailio.7 \
                           ocf_heartbeat_lvmlockd.7 \
                           ocf_heartbeat_lxc.7 \
+                          ocf_heartbeat_lxd-info.7 \
+                          ocf_heartbeat_machine-info.7 \
                           ocf_heartbeat_mysql.7 \
                           ocf_heartbeat_mysql-proxy.7 \
                           ocf_heartbeat_nagios.7 \

--- a/heartbeat/Makefile.am
+++ b/heartbeat/Makefile.am
@@ -67,8 +67,6 @@ ocf_SCRIPTS	     =  AoEtarget		\
 			LinuxSCSI		\
 			lvmlockd		\
 			LVM-activate		\
-			LXDInfo			\
-			MachineInfo		\
 			MailTo			\
 			ManageRAID		\
 			ManageVE		\
@@ -123,6 +121,8 @@ ocf_SCRIPTS	     =  AoEtarget		\
 			jira			\
 			kamailio		\
 			lxc			\
+			lxd-info		\
+			machine-info	\
 			minio			\
 			mysql			\
 			mysql-proxy		\
@@ -164,10 +164,10 @@ ocfcommon_DATA		= ocf-shellfuncs 	\
 			  ocf-binaries	 	\
 			  ocf-directories 	\
 			  ocf-returncodes 	\
- 			  ocf-rarun		\
- 			  ocf-distro		\
+			  ocf-rarun		\
+			  ocf-distro		\
 			  apache-conf.sh 	\
-			  http-mon.sh    	\
+			  http-mon.sh		\
 			  sapdb-nosha.sh	\
 			  sapdb.sh		\
 			  lvm-clvm.sh       \

--- a/heartbeat/lxd-info
+++ b/heartbeat/lxd-info
@@ -38,7 +38,7 @@ meta_data() {
 	cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="LXDInfo">
+<resource-agent name="lxd-info">
 <version>1.0</version>
 
 <longdesc lang="en">

--- a/heartbeat/machine-info
+++ b/heartbeat/machine-info
@@ -38,7 +38,7 @@ meta_data() {
 	cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="MachineInfo">
+<resource-agent name="machine-info">
 <version>1.0</version>
 
 <longdesc lang="en">


### PR DESCRIPTION
@oalbrigt Hm, noticed that something isn't quite working with the CI: The agent name was typoed as LXCInfo in `doc/man/Makefile.am` but the CI check still passed. Will need to investigate.
