### PR TITLE
send_arp: dont use "-Wcast-align" due to false-positive fail on ARM.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -807,7 +807,6 @@ else
 		-Wall
 		-Wbad-function-cast 
 		-Wcast-qual 
-		-Wcast-align 
 		-Wdeclaration-after-statement
 		-Wendif-labels
 		-Wfloat-equal


### PR DESCRIPTION
The -Wcast-align parameter isnt used for arping in iputils, and from the below mails it seems to usually report false-positives.

https://lists.isc.org/pipermail/inn-workers/2011-August/017857.html
https://lists.isc.org/pipermail/inn-workers/2011-August/017861.html