### PR TITLE
syslog-ng resource agent improvements and extensions

### DIFF
--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -156,6 +156,8 @@ man_MANS	       = ocf_heartbeat_AoEtarget.7 \
 			  ocf_heartbeat_mpathpersist.7 \
                           ocf_heartbeat_symlink.7 \
                           ocf_heartbeat_syslog-ng.7 \
+                          ocf_heartbeat_syslog-ng-pe-6.7 \
+                          ocf_heartbeat_syslog-ng-pe-7.7 \
                           ocf_heartbeat_tomcat.7 \
                           ocf_heartbeat_varnish.7 \
                           ocf_heartbeat_vmware.7 \

--- a/heartbeat/Makefile.am
+++ b/heartbeat/Makefile.am
@@ -155,6 +155,8 @@ ocf_SCRIPTS	     =  AoEtarget		\
 			slapd			\
 			symlink			\
 			syslog-ng		\
+			syslog-ng-pe-6		\
+			syslog-ng-pe-7		\
 			tomcat			\
 			varnish			\
 			vmware			\

--- a/heartbeat/syslog-ng
+++ b/heartbeat/syslog-ng
@@ -93,6 +93,33 @@ This parameter specifies syslog-ng's executable file.
 <content type="string" default="/sbin/syslog-ng"/>
 </parameter>
 
+<parameter name="control_file" unique="0">
+<longdesc lang="en">
+This parameter specifies the path, where syslog-ng would place its control
+socket, through which it can be controlled.
+</longdesc>
+<shortdesc lang="en">process control socket</shortdesc>
+<content type="string" default=""/>
+</parameter>
+
+<parameter name="persist_file" unique="0">
+<longdesc lang="en">
+This parameter specifies the path for syslog-ng's persist file, which holds
+persistent information about the mapping of destinations and disk buffers,
+the internal state of sources, etc.
+</longdesc>
+<shortdesc lang="en">persist file path</shortdesc>
+<content type="string" default=""/>
+</parameter>
+
+<parameter name="pidfile" unique="0">
+<longdesc lang="en">
+This parameter specifies the path where the pid file of syslog-ng resides.
+</longdesc>
+<shortdesc lang="en">pidfile path</shortdesc>
+<content type="string" default=""/>
+</parameter>
+
 <parameter name="start_opts" unique="0">
 <longdesc lang="en">
 This parameter specifies startup options for a 
@@ -151,7 +178,7 @@ start_syslog_ng()
 	# set -- $SYSLOG_NG_OPTS
 	# ocf_run "$SYSLOG_NG_EXE" -f "$SYSLOG_NG_CONF" "$@"
 	# reduce to this?
-	ocf_run "$SYSLOG_NG_EXE" -f "$CONFIGFILE" $START_OPTS
+	ocf_run "$SYSLOG_NG_EXE" -f "$CONFIGFILE" $START_OPTS $CONTROL_FILE $PERSIST_FILE $PID_FILE
 	ocf_status=$?
 	if [[ "$ocf_status" != "$OCF_SUCCESS" ]]; then
 		return $OCF_ERR_GENERIC
@@ -249,11 +276,18 @@ if ! ocf_is_decimal "$KILL_TERM_TIMEOUT"; then
 	exit $OCF_ERR_CONFIGURED
 fi
 
+CONTROL_FILE="${OCF_RESKEY_control_file}"
+PERSIST_FILE="${OCF_RESKEY_persist_file}"
+PID_FILE="${OCF_RESKEY_pidfile}"
 START_OPTS=${OCF_RESKEY_start_opts}
 EXECUTABLE=$(basename "$SYSLOG_NG_EXE")
 PROCESS_PATTERN="$EXECUTABLE -f $CONFIGFILE"
 
 COMMAND=$1
+
+[ -n "$PERSIST_FILE" ] && PERSIST_FILE="--persist-file $PERSIST_FILE"
+[ -n "$CONTROL_FILE" ] && CONTROL_FILE="--control $CONTROL_FILE"
+[ -n "$PID_FILE" ] && PID_FILE="--pidfile $PID_FILE"
 
 case "$COMMAND" in
 	start)

