### PR TITLE
Low: Add "s" suffix to action default times

### DIFF
--- a/heartbeat/AoEtarget
+++ b/heartbeat/AoEtarget
@@ -101,12 +101,12 @@ Location of the vblade binary.
     </parameter>
   </parameters>
   <actions>
-    <action name="start" timeout="15"/>
-    <action name="stop" timeout="15"/>
-    <action name="monitor" timeout="15" interval="10" depth="0"/>
-    <action name="reload" timeout="15"/>
-    <action name="meta-data" timeout="5"/>
-    <action name="validate-all" timeout="15"/>
+    <action name="start" timeout="15s"/>
+    <action name="stop" timeout="15s"/>
+    <action name="monitor" timeout="15s" interval="10s" depth="0"/>
+    <action name="reload" timeout="15s"/>
+    <action name="meta-data" timeout="5s"/>
+    <action name="validate-all" timeout="15s"/>
   </actions>
 </resource-agent>
 EOF

--- a/heartbeat/AudibleAlarm
+++ b/heartbeat/AudibleAlarm
@@ -57,13 +57,13 @@ The node list that should never sound the alarm.
 </parameters>
 
 <actions>
-<action name="start" timeout="10" />
-<action name="stop" timeout="10" />
-<action name="restart" timeout="10" />
-<action name="status" depth="0" timeout="10" interval="10" />
-<action name="monitor" depth="0" timeout="10" interval="10" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="start" timeout="10s" />
+<action name="stop" timeout="10s" />
+<action name="restart" timeout="10s" />
+<action name="status" depth="0" timeout="10s" interval="10s" />
+<action name="monitor" depth="0" timeout="10s" interval="10s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/CTDB
+++ b/heartbeat/CTDB
@@ -341,11 +341,11 @@ CTDB is managing Samba.
 </parameters>
 
 <actions>
-<action name="start"        timeout="90" />
-<action name="stop"         timeout="100" />
-<action name="monitor"      timeout="20" interval="10" depth="0" />
-<action name="meta-data"    timeout="5" />
-<action name="validate-all"   timeout="30" />
+<action name="start"        timeout="90s" />
+<action name="stop"         timeout="100s" />
+<action name="monitor"      timeout="20s" interval="10s" depth="0" />
+<action name="meta-data"    timeout="5s" />
+<action name="validate-all"   timeout="30s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/ClusterMon
+++ b/heartbeat/ClusterMon
@@ -99,11 +99,11 @@ Location to write HTML output to.
 </parameters>
 
 <actions>
-<action name="start"   timeout="20" />
-<action name="stop"    timeout="20" />
-<action name="monitor" depth="0"  timeout="20" interval="10" />
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="30" />
+<action name="start"   timeout="20s" />
+<action name="stop"    timeout="20s" />
+<action name="monitor" depth="0"  timeout="20s" interval="10s" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="30s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Delay
+++ b/heartbeat/Delay
@@ -78,12 +78,12 @@ Defaults to "startdelay" if unspecified.
 </parameters>
 
 <actions>
-<action name="start" timeout="30" />
-<action name="stop" timeout="30" />
-<action name="status" depth="0" timeout="30" interval="10" />
-<action name="monitor" depth="0" timeout="30" interval="10" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="start" timeout="30s" />
+<action name="stop" timeout="30s" />
+<action name="status" depth="0" timeout="30s" interval="10s" />
+<action name="monitor" depth="0" timeout="30s" interval="10s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Dummy
+++ b/heartbeat/Dummy
@@ -76,14 +76,14 @@ Fake attribute that can be changed to cause a reload
 </parameters>
 
 <actions>
-<action name="start"        timeout="20" />
-<action name="stop"         timeout="20" />
-<action name="monitor"      timeout="20" interval="10" depth="0" />
-<action name="reload"       timeout="20" />
-<action name="migrate_to"   timeout="20" />
-<action name="migrate_from" timeout="20" />
-<action name="meta-data"    timeout="5" />
-<action name="validate-all"   timeout="20" />
+<action name="start"        timeout="20s" />
+<action name="stop"         timeout="20s" />
+<action name="monitor"      timeout="20s" interval="10s" depth="0" />
+<action name="reload"       timeout="20s" />
+<action name="migrate_to"   timeout="20s" />
+<action name="migrate_from" timeout="20s" />
+<action name="meta-data"    timeout="5s" />
+<action name="validate-all"   timeout="20s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/EvmsSCC
+++ b/heartbeat/EvmsSCC
@@ -79,12 +79,12 @@ If set to true, suppresses the deprecation warning for this agent.
 </parameters>
 
 <actions>
-<action name="start" timeout="60" />
-<action name="stop" timeout="60" />
-<action name="notify" timeout="60" />
-<action name="status" depth="0" timeout="10" interval="10" />
-<action name="monitor" depth="0" timeout="10" interval="10" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="60s" />
+<action name="stop" timeout="60s" />
+<action name="notify" timeout="60s" />
+<action name="status" depth="0" timeout="10s" interval="10s" />
+<action name="monitor" depth="0" timeout="10s" interval="10s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Evmsd
+++ b/heartbeat/Evmsd
@@ -58,10 +58,10 @@ If set to true, suppresses the deprecation warning for this agent.
 </parameters>
 
 <actions>
-<action name="start"        timeout="20" />
-<action name="stop"         timeout="20" />
-<action name="monitor"      timeout="20" interval="10" depth="0" />
-<action name="meta-data"    timeout="5" />
+<action name="start"        timeout="20s" />
+<action name="stop"         timeout="20s" />
+<action name="monitor"      timeout="20s" interval="10s" depth="0" />
+<action name="meta-data"    timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -219,12 +219,12 @@ block if unresponsive nfs mounts are in use on the system.
 </parameters>
 
 <actions>
-<action name="start" timeout="60" />
-<action name="stop" timeout="60" />
-<action name="notify" timeout="60" />
-<action name="monitor" depth="0" timeout="40" interval="20" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="60s" />
+<action name="stop" timeout="60s" />
+<action name="notify" timeout="60s" />
+<action name="monitor" depth="0" timeout="40s" interval="20s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/ICP
+++ b/heartbeat/ICP
@@ -86,12 +86,12 @@ The device name.
 </parameters>
 
 <actions>
-<action name="start" timeout="20" />
-<action name="stop" timeout="20" />
-<action name="status" depth="0" timeout="20" interval="10" />
-<action name="monitor" depth="0" timeout="20" interval="10" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="20s" />
+<action name="stop" timeout="20s" />
+<action name="status" depth="0" timeout="20s" interval="10s" />
+<action name="monitor" depth="0" timeout="20s" interval="10s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/IPsrcaddr
+++ b/heartbeat/IPsrcaddr
@@ -102,9 +102,9 @@ dotted quad notation  255.255.255.0).
 <actions>
 <action name="start" timeout="20s" />
 <action name="stop" timeout="20s" />
-<action name="monitor" depth="0" timeout="20s" interval="10" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="monitor" depth="0" timeout="20s" interval="10s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -106,13 +106,13 @@ logical volumes.
 </parameters>
 
 <actions>
-<action name="start" timeout="30" />
-<action name="stop" timeout="30" />
-<action name="status" timeout="30" />
-<action name="monitor" depth="0" timeout="30" interval="10" />
-<action name="methods" timeout="5" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="start" timeout="30s" />
+<action name="stop" timeout="30s" />
+<action name="status" timeout="30s" />
+<action name="monitor" depth="0" timeout="30s" interval="10s" />
+<action name="methods" timeout="5s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
 </actions>
 </resource-agent>
 EOF

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -152,11 +152,11 @@ The tag used for tagging activation mode.
 </parameters>
 
 <actions>
