### PR TITLE
Drop python from build system since nothing uses it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -470,7 +470,6 @@ dnl ===============================================
 PATH="$PATH:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin"
 export PATH
 
-AM_PATH_PYTHON
 AC_CHECK_PROGS(MAKE, gmake make)
 AC_PATH_PROGS(SSH, ssh, /usr/bin/ssh)
 AC_PATH_PROGS(SCP, scp, /usr/bin/scp)

--- a/heartbeat/ocf-binaries.in
+++ b/heartbeat/ocf-binaries.in
@@ -33,7 +33,6 @@ export PATH
 : ${MSGFMT:=msgfmt}
 : ${NETSTAT:=netstat}
 : ${PERL:=perl}
-: ${PYTHON:=python}
 : ${RAIDSTART:=raidstart}
 : ${RAIDSTOP:=raidstop}
 : ${ROUTE:=route}

--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -56,7 +56,7 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 # Build dependencies
 BuildRequires: automake autoconf pkgconfig
-BuildRequires: perl python-devel
+BuildRequires: perl
 BuildRequires: libxslt glib2-devel
 BuildRequires: which
 


### PR DESCRIPTION
There's no need to require python when it isn't actually used.