### PR TITLE
Low: Remove "s" suffix from action default times

### DIFF
--- a/heartbeat/IPaddr
+++ b/heartbeat/IPaddr
@@ -195,11 +195,11 @@ netmask for ARP - in nonstandard hexadecimal format.
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="5s" />
-<action name="validate-all"  timeout="20s" />
-<action name="meta-data"  timeout="5s" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="monitor" depth="0"  timeout="20" interval="5" />
+<action name="validate-all"  timeout="20" />
+<action name="meta-data"  timeout="5" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -370,12 +370,12 @@ Expects a value as specified in section 5.5.4 of RFC 4862.
 
 </parameters>
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="status" depth="0"  timeout="20s" interval="10s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10s" />
-<action name="meta-data"  timeout="5s" />
-<action name="validate-all"  timeout="20s" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="status" depth="0"  timeout="20" interval="10" />
+<action name="monitor" depth="0"  timeout="20" interval="10" />
+<action name="meta-data"  timeout="5" />
+<action name="validate-all"  timeout="20" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/IPsrcaddr
+++ b/heartbeat/IPsrcaddr
@@ -100,9 +100,9 @@ dotted quad notation  255.255.255.0).
 </parameters>
 
 <actions>
-<action name="start" timeout="20s" />
-<action name="stop" timeout="20s" />
-<action name="monitor" depth="0" timeout="20s" interval="10" />
+<action name="start" timeout="20" />
+<action name="stop" timeout="20" />
+<action name="monitor" depth="0" timeout="20" interval="10" />
 <action name="validate-all" timeout="5" />
 <action name="meta-data" timeout="5" />
 </actions>

--- a/heartbeat/LinuxSCSI
+++ b/heartbeat/LinuxSCSI
@@ -140,11 +140,11 @@ If set to true, suppresses the deprecation warning for this agent.
 </parameters>
 
 <actions>
-<action name="start" timeout="20s" />
-<action name="stop" timeout="20s" />
+<action name="start" timeout="20" />
+<action name="stop" timeout="20" />
 <action name="methods" timeout="5" />
-<action name="status" depth="0" timeout="20s" interval="10" />
-<action name="monitor" depth="0" timeout="20s" interval="10" />
+<action name="status" depth="0" timeout="20" interval="10" />
+<action name="monitor" depth="0" timeout="20" interval="10" />
 <action name="meta-data" timeout="5" />
 <action name="validate-all" timeout="5" />
 </actions>

--- a/heartbeat/NodeUtilization
+++ b/heartbeat/NodeUtilization
@@ -102,7 +102,7 @@ If not set, the parameters will be set once when the resource instance starts.
 <actions>
 <action name="start"   timeout="90" />
 <action name="stop"    timeout="100" />
-<action name="monitor" timeout="20s" interval="60s"/>
+<action name="monitor" timeout="20" interval="60"/>
 <action name="meta-data"  timeout="5" />
 <action name="validate-all"  timeout="30" />
 </actions>

--- a/heartbeat/Pure-FTPd
+++ b/heartbeat/Pure-FTPd
@@ -91,11 +91,11 @@ Valid options are "" for pure-ftpd, "mysql" for pure-ftpd-mysql,
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="60s" />
-<action name="validate-all"  timeout="20s" />
-<action name="meta-data"  timeout="5s" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="monitor" depth="0"  timeout="20" interval="60" />
+<action name="validate-all"  timeout="20" />
+<action name="meta-data"  timeout="5" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Raid1
+++ b/heartbeat/Raid1
@@ -135,10 +135,10 @@ Only set this to "true" if you know what you are doing!
 </parameters>
 
 <actions>
-<action name="start" timeout="20s" />
-<action name="stop" timeout="20s" />
-<action name="status" depth="0" timeout="20s" interval="10" />
-<action name="monitor" depth="0" timeout="20s" interval="10" />
+<action name="start" timeout="20" />
+<action name="stop" timeout="20" />
+<action name="status" depth="0" timeout="20" interval="10" />
+<action name="monitor" depth="0" timeout="20" interval="10" />
 <action name="validate-all" timeout="5" />
 <action name="meta-data" timeout="5" />
 </actions>