-<action name="start"		timeout="90" />
-<action name="stop"		timeout="90" />
-<action name="monitor"		timeout="90" interval="30" depth="0" />
-<action name="meta-data"	timeout="10" />
-<action name="validate-all"	timeout="20" />
+<action name="start"		timeout="90s" />
+<action name="stop"		timeout="90s" />
+<action name="monitor"		timeout="90s" interval="30s" depth="0" />
+<action name="meta-data"	timeout="10s" />
+<action name="validate-all"	timeout="20s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/LinuxSCSI
+++ b/heartbeat/LinuxSCSI
@@ -142,11 +142,11 @@ If set to true, suppresses the deprecation warning for this agent.
 <actions>
 <action name="start" timeout="20s" />
 <action name="stop" timeout="20s" />
-<action name="methods" timeout="5" />
-<action name="status" depth="0" timeout="20s" interval="10" />
-<action name="monitor" depth="0" timeout="20s" interval="10" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="methods" timeout="5s" />
+<action name="status" depth="0" timeout="20s" interval="10s" />
+<action name="monitor" depth="0" timeout="20s" interval="10s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
 </actions>
 </resource-agent>
 EOF

--- a/heartbeat/MailTo
+++ b/heartbeat/MailTo
@@ -72,12 +72,12 @@ The subject of the email.
 </parameters>
 
 <actions>
-<action name="start" timeout="10" />
-<action name="stop" timeout="10" />
-<action name="status" depth="0" timeout="10" interval="10" />
-<action name="monitor" depth="0" timeout="10" interval="10" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="start" timeout="10s" />
+<action name="stop" timeout="10s" />
+<action name="status" depth="0" timeout="10s" interval="10s" />
+<action name="monitor" depth="0" timeout="10s" interval="10s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/ManageRAID
+++ b/heartbeat/ManageRAID
@@ -110,12 +110,12 @@ meta_data()
   </parameters>
 
   <actions>
-    <action name="start" timeout="75" />
-    <action name="stop" timeout="75" />
-    <action name="status" depth="0" timeout="10" interval="10" />
-    <action name="monitor" depth="0" timeout="10" interval="10" />
-    <action name="validate-all" timeout="5" />
-    <action name="meta-data" timeout="5" />
+    <action name="start" timeout="75s" />
+    <action name="stop" timeout="75s" />
+    <action name="status" depth="0" timeout="10s" interval="10s" />
+    <action name="monitor" depth="0" timeout="10s" interval="10s" />
+    <action name="validate-all" timeout="5s" />
+    <action name="meta-data" timeout="5s" />
   </actions>
 </resource-agent>
 END

--- a/heartbeat/ManageVE
+++ b/heartbeat/ManageVE
@@ -87,14 +87,14 @@ meta_data()
   </parameters>
 
   <actions>
-    <action name="start" timeout="75" />
-    <action name="stop" timeout="75" />
-    <action name="status" depth="0" timeout="10" interval="10" />
-    <action name="monitor" depth="0" timeout="10" interval="10" />
-    <action name="migrate_to" timeout="75" />
-    <action name="migrate_from" timeout="75" />
-    <action name="validate-all" timeout="5" />
-    <action name="meta-data" timeout="5" />
+    <action name="start" timeout="75s" />
+    <action name="stop" timeout="75s" />
+    <action name="status" depth="0" timeout="10s" interval="10s" />
+    <action name="monitor" depth="0" timeout="10s" interval="10s" />
+    <action name="migrate_to" timeout="75s" />
+    <action name="migrate_from" timeout="75s" />
+    <action name="validate-all" timeout="5s" />
+    <action name="meta-data" timeout="5s" />
   </actions>
 </resource-agent>
 END

--- a/heartbeat/NodeUtilization
+++ b/heartbeat/NodeUtilization
@@ -100,11 +100,11 @@ If not set, the parameters will be set once when the resource instance starts.
 </parameters>
 
 <actions>
-<action name="start"   timeout="90" />
-<action name="stop"    timeout="100" />
+<action name="start"   timeout="90s" />
+<action name="stop"    timeout="100s" />
 <action name="monitor" timeout="20s" interval="60s"/>
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="30" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="30s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Raid1
+++ b/heartbeat/Raid1
@@ -137,10 +137,10 @@ Only set this to "true" if you know what you are doing!
 <actions>
 <action name="start" timeout="20s" />
 <action name="stop" timeout="20s" />
-<action name="status" depth="0" timeout="20s" interval="10" />
-<action name="monitor" depth="0" timeout="20s" interval="10" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="status" depth="0" timeout="20s" interval="10s" />
+<action name="monitor" depth="0" timeout="20s" interval="10s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Route
+++ b/heartbeat/Route
@@ -138,13 +138,13 @@ detect   Detect from 'destination' address.
 </parameters>
 
 <actions>
-<action name="start"        timeout="20" />
-<action name="stop"         timeout="20" />
-<action name="monitor"      timeout="20" interval="10" 
+<action name="start"        timeout="20s" />
+<action name="stop"         timeout="20s" />
+<action name="monitor"      timeout="20s" interval="10s" 
                             depth="0"/>
-<action name="reload"       timeout="20" />
-<action name="meta-data"    timeout="5" />
-<action name="validate-all" timeout="20" />
+<action name="reload"       timeout="20s" />
+<action name="meta-data"    timeout="5s" />
+<action name="validate-all" timeout="20s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/SAPDatabase
+++ b/heartbeat/SAPDatabase
@@ -189,13 +189,13 @@ Usually you can leave this empty. Then the default: /usr/sap/hostctrl/exe is use
 </parameters>
 
 <actions>
-<action name="start" timeout="1800" />
-<action name="stop" timeout="1800" />
-<action name="status" timeout="60" />
-<action name="monitor" depth="0" timeout="60" interval="120" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
-<action name="methods" timeout="5" />
+<action name="start" timeout="1800s" />
+<action name="stop" timeout="1800s" />
+<action name="status" timeout="60s" />
+<action name="monitor" depth="0" timeout="60s" interval="120s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
+<action name="methods" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -214,17 +214,17 @@ The name of the SAP START profile. Specify this parameter, if you have changed t
 </parameters>
 
 <actions>
-<action name="start" timeout="180" />
-<action name="stop" timeout="240" />
-<action name="status" timeout="60" />
-<action name="monitor" depth="0" timeout="60" interval="120" />
-<action name="monitor" depth="0" timeout="60" interval="121" role="Slave" />
-<action name="monitor" depth="0" timeout="60" interval="119" role="Master" />
-<action name="promote" timeout="320" />
-<action name="demote" timeout="320" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
-<action name="methods" timeout="5" />
+<action name="start" timeout="180s" />
+<action name="stop" timeout="240s" />
+<action name="status" timeout="60s" />
+<action name="monitor" depth="0" timeout="60s" interval="120s" />
+<action name="monitor" depth="0" timeout="60s" interval="121s" role="Slave" />
+<action name="monitor" depth="0" timeout="60s" interval="119s" role="Master" />
+<action name="promote" timeout="320s" />
+<action name="demote" timeout="320s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
+<action name="methods" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/SendArp
+++ b/heartbeat/SendArp
@@ -116,8 +116,8 @@ sending ARPs succeeded.
 <actions>
 <action name="start"   timeout="20s" />
 <action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20" interval="10" />
-<action name="meta-data"  timeout="5" />
+<action name="monitor" depth="0"  timeout="20s" interval="10s" />
+<action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="20s" />
 </actions>
 </resource-agent>

--- a/heartbeat/ServeRAID
+++ b/heartbeat/ServeRAID
@@ -136,13 +136,13 @@ The logical drive under consideration.
 </parameters>
 
 <actions>
