### PR TITLE
Mid: IPaddr2: Change return code.

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -589,7 +589,7 @@ add_interface () {
 		arping -q -c 2 -w 3 -D -I $iface $ipaddr
 		if [ $? = 1 ]; then
 			ocf_log err "IPv4 address collision $ipaddr [DAD]"
-			return $OCF_ERR_CONFIGURED
+			return $OCF_ERR_GENERIC
 		fi
 	fi
 


### PR DESCRIPTION
Hi All,

Correct the return value of IPaddr2.
This content corresponds to the next issue.

 - https://github.com/ClusterLabs/resource-agents/issues/1163

Best Regards,
Hideo Yamauchi.