### PR TITLE
redirect standard output/error of selinuxenabled

### DIFF
--- a/rgmanager/src/resources/nfsserver.sh
+++ b/rgmanager/src/resources/nfsserver.sh
@@ -17,7 +17,7 @@ export LC_ALL LANG PATH
 . $(dirname $0)/ocf-shellfuncs
 
 # SELinux information
-which restorecon &> /dev/null && selinuxenabled
+which restorecon &> /dev/null && selinuxenabled &> /dev/null
 export SELINUX_ENABLED=$?
 if [ $SELINUX_ENABLED ]; then
 	export SELINUX_LABEL="$(ls -ldZ /var/lib/nfs/statd | cut -f4 -d' ')"


### PR DESCRIPTION
I noticed servers without selinux installed get spammed in the messages log by the monitor operation output of that command:
e.g.
lrmd[]:   notice: operation_finished: nfs-server_monitor_10000:6025:stderr [ /usr/lib/ocf/resource.d/heartbeat/nfsserver: line 183: selinuxenabled: command not found ]
