### PR TITLE
doc: RA dev guide: fix unnecessary quotations in examples

### DIFF
--- a/doc/dev-guides/ra-dev-guide.asc
+++ b/doc/dev-guides/ra-dev-guide.asc
@@ -1235,7 +1235,7 @@ in this example:
 
 [source,bash]
 --------------------------------------------------------------------------
-ocf_run "frobnicate --spam=eggs" || exit $OCF_ERR_GENERIC
+ocf_run frobnicate --spam=eggs || exit $OCF_ERR_GENERIC
 --------------------------------------------------------------------------
 
 With the command specified above, the resource agent will invoke
@@ -1253,7 +1253,7 @@ is nonzero.
 
 [source,bash]
 --------------------------------------------------------------------------
-ocf_run -q "frobnicate --spam=eggs" || exit $OCF_ERR_GENERIC
+ocf_run -q frobnicate --spam=eggs || exit $OCF_ERR_GENERIC
 --------------------------------------------------------------------------
 
 Finally, if the resource agent wants to log the output of a command
@@ -1262,7 +1262,7 @@ so by adding the +-info+ or +-warn+ option to +ocf_run+:
 
 [source,bash]
 --------------------------------------------------------------------------
-ocf_run -warn "frobnicate --spam=eggs"
+ocf_run -warn frobnicate --spam=eggs
 --------------------------------------------------------------------------
 
 === Locks: +ocf_take_lock+ and +ocf_release_lock_on_exit+
@@ -1316,7 +1316,7 @@ use the +ocf_is_true+ convenience function:
 [source,bash]
 --------------------------------------------------------------------------
 if ocf_is_true $OCF_RESKEY_superfrobnicate; then
-    ocf_run "frobnicate --super"
+    ocf_run frobnicate --super
 fi
 --------------------------------------------------------------------------
 


### PR DESCRIPTION
It fails with an error if an user wrote an RA as the examples verbatim.

I believe that it's pretty obvious so I'm going to merge it now.