### PR TITLE
SAPInstance improvements 2018/05 (4/4) - clear $DIR_EXECUTABLE variable between runs of sapinstance_init

### DIFF
--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -356,6 +356,8 @@ sapinstance_init() {
   InstanceNr=`echo "$InstanceName" | sed 's/.*\([0-9][0-9]\)$/\1/'`
   SAPVIRHOST=`echo "$myInstanceName" | cut -d_ -f3`
 
+  # make sure that we don't care the content of variable from previous run of sapinstance_init
+  DIR_EXECUTABLE=""
   # optional OCF parameters, we try to guess which directories are correct
   if  [ -z "$OCF_RESKEY_DIR_EXECUTABLE" ]
   then


### PR DESCRIPTION
Clear out the $DIR_EXECUTABLE variable so we catch the situation when we
lose the directory with binaries after first sapinstance_init
invocation. The second sapinstance_init invocation will not detect it as
it will have already preset the $DIR_EXECUTABLE from previous run.
This may allow us running actions after second sapinstance_init
invocation that would be not run if we knew that we miss the needed
binaries.

This affect the following functions/operations:
- sapinstance_monitor_clone
- sapinstance_promote_clone
- sapinstance_demote_clone

This is limited to only Master/Slave resource and only when the
sapinstance_init is invoked multiple times during one operation.