### PR TITLE
SAPDatabase: Add ability to specify extra arguments for SAPHostAgent functions (2/2)

### DIFF
--- a/heartbeat/SAPDatabase
+++ b/heartbeat/SAPDatabase
@@ -186,6 +186,11 @@ Usually you can leave this empty. Then the default: /usr/sap/hostctrl/exe is use
   <shortdesc lang="en">path to a post-start script</shortdesc>
   <content type="string" default="" />
  </parameter>
+ <parameter name="SAPHOSTAGENT_EXTRA_ARGUMENTS" unique="0" required="0">
+  <longdesc lang="en">Extra arguments for SAPHostAgent's StartDatabase/StopDatabase/GetDatabaseStatus functions that may be needed (for example by LiveCache)</longdesc>
+  <shortdesc lang="en">Extra arguments for SAPHostAgent's StartDatabase/StopDatabase/GetDatabaseStatus functions</shortdesc>
+  <content type="string" default="" />
+ </parameter>
 </parameters>
 
 <actions>

--- a/heartbeat/sapdb.sh
+++ b/heartbeat/sapdb.sh
@@ -136,7 +136,7 @@ sapdatabase_start() {
     then
       DBOSUSER="-dbuser $OCF_RESKEY_DBOSUSER "
     fi
-    output=`$SAPHOSTCTRL -function StartDatabase -dbname $SID -dbtype $DBTYPE $DBINST $DBOSUSER $FORCE -service`
+    output=`$SAPHOSTCTRL -function StartDatabase -dbname $SID -dbtype $DBTYPE $DBINST $DBOSUSER $OCF_RESKEY_SAPHOSTAGENT_EXTRA_ARGUMENTS $FORCE -service`
 
     sapdatabase_monitor 1
     rc=$?
@@ -178,7 +178,7 @@ sapdatabase_stop() {
     then
       DBOSUSER="-dbuser $OCF_RESKEY_DBOSUSER "
     fi
-    output=`$SAPHOSTCTRL -function StopDatabase -dbname $SID -dbtype $DBTYPE $DBINST $DBOSUSER -force -service`
+    output=`$SAPHOSTCTRL -function StopDatabase -dbname $SID -dbtype $DBTYPE $DBINST $DBOSUSER $OCF_RESKEY_SAPHOSTAGENT_EXTRA_ARGUMENTS -force -service`
 
     if [ $? -eq 0 ]
     then
@@ -224,7 +224,7 @@ sapdatabase_monitor() {
       then
         DBOSUSER="-dbuser $OCF_RESKEY_DBOSUSER "
       fi
-      output=`$SAPHOSTCTRL -function GetDatabaseStatus -dbname $SID -dbtype $DBTYPE $DBINST $DBOSUSER`
+      output=`$SAPHOSTCTRL -function GetDatabaseStatus -dbname $SID -dbtype $DBTYPE $DBINST $DBOSUSER $OCF_RESKEY_SAPHOSTAGENT_EXTRA_ARGUMENTS`
 
       # we have to parse the output, because the returncode doesn't tell anything about the instance status
       for SERVICE in `echo "$output" | grep -i 'Component[ ]*Name *[:=] [A-Za-z][A-Za-z0-9_]* (' | sed 's/^.*Component[ ]*Name *[:=] *\([A-Za-z][A-Za-z0-9_]*\).*$/\1/i'`


### PR DESCRIPTION
Hi, 
Currently for functions StartDatabase/StopDatabase/GetDatabaseStatus
so this can support LiveCache instances that require additional
arguments to be passed to SAPHostAgent in order to connect properly
to LiveCache instance as described in the SAP Note 1927600.

Additional note: I would like to also have ability to hide some of the arguments  - for example by providing them via file/script instead of directly specifying them in resource agent. This is not part of this PR but a questions that I would like to incorporate here for future changes. Would that make sense?