### PR TITLE
VirtualDomain: Properly migrate VMs on node shutdown (bsc#1074014)

### DIFF
--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -217,7 +217,7 @@ LVM_start() {
 
 	# systemd drop-in to stop process before storage services during
 	# shutdown/reboot
-	if ps -p 1 | grep -q systemd ; then
+	if systemd_is_running ; then
 		systemd_drop_in "99-LVM" "After" "blk-availability.service"
 	fi
 

--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -518,6 +518,14 @@ VirtualDomain_start() {
 		return $OCF_SUCCESS
 	fi
 
+	# systemd drop-in to stop domain before libvirtd terminates services
+	# during shutdown/reboot
+	if systemd_is_running ; then
+		systemd_drop_in "99-VirtualDomain-libvirt" "After" "libvirtd.service"
+		systemd_drop_in "99-VirtualDomain-machines" "Wants" "virt-guest-shutdown.target"
+		systemctl start virt-guest-shutdown.target
+	fi
+
 	snapshotimage="$OCF_RESKEY_snapshot/${DOMAIN_NAME}.state"
 	if [ -n "$OCF_RESKEY_snapshot" -a -f "$snapshotimage" ]; then
 		virsh restore $snapshotimage
@@ -824,6 +832,14 @@ VirtualDomain_migrate_to() {
 }
 
 VirtualDomain_migrate_from() {
+	# systemd drop-in to stop domain before libvirtd terminates services
+	# during shutdown/reboot
+	if systemd_is_running ; then
+		systemd_drop_in "99-VirtualDomain-libvirt" "After" "libvirtd.service"
+		systemd_drop_in "99-VirtualDomain-machines" "Wants" "virt-guest-shutdown.target"
+		systemctl start virt-guest-shutdown.target
+	fi
+
 	while ! VirtualDomain_monitor; do
 		sleep 1
 	done

--- a/heartbeat/clvm
+++ b/heartbeat/clvm
@@ -363,7 +363,7 @@ clvmd_start()
 
 	# systemd drop-in to stop process before storage services during
 	# shutdown/reboot
-	if ps -p 1 | grep -q systemd ; then
+	if systemd_is_running ; then
 		systemd_drop_in "99-clvmd" "After" "blk-availability.service"
 	fi
 

--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -668,6 +668,15 @@ dirname()
 	return 0
 }
 
+# usage: systemd_is_running
+# returns:
+#    0  PID 1 is systemd
+#    1  otherwise
+systemd_is_running()
+{
+	[ "$(cat /proc/1/comm 2>/dev/null)" = "systemd" ]
+}
+
 # usage: systemd_drop_in <name> <After|Before> <dependency.service>
 systemd_drop_in()
 {

--- a/heartbeat/tomcat
+++ b/heartbeat/tomcat
@@ -645,7 +645,7 @@ LOGGING_MANAGER="${OCF_RESKEY_logging_manager}"
 
 if [ -z "${TOMCAT_START_SCRIPT}" ]; then
 	if ocf_is_true $OCF_RESKEY_force_systemd && \
-	     ps -p 1 | grep -q systemd; then
+	     systemd_is_running; then
 		SYSTEMD=1
 	elif [ -e "$CATALINA_HOME/bin/catalina.sh" ]; then
 		TOMCAT_START_SCRIPT="$CATALINA_HOME/bin/catalina.sh"


### PR DESCRIPTION
There are three actors in sum controlling the VMs:
- pacemaker/VirtualDomain RA
  - issuing cluster resource operations,
- libvirtd
  - executing the given commands,
- systemd and systemd-machined
  - manages scope units of running VMs.

During shutdown both libvirtd and systemd-machined termination runs
concurrently with pacemaker so it cannot properly communicate with
libvirtd and terminate the machines (e.g. stopped scope unit would turn
the VM off instead of migration that's usually intended in a HA
cluster).

We add ordering dependency both on libvirtd.service and
virt-guest-shutdown.target so that pacemaker is terminated *before* the
other mechanisms would stop the VMs. Thus it can invoke appropriate
resource action on the running VM.

In order the ordering against virt-guest-shutdown.target to work its
stop job must be in the shutdown transaction thus we start the target
when activating a VM. The target is ordering-only, it doesn't activate
any other units.

Ref: #1087