### PR TITLE
ra-dev-guide: update instructions for GitHub

### DIFF
--- a/doc/dev-guides/ra-dev-guide.asc
+++ b/doc/dev-guides/ra-dev-guide.asc
@@ -1956,11 +1956,14 @@ repository hosted on
 https://github.com/ClusterLabs/resource-agents[the ClusterLabs
 repository on GitHub], please follow the steps outlined in this section.
 
-Create a working copy (a Git _clone_) of the upstream repository
-with the following command:
+Create a fork of the
+https://github.com/ClusterLabs/resource-agents[upstream repository] and
+clone it with the following commands:
 
 --------------------------------------------------------------------------
-git clone git://github.com/ClusterLabs/resource-agents
+git clone git://github.com/<your-username>/resource-agents
+git remote add upstream git@github.com:ClusterLabs/resource-agents.git
+git checkout -b <new-branch>
 --------------------------------------------------------------------------
 
 Then, copy your resource agent into the +heartbeat+ subdirectory:
@@ -2000,24 +2003,24 @@ It supports being configured as a primitive or as a master/slave set,
 and also optionally supports superfrobnication.
 --------------------------------------------------------------------------
 
-Now the patch set is good for review on the mailing list:
+Now push the patch set to GitHub:
 --------------------------------------------------------------------------
-git send-email --to=linux-ha-dev@lists.linux-ha.org
+git push
 --------------------------------------------------------------------------
 
-+git send-email+ will now roll all local commits not in the upstream
-repository into a nicely formatted email, and submit that to the
-mailing list. Please consult +man git-send-email+ for details on
-configuring and using +git send-email+.
+Create a Pull Request (PR) on Github that will be reviewed by the
+upstream developers.
 
 Once your new resource agent has been accepted for merging, one of the
-upstream developers will push your patch into the upstream
-repository. At that point, you can update your checkout from upstream,
-and remove your own patch set.
+upstream developers will Merge the Pull Request into the upstream
+repository. At that point, you can update your master branch from
+upstream, and remove your own branch.
 
 --------------------------------------------------------------------------
-git reset --hard origin/master
-git pull
+git checkout master
+git fetch upstream
+git merge upstream/master
+git branch -D <branch>
 --------------------------------------------------------------------------
 
 === Maintaining resource agents


### PR DESCRIPTION
Thanks to @helen-fornazier for pointing out our instructions needed an update in:
https://github.com/ClusterLabs/resource-agents/pull/1167