### PR TITLE
SAPInstance improvements 2018/05 (3/4) - detect binaries in M/S resource from both ASCS/ERS instance

### DIFF
--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -316,6 +316,11 @@ sapinstance_init() {
   InstanceName=`echo "$myInstanceName" | cut -d_ -f2`
   InstanceNr=`echo "$InstanceName" | sed 's/.*\([0-9][0-9]\)$/\1/'`
   SAPVIRHOST=`echo "$myInstanceName" | cut -d_ -f3`
+  if [ ! -z "$OCF_RESKEY_ERS_InstanceName" ]
+  then
+	ERSInstanceName=`echo $OCF_RESKEY_ERS_InstanceName| cut -d_ -f2`
+	ASCSInstanceName=`echo $OCF_RESKEY_InstanceName| cut -d_ -f2`
+  fi
 
   # optional OCF parameters, we try to guess which directories are correct
   if  [ -z "$OCF_RESKEY_DIR_EXECUTABLE" ]
@@ -330,6 +335,16 @@ sapinstance_init() {
       DIR_EXECUTABLE="/usr/sap/$SID/SYS/exe/run"
       SAPSTARTSRV="/usr/sap/$SID/SYS/exe/run/sapstartsrv"
       SAPCONTROL="/usr/sap/$SID/SYS/exe/run/sapcontrol"
+    elif [ ! -z "$ERSInstanceName" ] && have_binary /usr/sap/$SID/$ERSInstanceName/exe/sapstartsrv && have_binary /usr/sap/$SID/$ERSInstanceName/exe/sapcontrol
+    then
+      DIR_EXECUTABLE="/usr/sap/$SID/$ERSInstanceName/exe"
+      SAPSTARTSRV="/usr/sap/$SID/$ERSInstanceName/exe/sapstartsrv"
+      SAPCONTROL="/usr/sap/$SID/$ERSInstanceName/exe/sapcontrol"
+    elif [ ! -z "$ASCSInstanceName" ] && have_binary /usr/sap/$SID/$ASCSInstanceName/exe/sapstartsrv && have_binary /usr/sap/$SID/$ASCSInstanceName/exe/sapcontrol
+    then
+      DIR_EXECUTABLE="/usr/sap/$SID/$ASCSInstanceName/exe"
+      SAPSTARTSRV="/usr/sap/$SID/$ASCSInstanceName/exe/sapstartsrv"
+      SAPCONTROL="/usr/sap/$SID/$ASCSInstanceName/exe/sapcontrol"
     fi
   else
     if have_binary "$OCF_RESKEY_DIR_EXECUTABLE/sapstartsrv" && have_binary "$OCF_RESKEY_DIR_EXECUTABLE/sapcontrol"


### PR DESCRIPTION
When we have $OCF_RESKEY_ERS_InstanceName defined then we can use the
binaries from both ASCS and ERS instance.
This gives us one more place where we can autodetect the needed
binaries before giving up.