-<action name="start" timeout="40" />
-<action name="stop" timeout="40" />
-<action name="status" depth="0" timeout="20" interval="10" />
-<action name="monitor" depth="0" timeout="20" interval="10" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
-<action name="methods" timeout="5" />
+<action name="start" timeout="40s" />
+<action name="stop" timeout="40s" />
+<action name="status" depth="0" timeout="20s" interval="10s" />
+<action name="monitor" depth="0" timeout="20s" interval="10s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
+<action name="methods" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/SphinxSearchDaemon
+++ b/heartbeat/SphinxSearchDaemon
@@ -89,8 +89,8 @@ is able to query its indices and respond properly.
 <actions>
 <action name="start"        timeout="20s" />
 <action name="stop"         timeout="20s" />
-<action name="monitor"      timeout="20" interval="10" depth="0" />
-<action name="meta-data"    timeout="5" />
+<action name="monitor"      timeout="20s" interval="10s" depth="0" />
+<action name="meta-data"    timeout="5s" />
 <action name="validate-all"   timeout="20s" />
 </actions>
 </resource-agent>

--- a/heartbeat/Squid
+++ b/heartbeat/Squid
@@ -157,10 +157,10 @@ the configuration file given by "syslog_ng_conf" as a basename part,
 <actions>
 <action name="start" timeout="60s" />
 <action name="stop" timeout="120s" />
-<action name="status" timeout="60" />
+<action name="status" timeout="60s" />
 <action name="monitor" depth="0" timeout="30s" interval="10s" />
 <action name="meta-data" timeout="5s" />
-<action name="validate-all"  timeout="5"/>
+<action name="validate-all"  timeout="5s"/>
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Stateful
+++ b/heartbeat/Stateful
@@ -63,8 +63,8 @@ Location to store the resource state in
 <action name="stop"    timeout="20s" />
 <action name="promote"    timeout="20s" />
 <action name="demote"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20" interval="10"/>
-<action name="meta-data"  timeout="5" />
+<action name="monitor" depth="0"  timeout="20s" interval="10s"/>
+<action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="20s" />
 </actions>
 </resource-agent>

--- a/heartbeat/SysInfo
+++ b/heartbeat/SysInfo
@@ -96,7 +96,7 @@ Units:
 <action name="start"   timeout="20s" />
 <action name="stop"    timeout="20s" />
 <action name="monitor" timeout="20s" interval="60s"/>
-<action name="meta-data"  timeout="5" />
+<action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="20s" />
 </actions>
 </resource-agent>

--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -287,14 +287,14 @@ Instruct virsh to use specific shutdown mode
 </parameters>
 
 <actions>
-<action name="start" timeout="90" />
-<action name="stop" timeout="90" />
-<action name="status" depth="0" timeout="30" interval="10" />
-<action name="monitor" depth="0" timeout="30" interval="10" />
-<action name="migrate_from" timeout="60" />
-<action name="migrate_to" timeout="120" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="start" timeout="90s" />
+<action name="stop" timeout="90s" />
+<action name="status" depth="0" timeout="30s" interval="10s" />
+<action name="monitor" depth="0" timeout="30s" interval="10s" />
+<action name="migrate_from" timeout="60s" />
+<action name="migrate_to" timeout="120s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
 </actions>
 </resource-agent>
 EOF

--- a/heartbeat/WAS
+++ b/heartbeat/WAS
@@ -133,13 +133,13 @@ The WAS-(snoop)-port-number.
 </parameters>
 
 <actions>
-<action name="start" timeout="300" />
-<action name="stop" timeout="300" />
-<action name="status" depth="0" timeout="30" interval="10" />
-<action name="monitor" depth="0" timeout="30" interval="10" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
-<action name="methods" timeout="5" />
+<action name="start" timeout="300s" />
+<action name="stop" timeout="300s" />
+<action name="status" depth="0" timeout="30s" interval="10s" />
+<action name="monitor" depth="0" timeout="30s" interval="10s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
+<action name="methods" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/WAS6
+++ b/heartbeat/WAS6
@@ -107,13 +107,13 @@ The WAS profile name.
 </parameters>
 
 <actions>
-<action name="start" timeout="300" />
-<action name="stop" timeout="300" />
-<action name="status" depth="0" timeout="30" interval="10" />
-<action name="monitor" depth="0" timeout="30" interval="10" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
-<action name="methods" timeout="5" />
+<action name="start" timeout="300s" />
+<action name="stop" timeout="300s" />
+<action name="status" depth="0" timeout="30s" interval="10s" />
+<action name="monitor" depth="0" timeout="30s" interval="10s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
+<action name="methods" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/WinPopup
+++ b/heartbeat/WinPopup
@@ -56,12 +56,12 @@ The file containing the hosts to send WinPopup messages to.
 </parameters>
 
 <actions>
-<action name="start" timeout="30" />
-<action name="stop" timeout="30" />
-<action name="status" depth="0" timeout="10" interval="10" />
-<action name="monitor" depth="0" timeout="10" interval="10" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="30s" />
+<action name="stop" timeout="30s" />
+<action name="status" depth="0" timeout="10s" interval="10s" />
+<action name="monitor" depth="0" timeout="10s" interval="10s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Xen
+++ b/heartbeat/Xen
@@ -168,13 +168,13 @@ add this parameter with a list of scripts to monitor.
 </parameters>
 
 <actions>
-<action name="start" timeout="60" />
-<action name="stop" timeout="40" />
-<action name="migrate_from" timeout="120" />
-<action name="migrate_to" timeout="120" />
-<action name="monitor" depth="0" timeout="30" interval="10" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="start" timeout="60s" />
+<action name="stop" timeout="40s" />
+<action name="migrate_from" timeout="120s" />
+<action name="migrate_to" timeout="120s" />
+<action name="monitor" depth="0" timeout="30s" interval="10s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/Xinetd
+++ b/heartbeat/Xinetd
@@ -66,10 +66,10 @@ The name of the service managed by xinetd.
 <action name="start" timeout="20s" />
 <action name="stop" timeout="20s" />
 <action name="restart" timeout="20s" />
-<action name="status" depth="0" timeout="10" interval="10" />
-<action name="monitor" depth="0" timeout="10" interval="10" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="status" depth="0" timeout="10s" interval="10s" />
+<action name="monitor" depth="0" timeout="10s" interval="10s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/anything
+++ b/heartbeat/anything
@@ -296,9 +296,9 @@ before sending kill -SIGKILL. Defaults to 2/3 of the stop operation timeout.
 <actions>
 <action name="start"   timeout="20s" />
 <action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10" />
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="5" />
+<action name="monitor" depth="0"  timeout="20s" interval="10s" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -595,9 +595,9 @@ that doesn't work set this to true to enforce IPv6.
 <action name="start"   timeout="40s" />
 <action name="stop"    timeout="60s" />
 <action name="status"  timeout="30s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10" />
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="5" />
+<action name="monitor" depth="0"  timeout="20s" interval="10s" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/asterisk
+++ b/heartbeat/asterisk
@@ -178,12 +178,12 @@ If unset, the agent does no SIP URI monitoring.
 </parameters>
 
 <actions>
-<action name="start" timeout="20" />
-<action name="stop" timeout="20" />
-<action name="status" timeout="20" />
-<action name="monitor" timeout="30" interval="20" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="20s" />
+<action name="stop" timeout="20s" />
+<action name="status" timeout="20s" />
+<action name="monitor" timeout="30s" interval="20s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -119,11 +119,11 @@ Enable enhanced monitoring using AWS API calls to check route table entry
 </parameters>
 
 <actions>
