### PR TITLE
Medium: IPsrcaddr: Add "update_local_route" attribute

### DIFF
--- a/heartbeat/IPsrcaddr
+++ b/heartbeat/IPsrcaddr
@@ -58,8 +58,10 @@
 
 USAGE="usage: $0 {start|stop|status|monitor|validate-all|meta-data}";
 
-  CMDSHOW="$IP2UTIL route show   to exact 0.0.0.0/0"
-CMDCHANGE="$IP2UTIL route change to "
+        CMDSHOW="$IP2UTIL route show               to exact 0.0.0.0/0"
+      CMDCHANGE="$IP2UTIL route change             to"
+  CMDSHOW_LOCAL="$IP2UTIL route show   table local to exact $OCF_RESKEY_ipaddress"
+CMDCHANGE_LOCAL="$IP2UTIL route change table local local"
 
 SYSTYPE="`uname -s`"
 
@@ -96,6 +98,16 @@ dotted quad notation  255.255.255.0).
 </longdesc>
 <shortdesc lang="en">Netmask</shortdesc>
 <content type="string" default=""/>
+</parameter>
+
+<parameter name="update_local_route">
+<longdesc lang="en">
+If set, the route to destination \`ipaddress\` in the local route table
+will be updated to use \`ipaddress\` as the preferred source IP
+address.
+</longdesc>
+<shortdesc lang="en">Update local route</shortdesc>
+<content type="boolean" default="false"/>
 </parameter>
 </parameters>
 
@@ -159,6 +171,14 @@ srca_read() {
 	return 2
 }
 
+srca_read_local() {
+	local ROUTE="`$CMDSHOW_LOCAL`" || errorexit "command '$CMDSHOW' failed"
+	local SRCIP=`echo $ROUTE | sed -n "s/$MATCHROUTE/\3/p"`
+	[ -z "$SRCIP" ] && return 1
+	[ $SRCIP = $1 ] && return 0
+	return 2
+}
+
 #
 #	Add (or change if it already exists) the preferred source address
 #	The exit code should conform to LSB exit codes.
@@ -177,7 +197,14 @@ srca_start() {
 
 		$CMDCHANGE $ROUTE_WO_SRC src $1 || \
 			errorexit "command '$CMDCHANGE $ROUTE_WO_SRC src $1' failed"
+
 		rc=$?
+
+		if ocf_is_true "$OCF_RESKEY_update_local_route"; then
+			$CMDCHANGE_LOCAL $1 dev $INTERFACE proto kernel scope host src $1 || \
+				errorexit "command '$CMDCHANGE_LOCAL $1 dev $INTERFACE proto kernel scope host src $1' failed"
+			rc=$?
+		fi
 	fi
 
 	return $rc
@@ -210,20 +237,48 @@ srca_stop() {
 	$CMDCHANGE $ROUTE_WO_SRC || \
 		errorexit "command '$CMDCHANGE $ROUTE_WO_SRC' failed"
 
-	return $?
+	rc=$?
+
+	if ocf_is_true "$OCF_RESKEY_update_local_route"; then
+		$CMDCHANGE_LOCAL $1 dev $INTERFACE proto kernel scope host src $PRIMARY_IP || \
+			errorexit "command '$CMDCHANGE_LOCAL $1 dev $INTERFACE proto kernel scope host src $PRIMARY_IP' failed"
+		rc=$?
+	fi
+
+	return $rc
 }
 
 srca_status() {
 	srca_read $1
 
 	case $? in
+		0)	;;
+
+		1)	echo "No preferred source address defined for default route"
+			return $OCF_NOT_RUNNING;;
+
+		2)	echo "Preferred source address has incorrect value for default route"
+			return $OCF_ERR_GENERIC;;
+
+		*)	echo "Unknown error for default route"
+			return $OCF_ERR_GENERIC;;
+	esac
+
+	if ocf_is_true "$OCF_RESKEY_update_local_route"; then
+		srca_read_local $1
+	fi
+
+	case $? in
 		0)	echo "OK"
 			return $OCF_SUCCESS;;
 
-		1)	echo "No preferred source address defined"
+		1)	echo "No preferred source address defined for local route"
 			return $OCF_NOT_RUNNING;;
 
-		2)	echo "Preferred source address has incorrect value"
+		2)	echo "Preferred source address has incorrect value for local route"
+			return $OCF_ERR_GENERIC;;
+
+		*)	echo "Unknown error for local route"
 			return $OCF_ERR_GENERIC;;
 	esac
 }
@@ -473,7 +528,8 @@ rc=$?
 }
 
 INTERFACE=`echo $findif_out | awk '{print $1}'`
-NETWORK=`ip route list dev $INTERFACE scope link proto kernel match $ipaddress|grep -o '^[^ ]*'`
+NETWORK=`$IP2UTIL route list dev $INTERFACE scope link proto kernel match $ipaddress | grep -o '^[^ ]*'`
+PRIMARY_IP=`$IP2UTIL -o -f inet addr show dev $INTERFACE primary | awk '{print $4}' | cut -d/ -f1`
 
 case $1 in
 	start)		srca_start $ipaddress


### PR DESCRIPTION
Currently, the IPsrcaddr resource agent updates the default route to
use a specified IP address (`OCF_RESKEY_ipaddress`) as the preferred
source IP. It does not make any changes to the local route table.

This patch adds an "update_local_route" boolean attribute
(default=false), which updates the local route for destination
`$OCF_RESKEY_ipaddress` to use `src $OCF_RESKEY_ipaddress`.

#### Rationale
`IPsrcaddr` is often paired with `IPaddr2` to provide a virtual IP
address and then use that virtual IP as the preferred source IP for
outgoing connections on the default route. Some applications make local
connections to the virtual IP address. A subset of those require
that the source IP for the connection be the virtual IP.

In other words, the local connection in these cases needs to be:
```
    virtual_ip -> virtual_ip
```

However, this is what is occurring:
```
    primary_ip -> virtual_ip
```

The local routing table determines the source IP for these connections.
For routes in the local routing table, the default src IP address has
always been the primary IP address of the interface. After adding an
`IPaddr2` resource, there will be a local route like this:

```
# ip route show table local to exact <virtual_ip>
local <virtual_ip> dev <iface> proto kernel scope host src <primary_ip>
```

The IPsrcaddr resource agent needs to be able to update the local route
to `OCF_RESKEY_ipaddress` in addition to updating the default route.