### PR TITLE
SAPInstance improvements 2018/05 (1/4) - move logging in abnormal_end()

### DIFF
--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -294,13 +294,13 @@ abnormal_end() {
     exit $?
   }
 
+  ocf_log err $err_msg
   if [ "$ACTION" = "stop" ]
   then
     cleanup_instance
     exit $OCF_SUCCESS
   fi
 
-  ocf_log err $err_msg
   exit $OCF_ERR_CONFIGURED
 }
 


### PR DESCRIPTION
move logging when we detect missing binaries earlier to see that this was issue even during 'stop' action