### PR TITLE
Medium: pgsql: Fix incorrect SQL is selected with PostgreSQL 11 or later

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1954,7 +1954,8 @@ pgsql_validate_all() {
 
     if use_replication_slot; then
         ocf_version_cmp "$version" "9.4"
-        if [ $? -eq 0 -o $? -eq 3 ]; then
+        rc=$?
+        if [ $rc -eq 0 ]||[ $rc -eq 3 ]; then
             ocf_exit_reason "Replication slot needs PostgreSQL 9.4 or higher."
             return $OCF_ERR_CONFIGURED
         fi

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1811,6 +1811,7 @@ pgsql_validate_all() {
     local check_config_rc
     local rep_mode_string
     local socket_directories
+    local rc
 
     version=`cat $OCF_RESKEY_pgdata/PG_VERSION`
 
@@ -1895,7 +1896,8 @@ pgsql_validate_all() {
         CHECK_MS_SQL="select pg_is_in_recovery()"
         CHECK_SYNCHRONOUS_STANDBY_NAMES_SQL="show synchronous_standby_names"
         ocf_version_cmp "$version" "10"
-        if [ $? -eq 1 ] || [ $? -eq 2 ]; then
+        rc=$?
+        if [ $rc -eq 1 ]||[ $rc -eq 2 ]; then
             CHECK_XLOG_LOC_SQL="select pg_last_wal_replay_lsn(),pg_last_wal_receive_lsn()"
         else
             CHECK_XLOG_LOC_SQL="select pg_last_xlog_replay_location(),pg_last_xlog_receive_location()"


### PR DESCRIPTION
When  the return value of `ocf_version_cmp()` is `2` the right `test` command does not match because the  `$?` is replaced to the result of left test  command.
As a result incorrect SQL statement (i.e. pg_last_xlog*) is selected and fail to promote with PostgreSQL 11 or later.