-<action name="start" timeout="180" />
-<action name="stop" timeout="180" />
-<action name="monitor" depth="0" timeout="30" interval="60" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="180s" />
+<action name="stop" timeout="180s" />
+<action name="monitor" depth="0" timeout="30s" interval="60s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/aws-vpc-route53
+++ b/heartbeat/aws-vpc-route53
@@ -142,11 +142,11 @@ output has to be "text".
 </parameter>
 </parameters>
 <actions>
-<action name="start" timeout="180" />
-<action name="stop" timeout="180" />
-<action name="monitor" depth="0" timeout="180" interval="300" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="180s" />
+<action name="stop" timeout="180s" />
+<action name="monitor" depth="0" timeout="180s" interval="300s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/awseip
+++ b/heartbeat/awseip
@@ -111,15 +111,15 @@ a short delay between API calls, to avoid sending API too quick
 </parameters>
 
 <actions>
-<action name="start"        timeout="10" />
-<action name="stop"         timeout="10" />
-<action name="monitor"      timeout="10" interval="20" depth="0" />
-<action name="reload"       timeout="10" />
-<action name="migrate_to"   timeout="10" />
-<action name="migrate_from" timeout="10" />
-<action name="meta-data"    timeout="5" />
-<action name="validate"     timeout="10" />
-<action name="validate-all" timeout="10" />
+<action name="start"        timeout="10s" />
+<action name="stop"         timeout="10s" />
+<action name="monitor"      timeout="10s" interval="20s" depth="0" />
+<action name="reload"       timeout="10s" />
+<action name="migrate_to"   timeout="10s" />
+<action name="migrate_from" timeout="10s" />
+<action name="meta-data"    timeout="5s" />
+<action name="validate"     timeout="10s" />
+<action name="validate-all" timeout="10s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/awsvip
+++ b/heartbeat/awsvip
@@ -95,15 +95,15 @@ a short delay between API calls, to avoid sending API too quick
 </parameters>
 
 <actions>
-<action name="start"        timeout="10" />
-<action name="stop"         timeout="10" />
-<action name="monitor"      timeout="10" interval="20" depth="0" />
-<action name="reload"       timeout="10" />
-<action name="migrate_to"   timeout="10" />
-<action name="migrate_from" timeout="10" />
-<action name="meta-data"    timeout="5" />
-<action name="validate"     timeout="10" />
-<action name="validate-all" timeout="10" />
+<action name="start"        timeout="10s" />
+<action name="stop"         timeout="10s" />
+<action name="monitor"      timeout="10s" interval="20s" depth="0" />
+<action name="reload"       timeout="10s" />
+<action name="migrate_to"   timeout="10s" />
+<action name="migrate_from" timeout="10s" />
+<action name="meta-data"    timeout="5s" />
+<action name="validate"     timeout="10s" />
+<action name="validate-all" timeout="10s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/azure-lb
+++ b/heartbeat/azure-lb
@@ -73,9 +73,9 @@ Port to listen to.
 <actions>
 <action name="start"   timeout="20s" />
 <action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10" />
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="5" />
+<action name="monitor" depth="0"  timeout="20s" interval="10s" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/clvm
+++ b/heartbeat/clvm
@@ -75,11 +75,11 @@ is set to.
 </parameters>
 
 <actions>
-<action name="start"        timeout="90" />
-<action name="stop"         timeout="90" />
-<action name="monitor"      timeout="90" interval="30" depth="0" />
-<action name="meta-data"    timeout="10" />
-<action name="validate-all"   timeout="20" />
+<action name="start"        timeout="90s" />
+<action name="stop"         timeout="90s" />
+<action name="monitor"      timeout="90s" interval="30s" depth="0" />
+<action name="meta-data"    timeout="10s" />
+<action name="validate-all"   timeout="20s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/conntrackd
+++ b/heartbeat/conntrackd
@@ -76,15 +76,15 @@ For example "/packages/conntrackd-0.9.14/etc/conntrackd/conntrackd.conf"</longde
 </parameters>
 
 <actions>
-<action name="start"   timeout="30" />
-<action name="promote"	 timeout="30" />
-<action name="demote"	timeout="30" />
-<action name="notify"	timeout="30" />
-<action name="stop"    timeout="30" />
-<action name="monitor" timeout="20" interval="20" role="Slave" />
-<action name="monitor" timeout="20" interval="10" role="Master" />
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="30" />
+<action name="start"   timeout="30s" />
+<action name="promote"	 timeout="30s" />
+<action name="demote"	timeout="30s" />
+<action name="notify"	timeout="30s" />
+<action name="stop"    timeout="30s" />
+<action name="monitor" timeout="20s" interval="20s" role="Slave" />
+<action name="monitor" timeout="20s" interval="10s" role="Master" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="30s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/db2
+++ b/heartbeat/db2
@@ -109,15 +109,15 @@ The number of the partion (DBPARTITIONNUM) to be managed.
 </parameters>
 
 <actions>
-<action name="start" timeout="120"/>
-<action name="stop" timeout="120"/>
-<action name="promote" timeout="120"/>
-<action name="demote" timeout="120"/>
-<action name="notify" timeout="10"/>
-<action name="monitor" depth="0" timeout="60" interval="20"/>
-<action name="monitor" depth="0" timeout="60" role="Master" interval="22"/>
-<action name="validate-all" timeout="5"/>
-<action name="meta-data" timeout="5"/>
+<action name="start" timeout="120s"/>
+<action name="stop" timeout="120s"/>
+<action name="promote" timeout="120s"/>
+<action name="demote" timeout="120s"/>
+<action name="notify" timeout="10s"/>
+<action name="monitor" depth="0" timeout="60s" interval="20s"/>
+<action name="monitor" depth="0" timeout="60s" role="Master" interval="22s"/>
+<action name="validate-all" timeout="5s"/>
+<action name="meta-data" timeout="5s"/>
 </actions>
 </resource-agent>
 END

--- a/heartbeat/dhcpd
+++ b/heartbeat/dhcpd
@@ -178,12 +178,12 @@ Manage an ISC DHCP server service in a chroot environment.
     </parameter>
   </parameters>
   <actions>
-    <action name="start"        timeout="20" />
-    <action name="stop"         timeout="20" />
-    <action name="restart"         timeout="20" />
-    <action name="monitor"      timeout="20" interval="10" depth="0" />
-    <action name="meta-data"    timeout="5" />
-    <action name="validate-all"   timeout="20" />
+    <action name="start"        timeout="20s" />
+    <action name="stop"         timeout="20s" />
+    <action name="restart"         timeout="20s" />
+    <action name="monitor"      timeout="20s" interval="10s" depth="0" />
+    <action name="meta-data"    timeout="5s" />
+    <action name="validate-all"   timeout="20s" />
   </actions>
 </resource-agent>
 EOF

--- a/heartbeat/dnsupdate
+++ b/heartbeat/dnsupdate
@@ -117,12 +117,12 @@ delete all previous records.
 </parameters>
 
 <actions>
-<action name="start" timeout="30" />
-<action name="stop" timeout="30" />
-<action name="status" depth="0" timeout="30" interval="10" />
-<action name="monitor" depth="0" timeout="30" interval="10" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="start" timeout="30s" />
+<action name="stop" timeout="30s" />
+<action name="status" depth="0" timeout="30s" interval="10s" />
+<action name="monitor" depth="0" timeout="30s" interval="10s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/docker
+++ b/heartbeat/docker
@@ -179,11 +179,11 @@ container to be considered healthy.
 </parameters>
 
 <actions>
-<action name="start"        timeout="90" />
-<action name="stop"         timeout="90" />
-<action name="monitor"      timeout="30" interval="30" depth="0" />
-<action name="meta-data"    timeout="5" />
-<action name="validate-all"   timeout="30" />
+<action name="start"        timeout="90s" />
+<action name="stop"         timeout="90s" />
+<action name="monitor"      timeout="30s" interval="30s" depth="0" />
+<action name="meta-data"    timeout="5s" />
+<action name="validate-all"   timeout="30s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/eDir88
+++ b/heartbeat/eDir88
@@ -138,11 +138,11 @@ Value for the DHOST_OPTIONS java environment variable. If unset, original values
 </parameters>
 
 <actions>
