### PR TITLE
Medium: exportfs: Fix square bracket stripping in clientspec

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -272,7 +272,17 @@ exportfs_monitor ()
 		return $OCF_NOT_RUNNING
 	fi
 
-	spec="$(echo "$OCF_RESKEY_clientspec" | sed -e 's/^\[*//' -e 's/\]*$//')"
+	# IPv6 addresses and networks are encased in brackets that need
+	# to be removed
+        case "$OCF_RESKEY_clientspec" in
+		*:*:* )
+			spec="$(echo "$OCF_RESKEY_clientspec" | tr -d '[]')"
+			;;
+		*)
+			spec="$OCF_RESKEY_clientspec"
+			;;
+	esac
+
 	if forall is_exported "$spec"; then
 		if [ ${OCF_RESKEY_rmtab_backup} != "none" ]; then
 			forall backup_rmtab


### PR DESCRIPTION
This patch fixes the issue of the `exportfs` RA failing its monitor
operation if the `clientspec` matches either of two conditions:
    
- It includes a character class wildcard at the beginning or end of
  the string.
    
    Example:
        `clientspec='[ab]-host.example.com'`
    
  In this case, the leading square bracket is incorrectly stripped,
  leaving `'ab]-host.example.com'`.
    
- It consists of an IPv6 network with a CIDR netmask.
    
    Example:
          `clientspec='[fe80::]/64'`
    
  In this case, the closing square bracket is incorrectly left intact,
  leaving `'fe80::]/64'`.
    
In either of these conditions, the `start` operation creates the export
successfully, but the `monitor` immediately fails when it does not find
the string it's looking for. Similarly, the `stop` operation succeeds but 
does not actually remove the export.
    
This patch replaces the `sed` operation that strips brackets so that:
  - It only matches IPv6 addresses (using a colon to distinguish).
  - It matches the closing bracket in an IPv6 network.
