### PR TITLE
Fix raid1 stop detection

### DIFF
--- a/heartbeat/Raid1
+++ b/heartbeat/Raid1
@@ -384,8 +384,16 @@ raid1_monitor_one() {
 		2)	ocf_exit_reason "$mddev has failed."
 			return $OCF_ERR_GENERIC
 			;;
-		4)	ocf_exit_reason "mdadm failed on $mddev."
-			return $OCF_ERR_GENERIC
+		4)
+			if [ "$__OCF_ACTION" = "stop" ] ; then
+				# There may be a transient invalid device after
+				# we stop MD due to uevent processing, the
+				# original device is stopped though.
+				return $OCF_NOT_RUNNING
+			else
+				ocf_exit_reason "mdadm failed on $mddev."
+				return $OCF_ERR_GENERIC
+			fi
 			;;
 		*)	ocf_exit_reason "mdadm returned an unknown result ($rc)."
 			return $OCF_ERR_GENERIC

--- a/heartbeat/Raid1
+++ b/heartbeat/Raid1
@@ -246,7 +246,7 @@ mknod_raid1_stop() {
 	rm -f $tmp_block_file
 	ocf_log info "block device file $1 missing, creating one in order to stop the array"
 	mknod $tmp_block_file b 9 $n
-	$MDADM --stop $tmp_block_file --config=$RAIDCONF --wait-clean -W
+	$MDADM --stop $tmp_block_file --config=$RAIDCONF
 	rc=$?
 	rm -f $tmp_block_file
 	return $rc
@@ -254,12 +254,12 @@ mknod_raid1_stop() {
 raid1_stop_one() {
 	ocf_log info "Stopping array $1"
 	if [ -b "$1" ]; then
-		$MDADM --stop $1 --config=$RAIDCONF --wait-clean -W &&
+		$MDADM --stop $1 --config=$RAIDCONF &&
 			return
 	else
 		# newer mdadm releases can stop arrays when given the
 		# basename; try that first
-		$MDADM --stop `basename $1` --config=$RAIDCONF --wait-clean -W &&
+		$MDADM --stop `basename $1` --config=$RAIDCONF &&
 			return
 		# otherwise create a block device file
 		mknod_raid1_stop $1


### PR DESCRIPTION
The following sequence of events was observed in the wild:
```
16:19:04.379377+01:00 Raid1(rsc_Raid1_md7)[25734]: INFO: Stopping array /dev/md7
16:19:04.389490+01:00 kernel: [12955.559495] md7: detected capacity change from 429496664064 to 0
16:19:04.389499+01:00 kernel: [12955.559513] md: md7 stopped.
16:19:04.511817+01:00 Raid1(rsc_Raid1_md7)[25734]: ERROR: mdadm failed on /dev/md7.
16:19:04.520194+01:00 Raid1(rsc_Raid1_md7)[25734]: ERROR: RAID /dev/md7 still active after stop command!
```
As pointed by @neilbrown, the `-W` and `--wait-clean` flags are ignored (when they come *after* device) and useless as `mdadm --stop` only returns when the device is stopped.
The false positive is a transient device that may be created for short periods when the removal uevent is being processed by other programs.