### PR TITLE
Low: Improve awsvip awseip

### DIFF
--- a/heartbeat/awseip
+++ b/heartbeat/awseip
@@ -4,7 +4,7 @@
 #    Manage Elastic IP with Pacemaker
 #
 #
-# Copyright 2016 guessi <guessi@gmail.com>
+# Copyright 2016-2018 guessi <guessi@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/heartbeat/awseip
+++ b/heartbeat/awseip
@@ -182,9 +182,8 @@ awseip_start() {
 awseip_stop() {
     awseip_monitor || return $OCF_SUCCESS
 
-    ASSOCIATION_ID=$($AWSCLI --profile $OCF_RESKEY_profile --output json ec2 describe-addresses \
-                         --allocation-id ${ALLOCATION_ID} | grep -m 1 "AssociationId" | awk -F'"' '{print$4}')
-    $AWSCLI --profile $OCF_RESKEY_profile ec2 disassociate-address  \
+    $AWSCLI --profile ${OCF_RESKEY_profile} \
+        ec2 disassociate-address \
         --association-id ${ASSOCIATION_ID}
     RET=$?
 
@@ -200,7 +199,9 @@ awseip_stop() {
 }
 
 awseip_monitor() {
-    $AWSCLI --profile $OCF_RESKEY_profile ec2 describe-instances --instance-id "${INSTANCE_ID}" | grep -q "${ELASTIC_IP}"
+    $AWSCLI --profile ${OCF_RESKEY_profile} \
+        ec2 describe-addresses \
+            --allocation-id ${ALLOCATION_ID}
     RET=$?
 
     if [ $RET -ne 0 ]; then

--- a/heartbeat/awseip
+++ b/heartbeat/awseip
@@ -182,8 +182,9 @@ awseip_start() {
 awseip_stop() {
     awseip_monitor || return $OCF_SUCCESS
 
-    $AWSCLI --profile ${OCF_RESKEY_profile} \
-        ec2 disassociate-address \
+    ASSOCIATION_ID=$($AWSCLI --profile $OCF_RESKEY_profile --output json ec2 describe-addresses \
+                         --allocation-id ${ALLOCATION_ID} | grep -m 1 "AssociationId" | awk -F'"' '{print$4}')
+    $AWSCLI --profile $OCF_RESKEY_profile ec2 disassociate-address  \
         --association-id ${ASSOCIATION_ID}
     RET=$?
 
@@ -199,9 +200,7 @@ awseip_stop() {
 }
 
 awseip_monitor() {
-    $AWSCLI --profile ${OCF_RESKEY_profile} \
-        ec2 describe-addresses \
-            --allocation-id ${ALLOCATION_ID}
+    $AWSCLI --profile $OCF_RESKEY_profile ec2 describe-instances --instance-id "${INSTANCE_ID}" | grep -q "${ELASTIC_IP}"
     RET=$?
 
     if [ $RET -ne 0 ]; then

--- a/heartbeat/awseip
+++ b/heartbeat/awseip
@@ -184,7 +184,14 @@ awseip_stop() {
 
     ASSOCIATION_ID=$($AWSCLI --profile $OCF_RESKEY_profile --output json ec2 describe-addresses \
                          --allocation-id ${ALLOCATION_ID} | grep -m 1 "AssociationId" | awk -F'"' '{print$4}')
-    $AWSCLI --profile $OCF_RESKEY_profile ec2 disassociate-address  \
+
+    if [ -z "${ASSOCIATION_ID}" ]; then
+        ocf_log info "ASSOCIATION_ID not found while stopping AWS Elastic IP"
+        return $OCF_NOT_RUNNING
+    fi
+
+    $AWSCLI --profile ${OCF_RESKEY_profile} \
+        ec2 disassociate-address \
         --association-id ${ASSOCIATION_ID}
     RET=$?
 

--- a/heartbeat/awsvip
+++ b/heartbeat/awsvip
@@ -168,7 +168,11 @@ awsvip_stop() {
 }
 
 awsvip_monitor() {
-    $AWSCLI --profile $OCF_RESKEY_profile ec2 describe-instances --instance-id "${INSTANCE_ID}" | grep -q "${SECONDARY_PRIVATE_IP}"
+    $AWSCLI --profile ${OCF_RESKEY_profile} ec2 describe-instances \
+            --instance-id "${INSTANCE_ID}" \
+            --query 'Reservations[].Instances[].NetworkInterfaces[].PrivateIpAddresses[].PrivateIpAddress[]' \
+            --output text | \
+            grep -q "${SECONDARY_PRIVATE_IP}"
     RET=$?
 
     if [ $RET -ne 0 ]; then

--- a/heartbeat/awsvip
+++ b/heartbeat/awsvip
@@ -203,7 +203,8 @@ esac
 AWSCLI="${OCF_RESKEY_awscli}"
 SECONDARY_PRIVATE_IP="${OCF_RESKEY_secondary_private_ip}"
 INSTANCE_ID="$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
-NETWORK_ID="$($AWSCLI --profile $OCF_RESKEY_profile --output json ec2 describe-instances --instance-id ${INSTANCE_ID} | grep -m 1 'eni' | awk -F'"' '{print$4}')"
+MAC_ADDRESS="$(curl -s http://169.254.169.254/latest/meta-data/mac)"
+NETWORK_ID="$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC_ADDRESS}/interface-id)"
 
 case $__OCF_ACTION in
     start)

--- a/heartbeat/awsvip
+++ b/heartbeat/awsvip
@@ -4,7 +4,7 @@
 #    Manage Secondary Private IP with Pacemaker
 #
 #
-# Copyright 2016 guessi <guessi@gmail.com>
+# Copyright 2016-2018 guessi <guessi@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Improved:

## awseip
- High: fix allocation_id not found error

## awsvip
- Low: get secondary-private-ip more precisely
- Low: get network-id from meta-data directly