--- a/heartbeat/SendArp
+++ b/heartbeat/SendArp
@@ -114,11 +114,11 @@ sending ARPs succeeded.
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
 <action name="monitor" depth="0"  timeout="20" interval="10" />
 <action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="20s" />
+<action name="validate-all"  timeout="20" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/SphinxSearchDaemon
+++ b/heartbeat/SphinxSearchDaemon
@@ -87,11 +87,11 @@ is able to query its indices and respond properly.
 </parameters>
 
 <actions>
-<action name="start"        timeout="20s" />
-<action name="stop"         timeout="20s" />
+<action name="start"        timeout="20" />
+<action name="stop"         timeout="20" />
 <action name="monitor"      timeout="20" interval="10" depth="0" />
 <action name="meta-data"    timeout="5" />
-<action name="validate-all"   timeout="20s" />
+<action name="validate-all"   timeout="20" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Squid
+++ b/heartbeat/Squid
@@ -155,11 +155,11 @@ the configuration file given by "syslog_ng_conf" as a basename part,
 </parameters>
 
 <actions>
-<action name="start" timeout="60s" />
-<action name="stop" timeout="120s" />
+<action name="start" timeout="60" />
+<action name="stop" timeout="120" />
 <action name="status" timeout="60" />
-<action name="monitor" depth="0" timeout="30s" interval="10s" />
-<action name="meta-data" timeout="5s" />
+<action name="monitor" depth="0" timeout="30" interval="10" />
+<action name="meta-data" timeout="5" />
 <action name="validate-all"  timeout="5"/>
 </actions>
 </resource-agent>

--- a/heartbeat/Stateful
+++ b/heartbeat/Stateful
@@ -59,13 +59,13 @@ Location to store the resource state in
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="promote"    timeout="20s" />
-<action name="demote"    timeout="20s" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="promote"    timeout="20" />
+<action name="demote"    timeout="20" />
 <action name="monitor" depth="0"  timeout="20" interval="10"/>
 <action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="20s" />
+<action name="validate-all"  timeout="20" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/SysInfo
+++ b/heartbeat/SysInfo
@@ -88,16 +88,16 @@ Units:
 <parameter name="delay" unique="0">
 <longdesc lang="en">Interval to allow values to stabilize</longdesc>
 <shortdesc lang="en">Dampening Delay</shortdesc>
-<content type="string" default="0s" />
+<content type="string" default="0" />
 </parameter>
 
 </parameters>
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" timeout="20s" interval="60s"/>
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="monitor" timeout="20" interval="60"/>
 <action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="20s" />
+<action name="validate-all"  timeout="20" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/VIPArip
+++ b/heartbeat/VIPArip
@@ -85,11 +85,11 @@ Absolute path to the ripd binary.
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="5s" />
-<action name="validate-all"  timeout="20s" />
-<action name="meta-data"  timeout="5s" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="monitor" depth="0"  timeout="20" interval="5" />
+<action name="validate-all"  timeout="20" />
+<action name="meta-data"  timeout="5" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Xinetd
+++ b/heartbeat/Xinetd
@@ -63,9 +63,9 @@ The name of the service managed by xinetd.
 </parameters>
 
 <actions>
-<action name="start" timeout="20s" />
-<action name="stop" timeout="20s" />
-<action name="restart" timeout="20s" />
+<action name="start" timeout="20" />
+<action name="stop" timeout="20" />
+<action name="restart" timeout="20" />
 <action name="status" depth="0" timeout="10" interval="10" />
 <action name="monitor" depth="0" timeout="10" interval="10" />
 <action name="validate-all" timeout="5" />

--- a/heartbeat/ZFS
+++ b/heartbeat/ZFS
@@ -67,11 +67,11 @@ zpool import is given the -f option.
 </parameters>
 
 <actions>
-<action name="start"   timeout="60s" />
-<action name="stop"    timeout="60s" />
-<action name="monitor" depth="0"  timeout="30s" interval="5s" />
-<action name="validate-all"  timeout="30s" />
-<action name="meta-data"  timeout="5s" />
+<action name="start"   timeout="60" />
+<action name="stop"    timeout="60" />
+<action name="monitor" depth="0"  timeout="30" interval="5" />
+<action name="validate-all"  timeout="30" />
+<action name="meta-data"  timeout="5" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/anything
+++ b/heartbeat/anything
@@ -294,9 +294,9 @@ before sending kill -SIGKILL. Defaults to 2/3 of the stop operation timeout.
 </parameter>
 </parameters>
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="monitor" depth="0"  timeout="20" interval="10" />
 <action name="meta-data"  timeout="5" />
 <action name="validate-all"  timeout="5" />
 </actions>