-<action name="start" timeout="600" />
-<action name="stop" timeout="600" />
-<action name="monitor" timeout="60" interval="30" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="start" timeout="600s" />
+<action name="stop" timeout="600s" />
+<action name="monitor" timeout="60s" interval="30s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
 </actions>
 </resource-agent>
 EOFB

--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -152,11 +152,11 @@ Location of the rmtab backup, relative to directory.
 </parameters>
 
 <actions>
-<action name="start"   timeout="40" />
-<action name="stop"    timeout="120" />
-<action name="monitor" depth="0"  timeout="20" interval="10" />
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="30" />
+<action name="start"   timeout="40s" />
+<action name="stop"    timeout="120s" />
+<action name="monitor" depth="0"  timeout="20s" interval="10s" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="30s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/fio
+++ b/heartbeat/fio
@@ -60,11 +60,11 @@ descriptions to run.
 </parameters>
 
 <actions>
-<action name="start"        timeout="60" />
-<action name="stop"         timeout="60" />
-<action name="monitor"      timeout="60" interval="10" />
-<action name="meta-data"    timeout="5" />
-<action name="validate-all"   timeout="20" />
+<action name="start"        timeout="60s" />
+<action name="stop"         timeout="60s" />
+<action name="monitor"      timeout="60s" interval="10s" />
+<action name="meta-data"    timeout="5s" />
+<action name="validate-all"   timeout="20s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -250,16 +250,16 @@ Cluster check user password
 </parameters>
 
 <actions>
-<action name="start" timeout="120" />
-<action name="stop" timeout="120" />
-<action name="status" timeout="60" />
-<action name="monitor" depth="0" timeout="30" interval="20" />
-<action name="monitor" role="Master" depth="0" timeout="30" interval="10" />
-<action name="monitor" role="Slave" depth="0" timeout="30" interval="30" />
-<action name="promote" timeout="300" />
-<action name="demote" timeout="120" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="120s" />
+<action name="stop" timeout="120s" />
+<action name="status" timeout="60s" />
+<action name="monitor" depth="0" timeout="30s" interval="20s" />
+<action name="monitor" role="Master" depth="0" timeout="30s" interval="10s" />
+<action name="monitor" role="Slave" depth="0" timeout="30s" interval="30s" />
+<action name="promote" timeout="300s" />
+<action name="demote" timeout="120s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/garbd
+++ b/heartbeat/garbd
@@ -174,11 +174,11 @@ The group name of the Galera cluster to connect to.
 </parameters>
 
 <actions>
-<action name="start" timeout="20" />
-<action name="stop" timeout="20" />
-<action name="monitor" depth="0" timeout="20" interval="20" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="20s" />
+<action name="stop" timeout="20s" />
+<action name="monitor" depth="0" timeout="20s" interval="20s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/iSCSILogicalUnit
+++ b/heartbeat/iSCSILogicalUnit
@@ -269,12 +269,12 @@ in /sys/kernel/config/target/core/.
 </parameters>
 
 <actions>
-<action name="start"         timeout="10" />
-<action name="stop"          timeout="10" />
-<action name="status"        timeout="10" interval="10" depth="0" />
-<action name="monitor"       timeout="10" interval="10" depth="0" />
-<action name="meta-data"     timeout="5" />
-<action name="validate-all"  timeout="10" />
+<action name="start"         timeout="10s" />
+<action name="stop"          timeout="10s" />
+<action name="status"        timeout="10s" interval="10s" depth="0" />
+<action name="monitor"       timeout="10s" interval="10s" depth="0" />
+<action name="meta-data"     timeout="5s" />
+<action name="validate-all"  timeout="10s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/iSCSITarget
+++ b/heartbeat/iSCSITarget
@@ -162,12 +162,12 @@ dependent. Neither the name nor the value may contain whitespace.
 </parameters>
 
 <actions>
-<action name="start"		timeout="10" />
-<action name="stop"		 timeout="10" />
-<action name="status"	   timeout="10" interval="10" depth="0" />
-<action name="monitor"	  timeout="10" interval="10" depth="0" />
-<action name="meta-data"	timeout="5" />
-<action name="validate-all"   timeout="10" />
+<action name="start"		timeout="10s" />
+<action name="stop"		 timeout="10s" />
+<action name="status"	   timeout="10s" interval="10s" depth="0" />
+<action name="monitor"	  timeout="10s" interval="10s" depth="0" />
+<action name="meta-data"	timeout="5s" />
+<action name="validate-all"   timeout="10s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/ids
+++ b/heartbeat/ids
@@ -192,14 +192,14 @@ SQL test query to use for monitoring, defaults to 'SELECT COUNT(*) FROM systable
 
 
 <actions>
-<action name="start" timeout="120" />
-<action name="stop" timeout="120" />
-<action name="status" timeout="60" />
-<action name="monitor" depth="0" timeout="30" interval="10" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
-<action name="methods" timeout="5" />
-<action name="usage" timeout="5" />
+<action name="start" timeout="120s" />
+<action name="stop" timeout="120s" />
+<action name="status" timeout="60s" />
+<action name="monitor" depth="0" timeout="30s" interval="10s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
+<action name="methods" timeout="5s" />
+<action name="usage" timeout="5s" />
 </actions>
 
 

--- a/heartbeat/ipsec
+++ b/heartbeat/ipsec
@@ -78,11 +78,11 @@ The directory where the IPSEC tunnel configurations can be found.
 </parameters>
 
 <actions>
-<action name="start"        timeout="20" />
-<action name="stop"         timeout="20" />
-<action name="monitor"      timeout="20" interval="10" depth="0" />
-<action name="reload"       timeout="20" />
-<action name="meta-data"    timeout="5" />
+<action name="start"        timeout="20s" />
+<action name="stop"         timeout="20s" />
+<action name="monitor"      timeout="20s" interval="10s" depth="0" />
+<action name="reload"       timeout="20s" />
+<action name="meta-data"    timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/iscsi
+++ b/heartbeat/iscsi
@@ -143,13 +143,13 @@ attribute appropriately.
 </parameters>
 
 <actions>
-<action name="start" timeout="120" />
-<action name="stop" timeout="120" />
-<action name="status" timeout="30" />
-<action name="monitor" depth="0" timeout="30" interval="120" />
-<action name="validate-all" timeout="5" />
-<action name="methods" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="120s" />
+<action name="stop" timeout="120s" />
+<action name="status" timeout="30s" />
+<action name="monitor" depth="0" timeout="30s" interval="120s" />
+<action name="validate-all" timeout="5s" />
+<action name="methods" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 EOF

--- a/heartbeat/jboss
+++ b/heartbeat/jboss
@@ -502,7 +502,7 @@ Rotate console log suffix.
 <action name="status" timeout="30s" />
 <action name="monitor" depth="0" timeout="30s" interval="10s" />
 <action name="meta-data" timeout="5s" />
-<action name="validate-all"  timeout="5"/>
+<action name="validate-all"  timeout="5s"/>
 </actions>
 </resource-agent>
 END

--- a/heartbeat/jira
+++ b/heartbeat/jira
@@ -231,12 +231,12 @@ OCF Resource Agent to manage JIRA software
 
   </parameters>
   <actions>
