### PR TITLE
Replace deprecated CLI options

### DIFF
--- a/heartbeat/NodeUtilization
+++ b/heartbeat/NodeUtilization
@@ -129,10 +129,10 @@ set_utilization() {
 
     if ocf_is_true "$OCF_RESKEY_utilization_cpu"; then
         sys_cpu=$(( $(grep -c processor /proc/cpuinfo) - $OCF_RESKEY_utilization_cpu_reservation ))
-        uti_cpu=$(crm_attribute -Q -t nodes -U "$host_name" -z -n cpu 2>/dev/null)
+        uti_cpu=$(crm_attribute -Q -t nodes --node "$host_name" -z -n cpu 2>/dev/null)
 
         if [ "$sys_cpu" != "$uti_cpu" ]; then
-            if ! crm_attribute -t nodes -U "$host_name" -z -n cpu -v $sys_cpu; then
+            if ! crm_attribute -t nodes --node "$host_name" -z -n cpu -v $sys_cpu; then
                 ocf_log err "Failed to set the cpu utilization attribute for $host_name using crm_attribute."
                 return 1
             fi
@@ -141,10 +141,10 @@ set_utilization() {
 
     if ocf_is_true "$OCF_RESKEY_utilization_host_memory"; then
         sys_mem=$(( $(awk '/MemTotal/{printf("%d\n",$2/1024);exit(0)}' /proc/meminfo) - $OCF_RESKEY_utilization_host_memory_reservation ))
-        uti_mem=$(crm_attribute -Q -t nodes -U "$host_name" -z -n host_memory 2>/dev/null)
+        uti_mem=$(crm_attribute -Q -t nodes --node "$host_name" -z -n host_memory 2>/dev/null)
 
         if [ "$sys_mem" != "$uti_mem" ]; then
-            if ! crm_attribute -t nodes -U "$host_name" -z -n host_memory -v $sys_mem; then
+            if ! crm_attribute -t nodes --node "$host_name" -z -n host_memory -v $sys_mem; then
                 ocf_log err "Failed to set the host_memory utilization attribute for $host_name using crm_attribute."
                 return 1
             fi
@@ -153,12 +153,12 @@ set_utilization() {
 
     if ocf_is_true "$OCF_RESKEY_utilization_hv_memory"; then
         hv_mem=$(( $(Host_Total_Memory) - OCF_RESKEY_utilization_hv_memory_reservation ))
-        uti_mem=$(crm_attribute -Q -t nodes -U "$host_name" -z -n hv_memory 2>/dev/null)
+        uti_mem=$(crm_attribute -Q -t nodes --node "$host_name" -z -n hv_memory 2>/dev/null)
 
         [ $hv_mem -lt 0 ] && hv_mem=0
 
         if [ "$hv_mem" != "$uti_mem" ]; then
-            if ! crm_attribute -t nodes -U "$host_name" -z -n hv_memory -v $hv_mem; then
+            if ! crm_attribute -t nodes --node "$host_name" -z -n hv_memory -v $hv_mem; then
                 ocf_log err "Failed to set the hv_memory utilization attribute for $host_name using crm_attribute."
                 return 1
             fi

--- a/heartbeat/NodeUtilization
+++ b/heartbeat/NodeUtilization
@@ -129,7 +129,7 @@ set_utilization() {
 
     if ocf_is_true "$OCF_RESKEY_utilization_cpu"; then
         sys_cpu=$(( $(grep -c processor /proc/cpuinfo) - $OCF_RESKEY_utilization_cpu_reservation ))
-        uti_cpu=$(crm_attribute -Q -t nodes --node "$host_name" -z -n cpu 2>/dev/null)
+        uti_cpu=$(crm_attribute --quiet -t nodes --node "$host_name" -z -n cpu 2>/dev/null)
 
         if [ "$sys_cpu" != "$uti_cpu" ]; then
             if ! crm_attribute -t nodes --node "$host_name" -z -n cpu -v $sys_cpu; then
@@ -141,7 +141,7 @@ set_utilization() {
 
     if ocf_is_true "$OCF_RESKEY_utilization_host_memory"; then
         sys_mem=$(( $(awk '/MemTotal/{printf("%d\n",$2/1024);exit(0)}' /proc/meminfo) - $OCF_RESKEY_utilization_host_memory_reservation ))
-        uti_mem=$(crm_attribute -Q -t nodes --node "$host_name" -z -n host_memory 2>/dev/null)
+        uti_mem=$(crm_attribute --quiet -t nodes --node "$host_name" -z -n host_memory 2>/dev/null)
 
         if [ "$sys_mem" != "$uti_mem" ]; then
             if ! crm_attribute -t nodes --node "$host_name" -z -n host_memory -v $sys_mem; then
@@ -153,7 +153,7 @@ set_utilization() {
 
     if ocf_is_true "$OCF_RESKEY_utilization_hv_memory"; then
         hv_mem=$(( $(Host_Total_Memory) - OCF_RESKEY_utilization_hv_memory_reservation ))
-        uti_mem=$(crm_attribute -Q -t nodes --node "$host_name" -z -n hv_memory 2>/dev/null)
+        uti_mem=$(crm_attribute --quiet -t nodes --node "$host_name" -z -n hv_memory 2>/dev/null)
 
         [ $hv_mem -lt 0 ] && hv_mem=0
 

--- a/heartbeat/Xen
+++ b/heartbeat/Xen
@@ -434,7 +434,7 @@ Xen_Migrate_To() {
 		ocf_log info "$DOMAIN_NAME: Starting $xentool migrate to $target_node"
 
 		if [ -n "$target_attr" ]; then
-			nodevalue=`crm_attribute --type nodes --node $target_node --attr-name $target_attr -G -q`
+			nodevalue=`crm_attribute --type nodes --node $target_node -n $target_attr -G -q`
 			if [ -n "${nodevalue}" -a "${nodevalue}" != "(null)" ]; then
 				target_addr="$nodevalue"
 				ocf_log info "$DOMAIN_NAME: $target_node is using address $target_addr"

--- a/heartbeat/Xen
+++ b/heartbeat/Xen
@@ -434,7 +434,7 @@ Xen_Migrate_To() {
 		ocf_log info "$DOMAIN_NAME: Starting $xentool migrate to $target_node"
 
 		if [ -n "$target_attr" ]; then
-			nodevalue=`crm_attribute --type nodes --node $target_node --attr-name $target_attr --get-value -q`
+			nodevalue=`crm_attribute --type nodes --node $target_node --attr-name $target_attr -G -q`
 			if [ -n "${nodevalue}" -a "${nodevalue}" != "(null)" ]; then
 				target_addr="$nodevalue"
 				ocf_log info "$DOMAIN_NAME: $target_node is using address $target_addr"

--- a/heartbeat/Xen
+++ b/heartbeat/Xen
@@ -434,7 +434,7 @@ Xen_Migrate_To() {
 		ocf_log info "$DOMAIN_NAME: Starting $xentool migrate to $target_node"
 
 		if [ -n "$target_attr" ]; then
-			nodevalue=`crm_attribute --type nodes --node-uname $target_node --attr-name $target_attr --get-value -q`
+			nodevalue=`crm_attribute --type nodes --node $target_node --attr-name $target_attr --get-value -q`
 			if [ -n "${nodevalue}" -a "${nodevalue}" != "(null)" ]; then
 				target_addr="$nodevalue"
 				ocf_log info "$DOMAIN_NAME: $target_node is using address $target_addr"

--- a/heartbeat/db2
+++ b/heartbeat/db2
@@ -272,7 +272,7 @@ db2_fal_attrib() {
         ;;
 
         get)
-        crm_attribute -t nodes -l reboot -n $attr -G -Q 2>&1
+        crm_attribute -t nodes -l reboot -n $attr -G --quiet 2>&1
         rc=$?
         if [ $rc != 0 ]
         then

--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -293,7 +293,7 @@ clear_bootstrap_node()
 
 is_bootstrap()
 {
-    ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-bootstrap" -Q 2>/dev/null
+    ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-bootstrap" --quiet 2>/dev/null
 
 }
 
@@ -310,7 +310,7 @@ clear_no_grastate()
 is_no_grastate()
 {
     local node=$(ocf_attribute_target $1)
-    ${HA_SBIN_DIR}/crm_attribute -N $node -l reboot --name "${INSTANCE_ATTR_NAME}-no-grastate" -Q 2>/dev/null
+    ${HA_SBIN_DIR}/crm_attribute -N $node -l reboot --name "${INSTANCE_ATTR_NAME}-no-grastate" --quiet 2>/dev/null
 }
 
 clear_last_commit()
@@ -328,9 +328,9 @@ get_last_commit()
     local node=$(ocf_attribute_target $1)
 
     if [ -z "$node" ]; then
-       ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-last-committed" -Q 2>/dev/null
+       ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-last-committed" --quiet 2>/dev/null
     else 
-       ${HA_SBIN_DIR}/crm_attribute -N $node -l reboot --name "${INSTANCE_ATTR_NAME}-last-committed" -Q 2>/dev/null
+       ${HA_SBIN_DIR}/crm_attribute -N $node -l reboot --name "${INSTANCE_ATTR_NAME}-last-committed" --quiet 2>/dev/null
     fi
 }
 
@@ -349,9 +349,9 @@ get_safe_to_bootstrap()
     local node=$(ocf_attribute_target $1)
 
     if [ -z "$node" ]; then
-        ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-safe-to-bootstrap" -Q 2>/dev/null
+        ${HA_SBIN_DIR}/crm_attribute -N $NODENAME -l reboot --name "${INSTANCE_ATTR_NAME}-safe-to-bootstrap" --quiet 2>/dev/null
     else
-        ${HA_SBIN_DIR}/crm_attribute -N $node -l reboot --name "${INSTANCE_ATTR_NAME}-safe-to-bootstrap" -Q 2>/dev/null
+        ${HA_SBIN_DIR}/crm_attribute -N $node -l reboot --name "${INSTANCE_ATTR_NAME}-safe-to-bootstrap" --quiet 2>/dev/null
     fi
 }
 

--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -315,7 +315,7 @@ redis_monitor() {
 		# If score isn't set we the redis setting 'slave_priority'.
 		# If that isn't set, we default to 1000 for a master, and 1 for slave.
 		# We then add 1 for each connected client
-		score="$(crm_master_reboot --get-value --quiet 2>/dev/null)"
+		score="$(crm_master_reboot -G --quiet 2>/dev/null)"
 		if [[ -z "$score" ]]; then
 			score=$(calculate_score "${info[slave_priority]}" "${info[connected_clients]}")
 			set_score "$score"

--- a/heartbeat/vmware
+++ b/heartbeat/vmware
@@ -24,7 +24,7 @@
 #  * vmware-server 2.0 installed and autostarted on all nodes
 #  * vmdk files must be in the same directory of the vmx file
 #  * vmx filenames must be unique, even if stored in different directories
-#  * Default_Action_Timeout stock value (20 sec) isn't enough if you are
+#  * The default value of operation timeout (20 sec) isn't enough if you are
 #    dealing with many virtual machines: raise it to something around 600 secs
 #    or use operation attributes with the proposed values
 #  * Moving a vm among nodes will cause its mac address to change: if you need

--- a/tools/sfex_daemon.c
+++ b/tools/sfex_daemon.c
@@ -100,8 +100,8 @@ static void acquire_lock(void)
 static void error_todo (void)
 {
 	if (fork() == 0) {
-		cl_log(LOG_INFO, "Execute \"crm_resource -F -r %s -H %s\" command\n", rsc_id, nodename);
-		execl("/usr/sbin/crm_resource", "crm_resource", "-F", "-r", rsc_id, "-H", nodename, NULL);
+		cl_log(LOG_INFO, "Execute \"crm_resource -F -r %s --node %s\" command\n", rsc_id, nodename);
+		execl("/usr/sbin/crm_resource", "crm_resource", "-F", "-r", rsc_id, "--node", nodename, NULL);
 	} else {
 		exit(EXIT_FAILURE);
 	}
@@ -112,7 +112,7 @@ static void failure_todo(void)
 #ifdef SFEX_TESTING	
 	exit(EXIT_FAILURE);
 #else
-	/*execl("/usr/sbin/crm_resource", "crm_resource", "-F", "-r", rsc_id, "-H", nodename, NULL); */
+	/*execl("/usr/sbin/crm_resource", "crm_resource", "-F", "-r", rsc_id, "--node", nodename, NULL); */
 	int ret;
 
 	cl_log(LOG_INFO, "Force reboot node %s\n", nodename);


### PR DESCRIPTION
I didn't find any resource agents use the CLI options lately *dropped* from pacemaker-2.0 branch. By the opportunity I just replaced some of the deprecated ones.