### PR TITLE
Low: exportfs: Fix inconsistent whitespace in exportfs_monitor

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -274,8 +274,8 @@ exportfs_monitor ()
 
 	# IPv6 addresses and networks are encased in brackets that need
 	# to be removed
-        case "$OCF_RESKEY_clientspec" in
-		*:*:* )
+	case "$OCF_RESKEY_clientspec" in
+		*:*:*)
 			spec="$(echo "$OCF_RESKEY_clientspec" | tr -d '[]')"
 			;;
 		*)


### PR DESCRIPTION
In commit 64d392d412ce9e14d4b33a70cb2180890db15a36, I introduced some
inconsistent whitespace in the exportfs_monitor function. This patch
fixes it.