### PR TITLE
SAPInstance improvements 2018/05 (2/4) - make missing binaries on Slave non-fatal issue

### DIFF
--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -301,7 +301,7 @@ abnormal_end() {
   fi
 
   ocf_log err $err_msg
-  exit $OCF_ERR_CONFIGURED
+  exit $OCF_ERR_INSTALLED
 }
 
 #


### PR DESCRIPTION
make exit in abnormal_end() function not 'fatal' but only 'hard' so this
affects only node on which the issue occurred and not all nodes.
This should allow the node running Master to survive failure of resource
on node running Slave when it reaches the abnormal_end() function.