--- a/heartbeat/syslog-ng-pe-6
+++ b/heartbeat/syslog-ng-pe-6
@@ -1,0 +1,418 @@
+#!/bin/bash
+#
+# Description:  Manages a syslog-ng instance, provided by NTT OSSC as an 
+#               OCF High-Availability resource under Heartbeat/LinuxHA control
+#
+# Copyright (c) 2009 NIPPON TELEGRAPH AND TELEPHONE CORPORATION
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+#
+##############################################################################
+# OCF parameters:
+#   OCF_RESKEY_syslog_ng_binary : Path to syslog-ng binary.
+#                                 Default is "/sbin/syslog-ng"
+#   OCF_RESKEY_configfile       : Configuration file
+#   OCF_RESKEY_start_opts       : Startup options
+#   OCF_RESKEY_kill_term_timeout: Number of seconds to await to confirm a 
+#                                 normal stop method
+#
+#   Only OCF_RESKEY_configfile must be specified. Each of the rests 
+#   has its default value or refers OCF_RESKEY_configfile to make
+#   its value when no explicit value is given.
+#
+# Further infomation for setup:
+#   There are sample configurations at the end of this file.
+#
+###############################################################################
+
+: ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
+. ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
+
+usage() 
+{
+	cat <<-!
+usage: $0 action
+
+action:
+        start       : start a new syslog-ng instance
+
+        stop        : stop the running syslog-ng instance
+
+        status      : return the status of syslog-ng, run or down
+
+        monitor     : return TRUE if the syslog-ng appears to be working.
+
+        meta-data   : show meta data message
+
+        validate-all: validate the instance parameters
+!
+	return $OCF_ERR_UNIMPLEMENTED
+}
+
+metadata_syslog_ng()
+{
+	cat <<END
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="syslog-ng">
+<version>1.0</version>
+
+<longdesc lang="en">
+This script manages a syslog-ng instance as an HA resource.
+</longdesc>
+<shortdesc lang="en">Syslog-ng resource agent</shortdesc>
+
+<parameters>
+
+<parameter name="configfile" unique="0" required="1">
+<longdesc lang="en">
+This parameter specifies a configuration file 
+for a syslog-ng instance managed by this RA.
+</longdesc>
+<shortdesc lang="en">Configuration file</shortdesc>
+<content type="string" default=""/>
+</parameter>
+
+<parameter name="syslog_ng_binary" unique="0">
+<longdesc lang="en">
+This parameter specifies syslog-ng's executable file.
+</longdesc>
+<shortdesc lang="en">syslog-ng executable</shortdesc>
+<content type="string" default="/sbin/syslog-ng"/>
+</parameter>
+
+<parameter name="qdisk_dir" unique="0">
+<longdesc lang="en">
+This parameter specifies the directory used for holding disk buffers of
+syslog-ng.
+</longdesc>
+<shortdesc lang="en">disk buffer directory</shortdesc>
+<content type="string" default="/opt/syslog-ng/var/"/>
+</parameter>
+
+<parameter name="control_file" unique="0">
+<longdesc lang="en">
+This parameter specifies the path, where syslog-ng would place its control
+socket, through which it can be controlled.
+</longdesc>
+<shortdesc lang="en">process control socket</shortdesc>
+<content type="string" default="/opt/syslog-ng/var/run/syslog-ng.ctl"/>
+</parameter>
+
+<parameter name="persist_file" unique="0">
+<longdesc lang="en">
+This parameter specifies the path for syslog-ng's persist file, which holds
+persistent information about the mapping of destinations and disk buffers,
+the internal state of sources, etc.
+</longdesc>
+<shortdesc lang="en">persist file path</shortdesc>
+<content type="string" default="/opt/syslog-ng/var/syslog-ng.persist"/>
+</parameter>
+
+<parameter name="pidfile" unique="0">
+<longdesc lang="en">
+This parameter specifies the path where the pid file of syslog-ng resides.
+</longdesc>
+<shortdesc lang="en">pidfile path</shortdesc>
+<content type="string" default="/opt/syslog-ng/var/run/syslog-ng.pid"/>
+</parameter>
+
+<parameter name="start_opts" unique="0">
+<longdesc lang="en">
+This parameter specifies startup options for a 
+syslog-ng instance managed by this RA. When no value is given, no startup 
+options is used. Don't use option '-F'. It causes a stuck of a start action.
+</longdesc>
+<shortdesc lang="en">Start options</shortdesc>
+<content type="string" default=""/>
+</parameter>
+
+<parameter name="kill_term_timeout" unique="0">
+<longdesc lang="en">
+On a stop action, a normal stop method(pkill -TERM) is firstly used.
+And then the confirmation of its completion is waited for
+the specified seconds by this parameter.
+The default value is 10.
+</longdesc>
+<shortdesc lang="en">Number of seconds to await to confirm a normal stop method</shortdesc>
+<content type="integer" default="10"/>
+</parameter>
+
+</parameters>
+
+<actions>
+<action name="start" timeout="60s" />
+<action name="stop" timeout="120s" />
+<action name="status" timeout="60s" />
+<action name="monitor" depth="0" timeout="60s" interval="60s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all"  timeout="5s"/>
+</actions>
+</resource-agent>
+END
+	return $OCF_SUCCESS
+}
+
+monitor_syslog_ng()
+{
+	set -- $(pgrep -f "$PROCESS_PATTERN" 2>/dev/null)
+	case $# in
+		0) ocf_log debug "No syslog-ng process for $CONFIGFILE"
+		   return $OCF_NOT_RUNNING;;
+		1) return $OCF_SUCCESS;;
+	esac
+	ocf_log warn "Multiple syslog-ng process for $CONFIGFILE"
+	return $OCF_SUCCESS
+}
+
+start_syslog_ng()
+{
+	monitor_syslog_ng
+	if [[ $? = "$OCF_SUCCESS" ]]; then
+		return $OCF_SUCCESS
+	fi
+
+	# set -- $SYSLOG_NG_OPTS
+	# ocf_run "$SYSLOG_NG_EXE" -f "$SYSLOG_NG_CONF" "$@"
+	# reduce to this?
+	ocf_run "$SYSLOG_NG_EXE" --cfgfile "$CONFIGFILE" --qdisk-dir "$QDISK_DIR" --control "$CONTROL_FILE" --persist-file "$PERSIST_FILE" --pidfile "$PID_FILE" $START_OPTS
+	ocf_status=$?
+	if [[ "$ocf_status" != "$OCF_SUCCESS" ]]; then
+		return $OCF_ERR_GENERIC
+	fi
+
+	while true; do
+		monitor_syslog_ng
+		if [[ $? = "$OCF_SUCCESS" ]]; then
+			return $OCF_SUCCESS
+		fi
+		sleep 1
+	done
+}
+
+stop_syslog_ng()
+{
+	if [ -x /opt/syslog-ng/sbin/syslog-ng-ctl ]; then
+		if [ -S "$CONTROL_FILE" ]; then
+			/opt/syslog-ng/sbin/syslog-ng-ctl stop --control "$CONTROL_FILE"
+			CTL_STATUS=$?
+			[ $CTL_STATUS -ne 0 ] && pkill -TERM -f "$PROCESS_PATTERN"
+		else
+			pkill -TERM -f "$PROCESS_PATTERN"
+		fi
+	else
+		pkill -TERM -f "$PROCESS_PATTERN"
+	fi
+
+	typeset lapse_sec=0
+	while pgrep -f "$PROCESS_PATTERN" > /dev/null; do
+		sleep 1
+		lapse_sec=$(( lapse_sec + 1 ))
+		ocf_log debug "stop_syslog_ng[$SYSLOG_NG_NAME]: stop NORM $lapse_sec/$KILL_TERM_TIMEOUT"
+		if [ $lapse_sec -ge $KILL_TERM_TIMEOUT ]; then
+			break
+		fi
+	done
+
+	# if the process can't be removed, then the following part is
+	# not going to be executed (the RA will be killed by lrmd on
+	# timeout) and the pidfile will remain; don't know if that
+	# has any consequences
+	# 2009/09/18 Nakahira
+	# If the syslog-ng process hangs, syslog-ng RA waits
+	# $KILL_TERM_TIMEOUT seconds.
+	# The stop timeout of RA should be longer than $KILL_TERM_TIMEOUT.
+	lapse_sec=0
+	while pgrep -f "$PROCESS_PATTERN" > /dev/null; do
+		pkill -KILL -f "$PROCESS_PATTERN"
+		sleep 1
+		lapse_sec=$(( lapse_sec + 1 ))
+		ocf_log debug "stop_syslog_ng[$SYSLOG_NG_NAME]: suspend syslog_ng by SIGKILL ($lapse_sec/@@@)"
+	done
+
+	return $OCF_SUCCESS
+}
+
+status_syslog_ng()
+{
+	# ???? why not monitor and then print running or stopped
+	monitor_syslog_ng
+	rc=$?
+	if [ $rc = $OCF_SUCCESS ]; then
+		echo "Syslog-ng service is running."
+	elif [ $rc = $OCF_NOT_RUNNING ]; then
+		echo "Syslog-ng service is stopped."
+	else
+		echo "Mutiple syslog-ng process for $CONFIGFILE."
+	fi
+	return $rc
+}
+
+validate_all_syslog_ng()
+{
+	ocf_log info "validate_all_syslog_ng[$SYSLOG_NG_NAME]"
+	return $OCF_SUCCESS
+}
+
+if [[ "$1" = "meta-data" ]]; then
+	metadata_syslog_ng
+	exit $?
+fi
+
+CONFIGFILE="${OCF_RESKEY_configfile}"
+if [[ -z "$CONFIGFILE" ]]; then
+	ocf_log err "undefined parameter:configfile"
+	exit $OCF_ERR_CONFIGURED
+fi
+
+SYSLOG_NG_NAME=${CONFIGFILE##*/}
+SYSLOG_NG_NAME=${SYSLOG_NG_NAME%.*}
+
+SYSLOG_NG_EXE="${OCF_RESKEY_syslog_ng_binary:-/sbin/syslog-ng}"
+if [[ ! -x "$SYSLOG_NG_EXE" ]]; then
+	ocf_log err "Invalid value:syslog_ng_binary:$SYSLOG_NG_EXE"
+	exit $OCF_ERR_CONFIGURED
+fi
+
+# actually, the pidfile has no function; the status is checked by
+# testing for a running process only
+
+KILL_TERM_TIMEOUT="${OCF_RESKEY_kill_term_timeout-10}"
+if ! ocf_is_decimal "$KILL_TERM_TIMEOUT"; then
+	ocf_log err "Invalid value:kill_term_timeout:$KILL_TERM_TIMEOUT"
+	exit $OCF_ERR_CONFIGURED
+fi
+
+QDISK_DIR="${OCF_RESKEY_qdisk_dir}"
+CONTROL_FILE="${OCF_RESKEY_control_file}"
+PERSIST_FILE="${OCF_RESKEY_persist_file}"
+PID_FILE="${OCF_RESKEY_pidfile}"
+START_OPTS=${OCF_RESKEY_start_opts}
+EXECUTABLE=$(basename "$SYSLOG_NG_EXE")
+PROCESS_PATTERN="$EXECUTABLE --cfgfile $CONFIGFILE"
+
+COMMAND=$1
+
+case "$COMMAND" in
+	start)
+		ocf_log debug  "[$SYSLOG_NG_NAME] Enter syslog_ng start"
+		start_syslog_ng
+		func_status=$?
+		ocf_log debug  "[$SYSLOG_NG_NAME] Leave syslog_ng start $func_status"
+		exit $func_status
+		;;
+	stop)
+		ocf_log debug  "[$SYSLOG_NG_NAME] Enter syslog_ng stop"
+		stop_syslog_ng
+		func_status=$?
+		ocf_log debug  "[$SYSLOG_NG_NAME] Leave syslog_ng stop $func_status"
+		exit $func_status
+		;;
+	status)
+		status_syslog_ng
+		exit $?
+		;;
+	monitor)
+		#ocf_log debug  "[$SYSLOG_NG_NAME] Enter syslog_ng monitor"
+		monitor_syslog_ng
+		func_status=$?
+		#ocf_log debug  "[$SYSLOG_NG_NAME] Leave syslog_ng monitor $func_status"
+		exit $func_status
+		;;
+	validate-all)
+		validate_all_syslog_ng
+		exit $?
+		;;
+	*)
+		usage
+		;;
+esac
+
+# vim: set sw=4 ts=4 :
+
+### A sample snippet of cib.xml for a syslog-ng resource
+##
+#         <primitive id="prmApSyslog-ng" class="ocf" type="syslog-ng" provider="heartbeat">
+#           <instance_attributes id="prmDummyB_instance_attrs">
+#             <attributes>
+#	       <nvpair id="atr:Syslog-ng:syslog-ng:configfile" name="configfile" value="/etc/syslog-ng/syslog-ng-ext.conf"/>
+#             </attributes>
+#           </instance_attributes>
+#           <operations>
+#             <op id="op:prmSyslog-ng:start"   name="start" timeout="60s" on_fail="restart"/>
+#             <op id="op:prmSyslog-ng:monitor" name="monitor" interval="10s" timeout="60s" on_fail="restart"/>
+#             <op id="op:prmSyslog-ng:stop"    name="stop" timeout="60s" on_fail="block"/>
+#           </operations>
+#         </primitive>
+
+### A sample syslog-ng configuration file for a log collecting host
+### 
+### This sample is for a log collecting host by syslog-ng.
+### A syslog-ng process configurated by this sample accepts all messages
+### from a certain network. Any message from the network is preserved into
+### a file for security infomation. Restricting messages to "authpriv" from
+### the network is done on log sending hosts. (See the sample below)
+### Any internal message of the syslog-ng process is preserved into its 
+### dedicated file. And any "authpriv" internal message of the syslog-ng 
+### process is also preserved into the security infomation file.
+###
+### Change "f_incoming" to suit your enviroment.
+### If you use it as a configuration file for the sample cib.xml above,
+### save it into "/etc/syslog-ng/syslog-ng-ext.conf".
+##
+#options {
+#    sync (0);
+#    time_reopen (10);
+#    log_fifo_size (1000);
+#    long_hostnames (off);
+#    use_dns (yes);
+#    use_fqdn (no);
+#    create_dirs (no);
+#    keep_hostname (yes); };
+#
+#source s_internal { internal(); };
+#source s_incoming { udp(port(514)); };
+#filter f_internal { facility(authpriv); };
+#filter f_incoming { netmask("172.20.0.0/255.255.192.0"); };
+#
+#destination d_internal { file("/var/log/syslog-ng-ext.log" perm(0640));};
+#destination d_incoming {
+#    file("/var/log/secure-ext.log" create_dirs(yes) perm(0640)); };
+#
+#log { source(s_internal); destination(d_internal); };
+#log { source(s_internal); filter(f_internal); destination(d_incoming); };
+#log { source(s_incoming); filter(f_incoming); destination(d_incoming); };
+
+### A sample snippet of syslog-ng configuration file for a log sending host
+###
+### This sample is for a log sending host that uses syslog-ng.
+###
+### Replace "syslog-ng-ext" to the IP address or the hostname of your
+### log collecting host and append it to "syslog-ng.conf" of each log sending
+### host. See the install default syslog-ng.conf to know what "s_sys" and 
+### "f_auth" are.
+##
+#destination d_outgoing  { udp("syslog-ng-ext" port(514)); };
+#log { source(s_sys); filter(f_auth); destination(d_outgoing); };
+
+### A sample snippet of syslog configuration file for a log sending host
+###
+### This sample is for a log sending host that uses syslog.
+###
+### Replace "syslog-ng-ext" to the IP address or the hostname of your
+### log collecting host and append it to "syslog.conf" of each log sending
+### host.
+##
+# authpriv.*                                              @syslog-ng-ext

