### PR TITLE
mpathpersist: Fixed problem that character string could not be correc…

### DIFF
--- a/heartbeat/mpathpersist
+++ b/heartbeat/mpathpersist
@@ -271,7 +271,7 @@ mpathpersist_get_status() {
                         RESERVED_DEVS+=($dev)
                     fi
 
-                    reservation_key=`echo $READ_RESERVATION | $GREP -o 'Key=0x[0-9a-f]*' | $GREP -o '0x[0-9a-f]*'`
+                    reservation_key=`echo $READ_RESERVATION | $GREP -o 'Key = 0x[0-9a-f]*' | $GREP -o '0x[0-9a-f]*'`
                     if [ -n "$reservation_key" ]; then 
                         DEVS_WITH_RESERVATION+=($dev)
                         RESERVATION_KEYS+=($reservation_key)


### PR DESCRIPTION
…tly parsed

In "device-mapper-multipath-0.4.9-111.el7.x86_64" I use, the output of the command is as follows.
A space appears between Key and Equals.
```
# mpathpersist --in --read-reservation /dev/mapper/lun4
  PR generation=0x7fb, Reservation follows:
   Key = 0xc0a86506
  scope = LU_SCOPE, type = Write Exclusive
```
In order to correctly grep you need to modify the pattern.