### PR TITLE
SAPInstance resource resilience improvements

### DIFF
--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -322,6 +322,8 @@ sapinstance_init() {
 	ASCSInstanceName=`echo $OCF_RESKEY_InstanceName| cut -d_ -f2`
   fi
 
+  # make sure that we don't care the content of variable from previous run of sapinstance_init
+  DIR_EXECUTABLE=""
   # optional OCF parameters, we try to guess which directories are correct
   if  [ -z "$OCF_RESKEY_DIR_EXECUTABLE" ]
   then

--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -294,13 +294,13 @@ abnormal_end() {
     exit $?
   }
 
+  ocf_log err $err_msg
   if [ "$ACTION" = "stop" ]
   then
     cleanup_instance
     exit $OCF_SUCCESS
   fi
 
-  ocf_log err $err_msg
   exit $OCF_ERR_CONFIGURED
 }
 

--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -301,7 +301,7 @@ abnormal_end() {
     exit $OCF_SUCCESS
   fi
 
-  exit $OCF_ERR_CONFIGURED
+  exit $OCF_ERR_INSTALLED
 }
 
 #

--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -316,6 +316,11 @@ sapinstance_init() {
   InstanceName=`echo "$myInstanceName" | cut -d_ -f2`
   InstanceNr=`echo "$InstanceName" | sed 's/.*\([0-9][0-9]\)$/\1/'`
   SAPVIRHOST=`echo "$myInstanceName" | cut -d_ -f3`
+  if [ ! -z "$OCF_RESKEY_ERS_InstanceName" ]
+  then
+	ERSInstanceName=`echo $OCF_RESKEY_ERS_InstanceName| cut -d_ -f2`
+	ASCSInstanceName=`echo $OCF_RESKEY_InstanceName| cut -d_ -f2`
+  fi
 
   # optional OCF parameters, we try to guess which directories are correct
   if  [ -z "$OCF_RESKEY_DIR_EXECUTABLE" ]
@@ -330,6 +335,16 @@ sapinstance_init() {
       DIR_EXECUTABLE="/usr/sap/$SID/SYS/exe/run"
       SAPSTARTSRV="/usr/sap/$SID/SYS/exe/run/sapstartsrv"
       SAPCONTROL="/usr/sap/$SID/SYS/exe/run/sapcontrol"
+    elif [ ! -z "$ERSInstanceName" ] && have_binary /usr/sap/$SID/$ERSInstanceName/exe/sapstartsrv && have_binary /usr/sap/$SID/$ERSInstanceName/exe/sapcontrol
+    then
+      DIR_EXECUTABLE="/usr/sap/$SID/$ERSInstanceName/exe"
+      SAPSTARTSRV="/usr/sap/$SID/$ERSInstanceName/exe/sapstartsrv"
+      SAPCONTROL="/usr/sap/$SID/$ERSInstanceName/exe/sapcontrol"
+    elif [ ! -z "$ASCSInstanceName" ] && have_binary /usr/sap/$SID/$ASCSInstanceName/exe/sapstartsrv && have_binary /usr/sap/$SID/$ASCSInstanceName/exe/sapcontrol
+    then
+      DIR_EXECUTABLE="/usr/sap/$SID/$ASCSInstanceName/exe"
+      SAPSTARTSRV="/usr/sap/$SID/$ASCSInstanceName/exe/sapstartsrv"
+      SAPCONTROL="/usr/sap/$SID/$ASCSInstanceName/exe/sapcontrol"
     fi
   else
     if have_binary "$OCF_RESKEY_DIR_EXECUTABLE/sapstartsrv" && have_binary "$OCF_RESKEY_DIR_EXECUTABLE/sapcontrol"


### PR DESCRIPTION
Hi,

I have prepared some changes in this PR that are trying to improve the behaviour of `SAPInstance` resource agent (RA) when binaries needed by this RA gets missing.

- bd953cb move logging when we detect missing binaries earlier to see that this was issue even during 'stop' action
- f6fe133 - make the failure with missing binaries only 'hard' and not 'fatal' so this will only prevent resource from running on node where error was detected and not stop all resource instances on all nodes
- 64d9d49 - as we can use the binaries from both ASCS and ERS instances interchangeably for later operation make sure that we look for both of them. Without this only one location will be searched (except of common `/usr/sap/$SID/SYS/exe/run/`)
- 6069df2 - clear the `$DIR_EXECUTABLE` so that we properly detect when we are missing binaries when detection is done more than once during single operation. Currently the variable `$DIR_EXECUTABLE` may hold the path from previous run of `sapinstance_init` even if at the time of run some locations became unavailable. This tries to make shorter gap between the path detection and further actions. This is only effective when DIR_EXECUTABLE is not provided as resource attribute in which case there is only one path checked.

Changes were tested in RHEL 7.5 environment when trying to make binaries unavailable by removing execute bit on them (`chmod -x ...`) so `have_binary` function returns failure.

If anything is unclear/strange feel free to reach me out.