--- a/heartbeat/syslog-ng-pe-7
+++ b/heartbeat/syslog-ng-pe-7
@@ -1,0 +1,409 @@
+#!/bin/bash
+#
+# Description:  Manages a syslog-ng instance, provided by NTT OSSC as an 
+#               OCF High-Availability resource under Heartbeat/LinuxHA control
+#
+# Copyright (c) 2009 NIPPON TELEGRAPH AND TELEPHONE CORPORATION
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+#
+##############################################################################
+# OCF parameters:
+#   OCF_RESKEY_syslog_ng_binary : Path to syslog-ng binary.
+#                                 Default is "/sbin/syslog-ng"
+#   OCF_RESKEY_configfile       : Configuration file
+#   OCF_RESKEY_start_opts       : Startup options
+#   OCF_RESKEY_kill_term_timeout: Number of seconds to await to confirm a 
+#                                 normal stop method
+#
+#   Only OCF_RESKEY_configfile must be specified. Each of the rests 
+#   has its default value or refers OCF_RESKEY_configfile to make
+#   its value when no explicit value is given.
+#
+# Further infomation for setup:
+#   There are sample configurations at the end of this file.
+#
+###############################################################################
+
+: ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
+. ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
+
+usage() 
+{
+	cat <<-!
+usage: $0 action
+
+action:
+        start       : start a new syslog-ng instance
+
+        stop        : stop the running syslog-ng instance
+
+        status      : return the status of syslog-ng, run or down
+
+        monitor     : return TRUE if the syslog-ng appears to be working.
+
+        meta-data   : show meta data message
+
+        validate-all: validate the instance parameters
+!
+	return $OCF_ERR_UNIMPLEMENTED
+}
+
+metadata_syslog_ng()
+{
+	cat <<END
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="syslog-ng">
+<version>1.0</version>
+
+<longdesc lang="en">
+This script manages a syslog-ng instance as an HA resource.
+</longdesc>
+<shortdesc lang="en">Syslog-ng resource agent</shortdesc>
+
+<parameters>
+
+<parameter name="configfile" unique="0" required="1">
+<longdesc lang="en">
+This parameter specifies a configuration file 
+for a syslog-ng instance managed by this RA.
+</longdesc>
+<shortdesc lang="en">Configuration file</shortdesc>
+<content type="string" default=""/>
+</parameter>
+
+<parameter name="syslog_ng_binary" unique="0">
+<longdesc lang="en">
+This parameter specifies syslog-ng's executable file.
+</longdesc>
+<shortdesc lang="en">syslog-ng executable</shortdesc>
+<content type="string" default="/sbin/syslog-ng"/>
+</parameter>
+
+<parameter name="control_file" unique="0">
+<longdesc lang="en">
+This parameter specifies the path, where syslog-ng would place its control
+socket, through which it can be controlled.
+</longdesc>
+<shortdesc lang="en">process control socket</shortdesc>
+<content type="string" default="/opt/syslog-ng/var/run/syslog-ng.ctl"/>
+</parameter>
+
+<parameter name="persist_file" unique="0">
+<longdesc lang="en">
+This parameter specifies the path for syslog-ng's persist file, which holds
+persistent information about the mapping of destinations and disk buffers,
+the internal state of sources, etc.
+</longdesc>
+<shortdesc lang="en">persist file path</shortdesc>
+<content type="string" default="/opt/syslog-ng/var/syslog-ng.persist"/>
+</parameter>
+
+<parameter name="pidfile" unique="0">
+<longdesc lang="en">
+This parameter specifies the path where the pid file of syslog-ng resides.
+</longdesc>
+<shortdesc lang="en">pidfile path</shortdesc>
+<content type="string" default="/opt/syslog-ng/var/run/syslog-ng.pid"/>
+</parameter>
+
+<parameter name="start_opts" unique="0">
+<longdesc lang="en">
+This parameter specifies startup options for a 
+syslog-ng instance managed by this RA. When no value is given, no startup 
+options is used. Don't use option '-F'. It causes a stuck of a start action.
+</longdesc>
+<shortdesc lang="en">Start options</shortdesc>
+<content type="string" default=""/>
+</parameter>
+
+<parameter name="kill_term_timeout" unique="0">
+<longdesc lang="en">
+On a stop action, a normal stop method(pkill -TERM) is firstly used.
+And then the confirmation of its completion is waited for
+the specified seconds by this parameter.
+The default value is 10.
+</longdesc>
+<shortdesc lang="en">Number of seconds to await to confirm a normal stop method</shortdesc>
+<content type="integer" default="10"/>
+</parameter>
+
+</parameters>
+
+<actions>
+<action name="start" timeout="60s" />
+<action name="stop" timeout="120s" />
+<action name="status" timeout="60s" />
+<action name="monitor" depth="0" timeout="60s" interval="60s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all"  timeout="5s"/>
+</actions>
+</resource-agent>
+END
+	return $OCF_SUCCESS
+}
+
+monitor_syslog_ng()
+{
+	set -- $(pgrep -f "$PROCESS_PATTERN" 2>/dev/null)
+	case $# in
+		0) ocf_log debug "No syslog-ng process for $CONFIGFILE"
+		   return $OCF_NOT_RUNNING;;
+		1) return $OCF_SUCCESS;;
+	esac
+	ocf_log warn "Multiple syslog-ng process for $CONFIGFILE"
+	return $OCF_SUCCESS
+}
+
+start_syslog_ng()
+{
+	monitor_syslog_ng
+	if [[ $? = "$OCF_SUCCESS" ]]; then
+		return $OCF_SUCCESS
+	fi
+
+	# set -- $SYSLOG_NG_OPTS
+	# ocf_run "$SYSLOG_NG_EXE" -f "$SYSLOG_NG_CONF" "$@"
+	# reduce to this?
+	ocf_run "$SYSLOG_NG_EXE" --cfgfile "$CONFIGFILE" --control "$CONTROL_FILE" --persist-file "$PERSIST_FILE" --pidfile "$PID_FILE" $START_OPTS
+	ocf_status=$?
+	if [[ "$ocf_status" != "$OCF_SUCCESS" ]]; then
+		return $OCF_ERR_GENERIC
+	fi
+
+	while true; do
+		monitor_syslog_ng
+		if [[ $? = "$OCF_SUCCESS" ]]; then
+			return $OCF_SUCCESS
+		fi
+		sleep 1
+	done
+}
+
+stop_syslog_ng()
+{
+	if [ -x /opt/syslog-ng/sbin/syslog-ng-ctl ]; then
+		if [ -S "$CONTROL_FILE" ]; then
+			/opt/syslog-ng/sbin/syslog-ng-ctl stop --control "$CONTROL_FILE"
+			CTL_STATUS=$?
+			[ $CTL_STATUS -ne 0 ] && pkill -TERM -f "$PROCESS_PATTERN"
+		else
+			pkill -TERM -f "$PROCESS_PATTERN"
+		fi
+	else
+		pkill -TERM -f "$PROCESS_PATTERN"
+	fi
+
+	typeset lapse_sec=0
+	while pgrep -f "$PROCESS_PATTERN" > /dev/null; do
+		sleep 1
+		lapse_sec=$(( lapse_sec + 1 ))
+		ocf_log debug "stop_syslog_ng[$SYSLOG_NG_NAME]: stop NORM $lapse_sec/$KILL_TERM_TIMEOUT"
+		if [ $lapse_sec -ge $KILL_TERM_TIMEOUT ]; then
+			break
+		fi
+	done
+
+	# if the process can't be removed, then the following part is
+	# not going to be executed (the RA will be killed by lrmd on
+	# timeout) and the pidfile will remain; don't know if that
+	# has any consequences
+	# 2009/09/18 Nakahira
+	# If the syslog-ng process hangs, syslog-ng RA waits
+	# $KILL_TERM_TIMEOUT seconds.
+	# The stop timeout of RA should be longer than $KILL_TERM_TIMEOUT.
+	lapse_sec=0
+	while pgrep -f "$PROCESS_PATTERN" > /dev/null; do
+		pkill -KILL -f "$PROCESS_PATTERN"
+		sleep 1
+		lapse_sec=$(( lapse_sec + 1 ))
+		ocf_log debug "stop_syslog_ng[$SYSLOG_NG_NAME]: suspend syslog_ng by SIGKILL ($lapse_sec/@@@)"
+	done
+
+	return $OCF_SUCCESS
+}
+
+status_syslog_ng()
+{
+	# ???? why not monitor and then print running or stopped
+	monitor_syslog_ng
+	rc=$?
+	if [ $rc = $OCF_SUCCESS ]; then
+		echo "Syslog-ng service is running."
+	elif [ $rc = $OCF_NOT_RUNNING ]; then
+		echo "Syslog-ng service is stopped."
+	else
+		echo "Mutiple syslog-ng process for $CONFIGFILE."
+	fi
+	return $rc
+}
+
+validate_all_syslog_ng()
+{
+	ocf_log info "validate_all_syslog_ng[$SYSLOG_NG_NAME]"
+	return $OCF_SUCCESS
+}
+
+if [[ "$1" = "meta-data" ]]; then
+	metadata_syslog_ng
+	exit $?
+fi
+
+CONFIGFILE="${OCF_RESKEY_configfile}"
+if [[ -z "$CONFIGFILE" ]]; then
+	ocf_log err "undefined parameter:configfile"
+	exit $OCF_ERR_CONFIGURED
+fi
+
+SYSLOG_NG_NAME=${CONFIGFILE##*/}
+SYSLOG_NG_NAME=${SYSLOG_NG_NAME%.*}
+
+SYSLOG_NG_EXE="${OCF_RESKEY_syslog_ng_binary:-/sbin/syslog-ng}"
+if [[ ! -x "$SYSLOG_NG_EXE" ]]; then
+	ocf_log err "Invalid value:syslog_ng_binary:$SYSLOG_NG_EXE"
+	exit $OCF_ERR_CONFIGURED
+fi
+
+# actually, the pidfile has no function; the status is checked by
+# testing for a running process only
+
+KILL_TERM_TIMEOUT="${OCF_RESKEY_kill_term_timeout-10}"
+if ! ocf_is_decimal "$KILL_TERM_TIMEOUT"; then
+	ocf_log err "Invalid value:kill_term_timeout:$KILL_TERM_TIMEOUT"
+	exit $OCF_ERR_CONFIGURED
+fi
+
+QDISK_DIR="${OCF_RESKEY_qdisk_dir}"
+CONTROL_FILE="${OCF_RESKEY_control_file}"
+PERSIST_FILE="${OCF_RESKEY_persist_file}"
+PID_FILE="${OCF_RESKEY_pidfile}"
+START_OPTS=${OCF_RESKEY_start_opts}
+EXECUTABLE=$(basename "$SYSLOG_NG_EXE")
+PROCESS_PATTERN="$EXECUTABLE --cfgfile $CONFIGFILE"
+
+COMMAND=$1
+
+case "$COMMAND" in
+	start)
+		ocf_log debug  "[$SYSLOG_NG_NAME] Enter syslog_ng start"
+		start_syslog_ng
+		func_status=$?
+		ocf_log debug  "[$SYSLOG_NG_NAME] Leave syslog_ng start $func_status"
+		exit $func_status
+		;;
+	stop)
+		ocf_log debug  "[$SYSLOG_NG_NAME] Enter syslog_ng stop"
+		stop_syslog_ng
+		func_status=$?
+		ocf_log debug  "[$SYSLOG_NG_NAME] Leave syslog_ng stop $func_status"
+		exit $func_status
+		;;
+	status)
+		status_syslog_ng
+		exit $?
+		;;
+	monitor)
+		#ocf_log debug  "[$SYSLOG_NG_NAME] Enter syslog_ng monitor"
+		monitor_syslog_ng
+		func_status=$?
+		#ocf_log debug  "[$SYSLOG_NG_NAME] Leave syslog_ng monitor $func_status"
+		exit $func_status
+		;;
+	validate-all)
+		validate_all_syslog_ng
+		exit $?
+		;;
+	*)
+		usage
+		;;
+esac
+
+# vim: set sw=4 ts=4 :
+
+### A sample snippet of cib.xml for a syslog-ng resource
+##
+#         <primitive id="prmApSyslog-ng" class="ocf" type="syslog-ng" provider="heartbeat">
+#           <instance_attributes id="prmDummyB_instance_attrs">
+#             <attributes>
+#	       <nvpair id="atr:Syslog-ng:syslog-ng:configfile" name="configfile" value="/etc/syslog-ng/syslog-ng-ext.conf"/>
+#             </attributes>
+#           </instance_attributes>
+#           <operations>
+#             <op id="op:prmSyslog-ng:start"   name="start" timeout="60s" on_fail="restart"/>
+#             <op id="op:prmSyslog-ng:monitor" name="monitor" interval="10s" timeout="60s" on_fail="restart"/>
+#             <op id="op:prmSyslog-ng:stop"    name="stop" timeout="60s" on_fail="block"/>
+#           </operations>
+#         </primitive>
+
+### A sample syslog-ng configuration file for a log collecting host
+### 
+### This sample is for a log collecting host by syslog-ng.
+### A syslog-ng process configurated by this sample accepts all messages
+### from a certain network. Any message from the network is preserved into
+### a file for security infomation. Restricting messages to "authpriv" from
+### the network is done on log sending hosts. (See the sample below)
+### Any internal message of the syslog-ng process is preserved into its 
+### dedicated file. And any "authpriv" internal message of the syslog-ng 
+### process is also preserved into the security infomation file.
+###
+### Change "f_incoming" to suit your enviroment.
+### If you use it as a configuration file for the sample cib.xml above,
+### save it into "/etc/syslog-ng/syslog-ng-ext.conf".
+##
+#options {
+#    sync (0);
+#    time_reopen (10);
+#    log_fifo_size (1000);
+#    long_hostnames (off);
+#    use_dns (yes);
+#    use_fqdn (no);
+#    create_dirs (no);
+#    keep_hostname (yes); };
+#
+#source s_internal { internal(); };
+#source s_incoming { udp(port(514)); };
+#filter f_internal { facility(authpriv); };
+#filter f_incoming { netmask("172.20.0.0/255.255.192.0"); };
+#
+#destination d_internal { file("/var/log/syslog-ng-ext.log" perm(0640));};
+#destination d_incoming {
+#    file("/var/log/secure-ext.log" create_dirs(yes) perm(0640)); };
+#
+#log { source(s_internal); destination(d_internal); };
+#log { source(s_internal); filter(f_internal); destination(d_incoming); };
+#log { source(s_incoming); filter(f_incoming); destination(d_incoming); };
+
+### A sample snippet of syslog-ng configuration file for a log sending host
+###
+### This sample is for a log sending host that uses syslog-ng.
+###
+### Replace "syslog-ng-ext" to the IP address or the hostname of your
+### log collecting host and append it to "syslog-ng.conf" of each log sending
+### host. See the install default syslog-ng.conf to know what "s_sys" and 
+### "f_auth" are.
+##
+#destination d_outgoing  { udp("syslog-ng-ext" port(514)); };
+#log { source(s_sys); filter(f_auth); destination(d_outgoing); };
+
+### A sample snippet of syslog configuration file for a log sending host
+###
+### This sample is for a log sending host that uses syslog.
+###
+### Replace "syslog-ng-ext" to the IP address or the hostname of your
+### log collecting host and append it to "syslog.conf" of each log sending
+### host.
+##
+# authpriv.*                                              @syslog-ng-ext


### PR DESCRIPTION
* Added parameters to the syslog-ng resource agent in a backwards compatible way
* Added resource agent script for Syslog-ng Premium Edition 6
* Added resource agent script for Syslog-ng Premium Edition 7

(The Premium Edition is the non-free counterpart of the Syslog-ng open-source version. Their parameters, and install paths differ from that of the open-source edition. There are also slight differences between the PE 6 and PE 7 versions.)