### PR TITLE
gcp-vpc-move-vip.in: filter call to aggregatedList

### DIFF
--- a/heartbeat/gcp-vpc-move-vip.in
+++ b/heartbeat/gcp-vpc-move-vip.in
@@ -169,7 +169,8 @@ def get_localhost_alias():
 
 
 def get_zone(project, instance):
-  request = CONN.instances().aggregatedList(project=project)
+  fl = 'name="%s"' % instance
+  request = CONN.instances().aggregatedList(project=project, filter=fl)
   while request is not None:
     response = request.execute()
     zones = response.get('items', {})


### PR DESCRIPTION
Don't list all the instances in the project, filter only the one we are
interested in.