--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -592,10 +592,10 @@ that doesn't work set this to true to enforce IPv6.
 </parameters>
 
 <actions>
-<action name="start"   timeout="40s" />
-<action name="stop"    timeout="60s" />
-<action name="status"  timeout="30s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10" />
+<action name="start"   timeout="40" />
+<action name="stop"    timeout="60" />
+<action name="status"  timeout="30" />
+<action name="monitor" depth="0"  timeout="20" interval="10" />
 <action name="meta-data"  timeout="5" />
 <action name="validate-all"  timeout="5" />
 </actions>

--- a/heartbeat/azure-lb
+++ b/heartbeat/azure-lb
@@ -71,9 +71,9 @@ Port to listen to.
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="monitor" depth="0"  timeout="20" interval="10" />
 <action name="meta-data"  timeout="5" />
 <action name="validate-all"  timeout="5" />
 </actions>

--- a/heartbeat/ethmonitor
+++ b/heartbeat/ethmonitor
@@ -186,12 +186,12 @@ Only report success based on link status. Do not perform RX counter or arping re
 
 </parameters>
 <actions>
-<action name="start" timeout="60s" />
-<action name="stop" timeout="20s" />
-<action name="status" depth="0" timeout="60s" interval="10s" />
-<action name="monitor" depth="0" timeout="60s" interval="10s" />
-<action name="meta-data" timeout="5s" />
-<action name="validate-all" timeout="20s" />
+<action name="start" timeout="60" />
+<action name="stop" timeout="20" />
+<action name="status" depth="0" timeout="60" interval="10" />
+<action name="monitor" depth="0" timeout="60" interval="10" />
+<action name="meta-data" timeout="5" />
+<action name="validate-all" timeout="20" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/iface-bridge
+++ b/heartbeat/iface-bridge
@@ -273,12 +273,12 @@ bridge_meta_data() {
   </parameters>
 
   <actions>
-    <action name="start"        timeout="30s" />
-    <action name="stop"         timeout="20s" />
-    <action name="status"       timeout="20s" depth="0" interval="10s" />
-    <action name="monitor"      timeout="20s" depth="0" interval="10s" />
-    <action name="meta-data"    timeout="5s" />
-    <action name="validate-all" timeout="20s" />
+    <action name="start"        timeout="30" />
+    <action name="stop"         timeout="20" />
+    <action name="status"       timeout="20" depth="0" interval="10" />
+    <action name="monitor"      timeout="20" depth="0" interval="10" />
+    <action name="meta-data"    timeout="5" />
+    <action name="validate-all" timeout="20" />
   </actions>
 </resource-agent>
 END

--- a/heartbeat/iface-vlan
+++ b/heartbeat/iface-vlan
@@ -173,12 +173,12 @@ vlan_meta_data() {
   </parameters>
 
   <actions>
-    <action name="start"        timeout="30s" />
-    <action name="stop"         timeout="20s" />
-    <action name="status"       timeout="20s" depth="0" interval="10s" />
-    <action name="monitor"      timeout="20s" depth="0" interval="10s" />
-    <action name="meta-data"    timeout="5s" />
-    <action name="validate-all" timeout="20s" />
+    <action name="start"        timeout="30" />
+    <action name="stop"         timeout="20" />
+    <action name="status"       timeout="20" depth="0" interval="10" />
+    <action name="monitor"      timeout="20" depth="0" interval="10" />
+    <action name="meta-data"    timeout="5" />
+    <action name="validate-all" timeout="20" />
   </actions>
 </resource-agent>
 END

--- a/heartbeat/jboss
+++ b/heartbeat/jboss
@@ -497,11 +497,11 @@ Rotate console log suffix.
 </parameters>
 
 <actions>
-<action name="start" timeout="60s" />
-<action name="stop" timeout="120s" />
-<action name="status" timeout="30s" />
-<action name="monitor" depth="0" timeout="30s" interval="10s" />
-<action name="meta-data" timeout="5s" />
+<action name="start" timeout="60" />
+<action name="stop" timeout="120" />
+<action name="status" timeout="30" />
+<action name="monitor" depth="0" timeout="30" interval="10" />
+<action name="meta-data" timeout="5" />
 <action name="validate-all"  timeout="5"/>
 </actions>
 </resource-agent>

--- a/heartbeat/lxd-info
+++ b/heartbeat/lxd-info
@@ -59,16 +59,16 @@ Sample output:
 <parameter name="delay" unique="0">
 <longdesc lang="en">Interval to allow values to stabilize</longdesc>
 <shortdesc lang="en">Dampening Delay</shortdesc>
-<content type="string" default="0s" />
+<content type="string" default="0" />
 </parameter>
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" timeout="20s" interval="60s"/>
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="monitor" timeout="20" interval="60"/>
 <action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="20s" />
+<action name="validate-all"  timeout="20" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/machine-info
+++ b/heartbeat/machine-info
@@ -60,16 +60,16 @@ Sample output:
 <parameter name="delay" unique="0">
 <longdesc lang="en">Interval to allow values to stabilize</longdesc>
 <shortdesc lang="en">Dampening Delay</shortdesc>
-<content type="string" default="0s" />
+<content type="string" default="0" />
 </parameter>
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" timeout="20s" interval="60s"/>
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="monitor" timeout="20" interval="60"/>
 <action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="20s" />
+<action name="validate-all"  timeout="20" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/mysql-proxy
+++ b/heartbeat/mysql-proxy
@@ -263,12 +263,12 @@ Specify any of them here.
 </parameters>
 
 <actions>
-<action name="start"   timeout="30s" />
-<action name="stop"    timeout="30s" />
-<action name="reload"  timeout="30s" />
-<action name="monitor" depth="0"  timeout="20s" interval="60s" />
-<action name="validate-all"  timeout="30s" />
-<action name="meta-data"  timeout="5s" />
+<action name="start"   timeout="30" />
+<action name="stop"    timeout="30" />
+<action name="reload"  timeout="30" />
+<action name="monitor" depth="0"  timeout="20" interval="60" />
+<action name="validate-all"  timeout="30" />
+<action name="meta-data"  timeout="5" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -141,8 +141,8 @@ is_redhat_based && nfsserver_redhat_meta_data
 
 <actions>
 <action name="start"   timeout="40" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10" />
+<action name="stop"    timeout="20" />
+<action name="monitor" depth="0"  timeout="20" interval="10" />
 <action name="meta-data"  timeout="5" />
 <action name="validate-all"  timeout="30" />
 </actions>

--- a/heartbeat/nginx
+++ b/heartbeat/nginx
@@ -785,14 +785,14 @@ Extra options to apply when starting nginx.
 </parameters>
 
 <actions>
-<action name="start"   timeout="40s" />
-<action name="stop"    timeout="60s" />
-<action name="reload"  timeout="40s" />
-<action name="status"  timeout="30s" />
-<action name="monitor" timeout="30s" depth="0" interval="10s" />
-<action name="monitor" timeout="30s" depth="10" interval="30s" />
-<action name="monitor" timeout="45s" depth="20" />
-<action name="monitor" timeout="60s" depth="30" />
+<action name="start"   timeout="40" />
+<action name="stop"    timeout="60" />
+<action name="reload"  timeout="40" />
+<action name="status"  timeout="30" />
+<action name="monitor" timeout="30" depth="0" interval="10" />
+<action name="monitor" timeout="30" depth="10" interval="30" />
+<action name="monitor" timeout="45" depth="20" />
+<action name="monitor" timeout="60" depth="30" />
 <action name="meta-data"  timeout="5" />
 <action name="validate-all"  timeout="5" />
 </actions>

--- a/heartbeat/ovsmonitor
+++ b/heartbeat/ovsmonitor
@@ -148,12 +148,12 @@ Only report success based on link status. Do not perform RX counter related conn
 
 </parameters>
 <actions>
-<action name="start" timeout="60s" />
-<action name="stop" timeout="20s" />
-<action name="status" depth="0" timeout="60s" interval="10s" />
-<action name="monitor" depth="0" timeout="60s" interval="10s" />
-<action name="meta-data" timeout="5s" />
-<action name="validate-all" timeout="20s" />
+<action name="start" timeout="60" />
+<action name="stop" timeout="20" />
+<action name="status" depth="0" timeout="60" interval="10" />
+<action name="monitor" depth="0" timeout="60" interval="10" />
+<action name="meta-data" timeout="5" />
+<action name="validate-all" timeout="20" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/pingd
+++ b/heartbeat/pingd
@@ -74,7 +74,7 @@ The user we want to run pingd as
 The time to wait (dampening) further changes occur
 </longdesc>
 <shortdesc lang="en">Dampening interval</shortdesc>
-<content type="integer" default="1s"/>
+<content type="integer" default="1"/>
 </parameter>
 
 <parameter name="set" unique="0">
@@ -128,11 +128,11 @@ If set to true, suppresses the deprecation warning for this agent.
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="monitor" depth="0"  timeout="20" interval="10" />
 <action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="20s" />
+<action name="validate-all"  timeout="20" />
 </actions>
 </resource-agent>
 END
@@ -248,7 +248,7 @@ fi
 
 : ${OCF_RESKEY_pidfile:="$HA_RSCTMP/pingd-${OCF_RESOURCE_INSTANCE}"}
 : ${OCF_RESKEY_name:="pingd"}
-: ${OCF_RESKEY_dampen:="1s"}
+: ${OCF_RESKEY_dampen:="1"}
 
 if [ "$__OCF_ACTION" = "meta-data" ]; then
     meta_data

--- a/heartbeat/postfix
+++ b/heartbeat/postfix
@@ -84,12 +84,12 @@ Specify any of them here.
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="reload"  timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="60s" />
-<action name="validate-all"  timeout="20s" />
-<action name="meta-data"  timeout="5s" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="reload"  timeout="20" />
+<action name="monitor" depth="0"  timeout="20" interval="60" />
+<action name="validate-all"  timeout="20" />
+<action name="meta-data"  timeout="5" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/proftpd
+++ b/heartbeat/proftpd
@@ -108,12 +108,12 @@ For example, "/etc/proftpd.conf"
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="60s" />
-<action name="monitor" depth="10"  timeout="20s" interval="120s" />
-<action name="validate-all"  timeout="20s" />
-<action name="meta-data"  timeout="5s" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="monitor" depth="0"  timeout="20" interval="60" />
+<action name="monitor" depth="10"  timeout="20" interval="120" />
+<action name="validate-all"  timeout="20" />
+<action name="meta-data"  timeout="5" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/rsyncd
+++ b/heartbeat/rsyncd
@@ -88,11 +88,11 @@ limit. A value of zero specifies no limit.
 </parameters>
 
 <actions>
-<action name="start" timeout="20s"/>
-<action name="stop" timeout="20s"/>
-<action name="monitor" depth="0" timeout="20s" interval="60s" />
-<action name="validate-all" timeout="20s"/>
-<action name="meta-data"  timeout="5s"/>
+<action name="start" timeout="20"/>
+<action name="stop" timeout="20"/>
+<action name="monitor" depth="0" timeout="20" interval="60" />
+<action name="validate-all" timeout="20"/>
+<action name="meta-data"  timeout="5"/>
 </actions>
 </resource-agent>
 END

--- a/heartbeat/rsyslog
+++ b/heartbeat/rsyslog
@@ -104,11 +104,11 @@ options is used. Don't use option '-F'. It causes a stuck of a start action.
 </parameters>
 
 <actions>
-<action name="start" timeout="20s" />
-<action name="stop" timeout="60s" />
-<action name="status" timeout="20s" />
-<action name="monitor" depth="0" timeout="20s" interval="20s" />
-<action name="meta-data" timeout="5s" />
+<action name="start" timeout="20" />
+<action name="stop" timeout="60" />
+<action name="status" timeout="20" />
+<action name="monitor" depth="0" timeout="20" interval="20" />
+<action name="meta-data" timeout="5" />
 <action name="validate-all"  timeout="5"/>
 </actions>
 </resource-agent>

--- a/heartbeat/sfex
+++ b/heartbeat/sfex
@@ -111,11 +111,11 @@ The "safety margin" is decided within the range of about 10-20 seconds(It depend
 </parameters>
 
 <actions>
-<action name="start" timeout="120s" />
-<action name="stop" timeout="20s" />
-<action name="monitor" depth="0" timeout="10s" interval="10s" />
-<action name="meta-data" timeout="5s" />
-<action name="validate-all" timeout="5s" />
+<action name="start" timeout="120" />
+<action name="stop" timeout="20" />
+<action name="monitor" depth="0" timeout="10" interval="10" />
+<action name="meta-data" timeout="5" />
+<action name="validate-all" timeout="5" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/slapd
+++ b/heartbeat/slapd
@@ -209,11 +209,11 @@ Maximum number of open files (for ulimit -n)
 </parameters>
 
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="60s" />
-<action name="validate-all"  timeout="20s" />
-<action name="meta-data"  timeout="5s" />
+<action name="start"   timeout="20" />
+<action name="stop"    timeout="20" />
+<action name="monitor" depth="0"  timeout="20" interval="60" />
+<action name="validate-all"  timeout="20" />
+<action name="meta-data"  timeout="5" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/syslog-ng
+++ b/heartbeat/syslog-ng
@@ -117,11 +117,11 @@ The default value is 10.
 </parameters>
 
 <actions>
-<action name="start" timeout="60s" />
-<action name="stop" timeout="120s" />
-<action name="status" timeout="60s" />
-<action name="monitor" depth="0" timeout="60s" interval="60s" />
-<action name="meta-data" timeout="5s" />
+<action name="start" timeout="60" />
+<action name="stop" timeout="120" />
+<action name="status" timeout="60" />
+<action name="monitor" depth="0" timeout="60" interval="60" />
+<action name="meta-data" timeout="5" />
 <action name="validate-all"  timeout="5"/>
 </actions>
 </resource-agent>
@@ -300,9 +300,9 @@ esac
 #             </attributes>
 #           </instance_attributes>
 #           <operations>
-#             <op id="op:prmSyslog-ng:start"   name="start" timeout="60s" on_fail="restart"/>
-#             <op id="op:prmSyslog-ng:monitor" name="monitor" interval="10s" timeout="60s" on_fail="restart"/>
-#             <op id="op:prmSyslog-ng:stop"    name="stop" timeout="60s" on_fail="block"/>
+#             <op id="op:prmSyslog-ng:start"   name="start" timeout="60" on_fail="restart"/>
+#             <op id="op:prmSyslog-ng:monitor" name="monitor" interval="10" timeout="60" on_fail="restart"/>
+#             <op id="op:prmSyslog-ng:stop"    name="stop" timeout="60" on_fail="block"/>
 #           </operations>
 #         </primitive>
 

--- a/heartbeat/tomcat
+++ b/heartbeat/tomcat
@@ -544,11 +544,11 @@ Logging_manager of tomcat
 </parameters>
 
 <actions>
-<action name="start" timeout="60s" />
-<action name="stop" timeout="120s" />
+<action name="start" timeout="60" />
+<action name="stop" timeout="120" />
 <action name="status" timeout="60" />
-<action name="monitor" depth="0" timeout="30s" interval="10s" />
-<action name="meta-data" timeout="5s" />
+<action name="monitor" depth="0" timeout="30" interval="10" />
+<action name="meta-data" timeout="5" />
 <action name="validate-all"  timeout="5"/>
 </actions>
 </resource-agent>

--- a/heartbeat/vsftpd
+++ b/heartbeat/vsftpd
@@ -83,11 +83,11 @@ For example, "/var/run/vsftpd.pid"
 </parameters>
 
 <actions>
-<action name="start" timeout="20s"/>
-<action name="stop" timeout="20s"/>
-<action name="monitor" depth="0" timeout="20s" interval="60s" />
-<action name="validate-all" timeout="20s"/>
-<action name="meta-data"  timeout="5s"/>
+<action name="start" timeout="20"/>
+<action name="stop" timeout="20"/>
+<action name="monitor" depth="0" timeout="20" interval="60" />
+<action name="validate-all" timeout="20"/>
+<action name="meta-data"  timeout="5"/>
 </actions>
 </resource-agent>
 END


### PR DESCRIPTION
This patch introduces consistency by removing the trailing "s" character
from default time values for actions in resource agent metadata.
The default unit for time is seconds. Currently, some instances of time
values include the explicit "s" for the seconds unit, while others do
not.