-    <action name="start"        timeout="300" />
-    <action name="stop"         timeout="300" />
-    <action name="monitor"      timeout="30"
-                                interval="10" depth="0" />
-    <action name="meta-data"    timeout="5" />
-    <action name="validate-all"   timeout="20" />
+    <action name="start"        timeout="300s" />
+    <action name="stop"         timeout="300s" />
+    <action name="monitor"      timeout="30s"
+                                interval="10s" depth="0" />
+    <action name="meta-data"    timeout="5s" />
+    <action name="validate-all"   timeout="20s" />
   </actions>
 </resource-agent>
 EOF

--- a/heartbeat/kamailio
+++ b/heartbeat/kamailio
@@ -286,13 +286,13 @@ Parameters for a third Kamailio instance:
 </parameters>
 
  <actions>
-  <action name="start" timeout="60" />
-  <action name="stop" timeout="30" />
-  <action name="status" timeout="30" interval="10" />
-  <action name="monitor" timeout="30" interval="10" />
-  <action name="meta-data" timeout="5" />
-  <action name="validate-all" timeout="5" />
-  <action name="notify" timeout="5" />
+  <action name="start" timeout="60s" />
+  <action name="stop" timeout="30s" />
+  <action name="status" timeout="30s" interval="10s" />
+  <action name="monitor" timeout="30s" interval="10s" />
+  <action name="meta-data" timeout="5s" />
+  <action name="validate-all" timeout="5s" />
+  <action name="notify" timeout="5s" />
  </actions>
 </resource-agent>
 END

--- a/heartbeat/lvmlockd
+++ b/heartbeat/lvmlockd
@@ -87,11 +87,11 @@ Adopt locks from a previous instance of lvmlockd.
 </parameters>
 
 <actions>
-<action name="start"		timeout="90" />
-<action name="stop"		timeout="90" />
-<action name="monitor"		timeout="90" interval="30" depth="0" />
-<action name="meta-data"	timeout="10" />
-<action name="validate-all"	timeout="20" />
+<action name="start"		timeout="90s" />
+<action name="stop"		timeout="90s" />
+<action name="monitor"		timeout="90s" interval="30s" depth="0" />
+<action name="meta-data"	timeout="10s" />
+<action name="validate-all"	timeout="20s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/lxc
+++ b/heartbeat/lxc
@@ -95,11 +95,11 @@ The default value is set to 'false', change to 'true' to activate this option</l
 </parameters>
 
 <actions>
-<action name="start"        timeout="10" />
-<action name="stop"         timeout="30" />
-<action name="monitor"      timeout="20" interval="60" depth="0"/>
-<action name="validate-all" timeout="20" />
-<action name="meta-data"    timeout="5" />
+<action name="start"        timeout="10s" />
+<action name="stop"         timeout="30s" />
+<action name="monitor"      timeout="20s" interval="60s" depth="0"/>
+<action name="validate-all" timeout="20s" />
+<action name="meta-data"    timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/lxd-info
+++ b/heartbeat/lxd-info
@@ -67,7 +67,7 @@ Sample output:
 <action name="start"   timeout="20s" />
 <action name="stop"    timeout="20s" />
 <action name="monitor" timeout="20s" interval="60s"/>
-<action name="meta-data"  timeout="5" />
+<action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="20s" />
 </actions>
 </resource-agent>

--- a/heartbeat/machine-info
+++ b/heartbeat/machine-info
@@ -68,7 +68,7 @@ Sample output:
 <action name="start"   timeout="20s" />
 <action name="stop"    timeout="20s" />
 <action name="monitor" timeout="20s" interval="60s"/>
-<action name="meta-data"  timeout="5" />
+<action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="20s" />
 </actions>
 </resource-agent>

--- a/heartbeat/minio
+++ b/heartbeat/minio
@@ -99,11 +99,11 @@ For example, "/etc/minio"
 </parameters>
 
 <actions>
-<action name="start"   timeout="20" />
-<action name="stop"    timeout="20" />
-<action name="monitor" depth="0"  timeout="20" interval="60" />
-<action name="validate-all"  timeout="2" />
-<action name="meta-data"  timeout="5" />
+<action name="start"   timeout="20s" />
+<action name="stop"    timeout="20s" />
+<action name="monitor" depth="0"  timeout="20s" interval="60s" />
+<action name="validate-all"  timeout="2s" />
+<action name="meta-data"  timeout="5s" />
 </actions>
 
 </resource-agent>

--- a/heartbeat/mpathpersist
+++ b/heartbeat/mpathpersist
@@ -163,15 +163,15 @@ Setting it to 0 will disable this behavior.
 </parameters>
 
 <actions>
-<action name="start"   timeout="30" />
-<action name="promote"   timeout="30" />
-<action name="demote"   timeout="30" />
-<action name="notify"   timeout="30" />
-<action name="stop"    timeout="30" />
-<action name="monitor" depth="0"  timeout="20" interval="29" role="Slave" />
-<action name="monitor" depth="0"  timeout="20" interval="60" role="Master" />
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="30" />
+<action name="start"   timeout="30s" />
+<action name="promote"   timeout="30s" />
+<action name="demote"   timeout="30s" />
+<action name="notify"   timeout="30s" />
+<action name="stop"    timeout="30s" />
+<action name="monitor" depth="0"  timeout="20s" interval="29s" role="Slave" />
+<action name="monitor" depth="0"  timeout="20s" interval="60s" role="Master" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="30s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -284,17 +284,17 @@ whether a node is usable for clients to read from.</shortdesc>
 </parameters>
 
 <actions>
