### PR TITLE
Correctly pickup old keys (improved v 0.0.2)

### DIFF
--- a/heartbeat/sg_persist.in
+++ b/heartbeat/sg_persist.in
@@ -496,25 +496,25 @@ sg_persist_action_monitor() {
     if [ ${#REGISTERED_DEVS[*]} -eq 0 ]; then
         ocf_log debug "$RESOURCE monitor: no registrations"
         if [ -n "$ACT_MASTER_SCORE" ]; then
-	    ocf_run $MASTER_SCORE_ATTRIBUTE --delete
-	    ocf_run $PENDING_ATTRIBUTE --delete
-	fi
+            ocf_run $MASTER_SCORE_ATTRIBUTE --delete
+            ocf_run $PENDING_ATTRIBUTE --delete
+        fi
         return $OCF_NOT_RUNNING
     fi
 
     if [ ${#RESERVED_DEVS[*]} -eq ${#WORKING_DEVS[*]} ]; then 
         if [ -z "$ACT_MASTER_SCORE" ]; then
-	    ocf_run $MASTER_SCORE_ATTRIBUTE --update=$MASTER_SCORE
-	    ocf_run $PENDING_ATTRIBUTE --update=""
-	fi
+            ocf_run $MASTER_SCORE_ATTRIBUTE --update=$MASTER_SCORE
+            ocf_run $PENDING_ATTRIBUTE --update=""
+        fi
         return $OCF_RUNNING_MASTER
     fi
 
     if [ ${#REGISTERED_DEVS[*]} -eq ${#WORKING_DEVS[*]} ]; then 
         if [ -z "$ACT_MASTER_SCORE" ]; then
-	    ocf_run $MASTER_SCORE_ATTRIBUTE --update=$MASTER_SCORE
-	    ocf_run $PENDING_ATTRIBUTE --update=""
-	fi
+            ocf_run $MASTER_SCORE_ATTRIBUTE --update=$MASTER_SCORE
+            ocf_run $PENDING_ATTRIBUTE --update=""
+        fi
         if [ $RESERVATION_TYPE -eq 7 ] || [ $RESERVATION_TYPE -eq 8 ]; then
             if [ ${#DEVS_WITH_RESERVATION[*]} -gt 0 ]; then
                 return $OCF_RUNNING_MASTER

--- a/heartbeat/sg_persist.in
+++ b/heartbeat/sg_persist.in
@@ -495,14 +495,26 @@ sg_persist_action_monitor() {
 
     if [ ${#REGISTERED_DEVS[*]} -eq 0 ]; then
         ocf_log debug "$RESOURCE monitor: no registrations"
+        if [ -n "$ACT_MASTER_SCORE" ]; then
+	    ocf_run $MASTER_SCORE_ATTRIBUTE --delete
+	    ocf_run $PENDING_ATTRIBUTE --delete
+	fi
         return $OCF_NOT_RUNNING
     fi
 
     if [ ${#RESERVED_DEVS[*]} -eq ${#WORKING_DEVS[*]} ]; then 
+        if [ -z "$ACT_MASTER_SCORE" ]; then
+	    ocf_run $MASTER_SCORE_ATTRIBUTE --update=$MASTER_SCORE
+	    ocf_run $PENDING_ATTRIBUTE --update=""
+	fi
         return $OCF_RUNNING_MASTER
     fi
 
     if [ ${#REGISTERED_DEVS[*]} -eq ${#WORKING_DEVS[*]} ]; then 
+        if [ -z "$ACT_MASTER_SCORE" ]; then
+	    ocf_run $MASTER_SCORE_ATTRIBUTE --update=$MASTER_SCORE
+	    ocf_run $PENDING_ATTRIBUTE --update=""
+	fi
         if [ $RESERVATION_TYPE -eq 7 ] || [ $RESERVATION_TYPE -eq 8 ]; then
             if [ ${#DEVS_WITH_RESERVATION[*]} -gt 0 ]; then
                 return $OCF_RUNNING_MASTER


### PR DESCRIPTION
If a comp hardly poweroffed there are staled old registration keys on the scsi
device. On a poweron the module sg_persist recognizes them by the monitor-probe and
set itself state to the "slave" state without "start" action and thus
don't set ACT_MASTER_SCORE. And without it the comp can never be
"master". This patch is for fixing this. It add ACT_MASTER_SCORE or
remove ACT_MASTER_SCORE in the "monitor" if the "monitor" see that the
keys unexpectedly exists or absent, thus simulate normal behaviour of
the "start" or "stop".