-<action name="start" timeout="120" />
-<action name="stop" timeout="120" />
-<action name="status" timeout="60" />
-<action name="monitor" depth="0" timeout="30" interval="20" />
-<action name="monitor" role="Master" depth="0" timeout="30" interval="10" />
-<action name="monitor" role="Slave" depth="0" timeout="30" interval="30" />
-<action name="promote" timeout="120" />
-<action name="demote" timeout="120" />
-<action name="notify" timeout="90" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="120s" />
+<action name="stop" timeout="120s" />
+<action name="status" timeout="60s" />
+<action name="monitor" depth="0" timeout="30s" interval="20s" />
+<action name="monitor" role="Master" depth="0" timeout="30s" interval="10s" />
+<action name="monitor" role="Slave" depth="0" timeout="30s" interval="30s" />
+<action name="promote" timeout="120s" />
+<action name="demote" timeout="120s" />
+<action name="notify" timeout="90s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/nagios
+++ b/heartbeat/nagios
@@ -111,12 +111,12 @@ nagios_meta_data() {
 </parameters>
 
 <actions>
-<action name="start" timeout="20" />
-<action name="stop" timeout="20" />
-<action name="status" timeout="20" />
-<action name="monitor" depth="0" timeout="20" interval="10" start-delay="10" />
-<action name="validate-all" timeout="20" />
-<action name="meta-data" timeout="20" />
+<action name="start" timeout="20s" />
+<action name="stop" timeout="20s" />
+<action name="status" timeout="20s" />
+<action name="monitor" depth="0" timeout="20s" interval="10s" start-delay="10" />
+<action name="validate-all" timeout="20s" />
+<action name="meta-data" timeout="20s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/named
+++ b/heartbeat/named
@@ -180,14 +180,14 @@ IP Address where named listens.
 </parameters>
 
 <actions>
-<action name="start" timeout="60" />
-<action name="stop" timeout="60" />
-<action name="reload" timeout="60" />
-<action name="status" timeout="10" />
-<action name="monitor" depth="0" timeout="30" interval="30"/>
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
-<action name="methods" timeout="5" />
+<action name="start" timeout="60s" />
+<action name="stop" timeout="60s" />
+<action name="reload" timeout="60s" />
+<action name="status" timeout="10s" />
+<action name="monitor" depth="0" timeout="30s" interval="30s"/>
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
+<action name="methods" timeout="5s" />
 </actions>
 </resource-agent>
 

--- a/heartbeat/nfsnotify
+++ b/heartbeat/nfsnotify
@@ -86,12 +86,12 @@ arguments.
 </parameters>
 
 <actions>
-<action name="start"        timeout="90" />
-<action name="stop"         timeout="90" />
-<action name="monitor"      timeout="90" interval="30" depth="0" />
-<action name="reload"       timeout="90" />
-<action name="meta-data"    timeout="10" />
-<action name="validate-all"   timeout="20" />
+<action name="start"        timeout="90s" />
+<action name="stop"         timeout="90s" />
+<action name="monitor"      timeout="90s" interval="30s" depth="0" />
+<action name="reload"       timeout="90s" />
+<action name="meta-data"    timeout="10s" />
+<action name="validate-all"   timeout="20s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -140,11 +140,11 @@ is_redhat_based && nfsserver_redhat_meta_data
 </parameters>
 
 <actions>
-<action name="start"   timeout="40" />
+<action name="start"   timeout="40s" />
 <action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10" />
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="30" />
+<action name="monitor" depth="0"  timeout="20s" interval="10s" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="30s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/nginx
+++ b/heartbeat/nginx
@@ -793,8 +793,8 @@ Extra options to apply when starting nginx.
 <action name="monitor" timeout="30s" depth="10" interval="30s" />
 <action name="monitor" timeout="45s" depth="20" />
 <action name="monitor" timeout="60s" depth="30" />
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="5" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/oraasm
+++ b/heartbeat/oraasm
@@ -70,12 +70,12 @@ If not specified, then the Disk Group along with its home should be listed in /e
 </parameters>
 
 <actions>
-<action name="start" timeout="60" />
-<action name="stop" timeout="60" />
-<action name="status" timeout="30" />
-<action name="monitor" depth="0" timeout="30" interval="10" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="60s" />
+<action name="stop" timeout="60s" />
+<action name="status" timeout="30s" />
+<action name="monitor" depth="0" timeout="30s" interval="10s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/oracle
+++ b/heartbeat/oracle
@@ -218,13 +218,13 @@ Oracle instance we are willing to listen.
 </parameters>
 
 <actions>
-<action name="start" timeout="120" />
-<action name="stop" timeout="120" />
-<action name="status" timeout="5" />
-<action name="monitor" depth="0" timeout="30" interval="120" />
-<action name="validate-all" timeout="5" />
-<action name="methods" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="120s" />
+<action name="stop" timeout="120s" />
+<action name="status" timeout="5s" />
+<action name="monitor" depth="0" timeout="30s" interval="120s" />
+<action name="validate-all" timeout="5s" />
+<action name="methods" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/oralsnr
+++ b/heartbeat/oralsnr
@@ -119,13 +119,13 @@ Defaults to LISTENER.
 </parameters>
 
 <actions>
-<action name="start" timeout="120" />
-<action name="stop" timeout="120" />
-<action name="status" timeout="60" />
-<action name="monitor" depth="0" timeout="30" interval="10" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
-<action name="methods" timeout="5" />
+<action name="start" timeout="120s" />
+<action name="stop" timeout="120s" />
+<action name="status" timeout="60s" />
+<action name="monitor" depth="0" timeout="30s" interval="10s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
+<action name="methods" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/pgagent
+++ b/heartbeat/pgagent
@@ -101,11 +101,11 @@ meta_data() {
 </parameter>
 </parameters>
 <actions>
-<action name="start" timeout="5" />
-<action name="stop" timeout="5" />
-<action name="monitor" timeout="20" interval="10" depth="0" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="start" timeout="5s" />
+<action name="stop" timeout="5s" />
+<action name="monitor" timeout="20s" interval="10s" depth="0" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -452,17 +452,17 @@ wal receiver is not running in the master and the attribute shows status as
 </parameters>
 
 <actions>
-<action name="start" timeout="120" />
-<action name="stop" timeout="120" />
-<action name="status" timeout="60" />
-<action name="monitor" depth="0" timeout="30" interval="30"/>
-<action name="monitor" depth="0" timeout="30" interval="29" role="Master" />
-<action name="promote" timeout="120" />
-<action name="demote" timeout="120" />
-<action name="notify"   timeout="90" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
-<action name="methods" timeout="5" />
+<action name="start" timeout="120s" />
+<action name="stop" timeout="120s" />
+<action name="status" timeout="60s" />
+<action name="monitor" depth="0" timeout="30s" interval="30s"/>
+<action name="monitor" depth="0" timeout="30s" interval="29s" role="Master" />
+<action name="promote" timeout="120s" />
+<action name="demote" timeout="120s" />
+<action name="notify"   timeout="90s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
+<action name="methods" timeout="5s" />
 </actions>
 </resource-agent>
 EOF

--- a/heartbeat/pingd
+++ b/heartbeat/pingd
@@ -130,8 +130,8 @@ If set to true, suppresses the deprecation warning for this agent.
 <actions>
 <action name="start"   timeout="20s" />
 <action name="stop"    timeout="20s" />
-<action name="monitor" depth="0"  timeout="20s" interval="10" />
-<action name="meta-data"  timeout="5" />
+<action name="monitor" depth="0"  timeout="20s" interval="10s" />
+<action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="20s" />
 </actions>
 </resource-agent>

--- a/heartbeat/portblock
+++ b/heartbeat/portblock
@@ -210,12 +210,12 @@ file name as a single argument. For csync2, set it to "csync2 -xv".
 </parameters>
 
 <actions>
-<action name="start" timeout="20" />
-<action name="stop" timeout="20" />
-<action name="status" depth="0" timeout="10" interval="10" />
-<action name="monitor" depth="0" timeout="10" interval="10" />
-<action name="meta-data" timeout="5" />
-<action name="validate-all" timeout="5" />
+<action name="start" timeout="20s" />
+<action name="stop" timeout="20s" />
+<action name="status" depth="0" timeout="10s" interval="10s" />
+<action name="monitor" depth="0" timeout="10s" interval="10s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/pound
+++ b/heartbeat/pound
@@ -125,12 +125,12 @@ a time. Helps to fix the 'Too many open files' error message.
 </parameters>
 
 <actions>
-<action name="start"        timeout="20" />
-<action name="stop"         timeout="20" />
-<action name="monitor"      timeout="20" interval="10" depth="0" />
-<action name="status"       timeout="20" />
-<action name="meta-data"    timeout="5" />
-<action name="validate-all"   timeout="20" />
+<action name="start"        timeout="20s" />
+<action name="stop"         timeout="20s" />
+<action name="monitor"      timeout="20s" interval="10s" depth="0" />
+<action name="status"       timeout="20s" />
+<action name="meta-data"    timeout="5s" />
+<action name="validate-all"   timeout="20s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -74,11 +74,11 @@ Policy string to pass to 'rabbitmqctl set_policy' right after bootstrapping the 
 </parameters>
 
 <actions>
-<action name="start"        timeout="100" />
-<action name="stop"         timeout="90" />
-<action name="monitor"      timeout="40" interval="10" depth="0" />
-<action name="meta-data"    timeout="10" />
-<action name="validate-all"   timeout="20" />
+<action name="start"        timeout="100s" />
+<action name="stop"         timeout="90s" />
+<action name="monitor"      timeout="40s" interval="10s" depth="0" />
+<action name="meta-data"    timeout="10s" />
+<action name="validate-all"   timeout="20s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/redis
+++ b/heartbeat/redis
@@ -169,17 +169,17 @@ is in use.
 </parameters>
 
 <actions>
-<action name="start" timeout="120" />
-<action name="stop" timeout="120" />
-<action name="status" timeout="60" />
-<action name="monitor" depth="0" timeout="60" interval="45" />
-<action name="monitor" role="Master" depth="0" timeout="60" interval="20" />
-<action name="monitor" role="Slave" depth="0" timeout="60" interval="60" />
-<action name="promote" timeout="120" />
-<action name="demote" timeout="120" />
-<action name="notify" timeout="90" />
-<action name="validate-all" timeout="5" />
-<action name="meta-data" timeout="5" />
+<action name="start" timeout="120s" />
+<action name="stop" timeout="120s" />
+<action name="status" timeout="60s" />
+<action name="monitor" depth="0" timeout="60s" interval="45s" />
+<action name="monitor" role="Master" depth="0" timeout="60s" interval="20s" />
+<action name="monitor" role="Slave" depth="0" timeout="60s" interval="60s" />
+<action name="promote" timeout="120s" />
+<action name="demote" timeout="120s" />
+<action name="notify" timeout="90s" />
+<action name="validate-all" timeout="5s" />
+<action name="meta-data" timeout="5s" />
 </actions>
 </resource-agent>
 EOI

--- a/heartbeat/rkt
+++ b/heartbeat/rkt
@@ -143,11 +143,11 @@ shutdown
 </parameters>
 
 <actions>
-<action name="start"        timeout="90" />
-<action name="stop"         timeout="90" />
-<action name="monitor"      timeout="30" interval="30" depth="0" />
-<action name="meta-data"    timeout="5" />
-<action name="validate-all"   timeout="30" />
+<action name="start"        timeout="90s" />
+<action name="stop"         timeout="90s" />
+<action name="monitor"      timeout="30s" interval="30s" depth="0" />
+<action name="meta-data"    timeout="5s" />
+<action name="validate-all"   timeout="30s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/rsyslog
+++ b/heartbeat/rsyslog
@@ -109,7 +109,7 @@ options is used. Don't use option '-F'. It causes a stuck of a start action.
 <action name="status" timeout="20s" />
 <action name="monitor" depth="0" timeout="20s" interval="20s" />
 <action name="meta-data" timeout="5s" />
-<action name="validate-all"  timeout="5"/>
+<action name="validate-all"  timeout="5s"/>
 </actions>
 </resource-agent>
 END

--- a/heartbeat/scsi2reservation
+++ b/heartbeat/scsi2reservation
@@ -66,11 +66,11 @@ Times to re-try before giving up.
 </parameters>
 
 <actions>
-<action name="start"   timeout="300" />
-<action name="stop"    timeout="100" />
-<action name="monitor" depth="0"  timeout="20" interval="20" />
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="30" />
+<action name="start"   timeout="300s" />
+<action name="stop"    timeout="100s" />
+<action name="monitor" depth="0"  timeout="20s" interval="20s" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="30s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/sg_persist
+++ b/heartbeat/sg_persist
@@ -154,15 +154,15 @@ Setting it to 0 will disable this behavior.
 </parameters>
 
 <actions>
-<action name="start"   timeout="30" />
-<action name="promote"   timeout="30" />
-<action name="demote"   timeout="30" />
-<action name="notify"   timeout="30" />
-<action name="stop"    timeout="30" />
-<action name="monitor" depth="0"  timeout="20" interval="29" role="Slave" />
-<action name="monitor" depth="0"  timeout="20" interval="60" role="Master" />
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="30" />
+<action name="start"   timeout="30s" />
+<action name="promote"   timeout="30s" />
+<action name="demote"   timeout="30s" />
+<action name="notify"   timeout="30s" />
+<action name="stop"    timeout="30s" />
+<action name="monitor" depth="0"  timeout="20s" interval="29s" role="Slave" />
+<action name="monitor" depth="0"  timeout="20s" interval="60s" role="Master" />
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="30s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/symlink
+++ b/heartbeat/symlink
@@ -77,11 +77,11 @@ refuse to create a symlink if it clashes with an existing file.
 </parameter>
 </parameters>
 <actions>
-<action name="start"   timeout="15" />
-<action name="stop"    timeout="15" />
-<action name="monitor" depth="0"  timeout="15" interval="60"/>
-<action name="meta-data"  timeout="5" />
-<action name="validate-all"  timeout="10" />
+<action name="start"   timeout="15s" />
+<action name="stop"    timeout="15s" />
+<action name="monitor" depth="0"  timeout="15s" interval="60s"/>
+<action name="meta-data"  timeout="5s" />
+<action name="validate-all"  timeout="10s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/syslog-ng
+++ b/heartbeat/syslog-ng
@@ -122,7 +122,7 @@ The default value is 10.
 <action name="status" timeout="60s" />
 <action name="monitor" depth="0" timeout="60s" interval="60s" />
 <action name="meta-data" timeout="5s" />
-<action name="validate-all"  timeout="5"/>
+<action name="validate-all"  timeout="5s"/>
 </actions>
 </resource-agent>
 END

--- a/heartbeat/tomcat
+++ b/heartbeat/tomcat
@@ -546,10 +546,10 @@ Logging_manager of tomcat
 <actions>
 <action name="start" timeout="60s" />
 <action name="stop" timeout="120s" />
-<action name="status" timeout="60" />
+<action name="status" timeout="60s" />
 <action name="monitor" depth="0" timeout="30s" interval="10s" />
 <action name="meta-data" timeout="5s" />
-<action name="validate-all"  timeout="5"/>
+<action name="validate-all"  timeout="5s"/>
 </actions>
 </resource-agent>
 END

--- a/heartbeat/varnish
+++ b/heartbeat/varnish
@@ -268,12 +268,12 @@ Path to a file containing a secret used for authorizing access to the management
 </parameters>
 
 <actions>
-<action name="start"        timeout="20" />
-<action name="stop"         timeout="20" />
-<action name="monitor"      timeout="20" interval="10" depth="0" />
-<action name="status"       timeout="20" />
-<action name="meta-data"    timeout="5" />
-<action name="validate-all"   timeout="20" />
+<action name="start"        timeout="20s" />
+<action name="stop"         timeout="20s" />
+<action name="monitor"      timeout="20s" interval="10s" depth="0" />
+<action name="status"       timeout="20s" />
+<action name="meta-data"    timeout="5s" />
+<action name="validate-all"   timeout="20s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/vmware
+++ b/heartbeat/vmware
@@ -337,10 +337,10 @@ vmware-vim-cmd executable path
 </parameters>
 
 <actions>
-<action name="start"        timeout="600" />
-<action name="stop"         timeout="600" />
-<action name="monitor"      timeout="30" interval="300" depth="0"/>
-<action name="meta-data"    timeout="5" />
+<action name="start"        timeout="600s" />
+<action name="stop"         timeout="600s" />
+<action name="monitor"      timeout="30s" interval="300s" depth="0"/>
+<action name="meta-data"    timeout="5s" />
 </actions>
 </resource-agent>
 END

--- a/heartbeat/zabbixserver
+++ b/heartbeat/zabbixserver
@@ -96,11 +96,11 @@ if not specified.
 </parameters>
 
 <actions>
-<action name="start"        timeout="20" />
-<action name="stop"         timeout="20" />
-<action name="monitor"      timeout="20" interval="10" depth="0"/>
-<action name="validate-all" timeout="20" />
-<action name="meta-data"    timeout="5" />
+<action name="start"        timeout="20s" />
+<action name="stop"         timeout="20s" />
+<action name="monitor"      timeout="20s" interval="10s" depth="0"/>
+<action name="validate-all" timeout="20s" />
+<action name="meta-data"    timeout="5s" />
 </actions>
 </resource-agent>
 END


### PR DESCRIPTION
This patch introduces consistency by adding an explicit trailing "s"
character to default time values for actions in resource agent metadata.
The default unit for time is seconds, but other units are supported.
Currently, some instances of time values include the explicit "s", while
others do not.

Adding the "s" will also be more consistent with the approach in
fence agents.