### PR TITLE
 SAPInstance: implemeted reload method

### DIFF
--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -61,7 +61,7 @@ sapinstance_usage() {
 	The 'monitor' operation reports whether the instance seems to be working
 	The 'promote' operation starts the primary instance in a Master/Slave configuration
 	The 'demote' operation stops the primary instance and starts the ERS instance
-    The 'reload' operation allows changed parameters (non-unique only) without restarting the service
+	The 'reload' operation allows changed parameters (non-unique only) without restarting the service
 	The 'notify' operation always returns SUCCESS
 	The 'validate-all' operation reports whether the parameters are valid
 	The 'methods' operation reports on the methods $0 supports
@@ -246,7 +246,7 @@ sapinstance_methods() {
 	monitor
         promote
         demote
-    reload
+	reload
         notify
 	validate-all
 	methods
@@ -969,8 +969,8 @@ case "$ACTION" in
   validate-all)                           sapinstance_validate
                                           exit $?;;
   reload )
-                     ocf_log info "reloading SAPInstance parameters"
-                     exit $OCF_SUCCESS;;
+                                          ocf_log info "reloading SAPInstance parameters"
+                                          exit $OCF_SUCCESS;;
   *)                                      sapinstance_methods
                                           exit $OCF_ERR_UNIMPLEMENTED;;
 esac

--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -61,6 +61,7 @@ sapinstance_usage() {
 	The 'monitor' operation reports whether the instance seems to be working
 	The 'promote' operation starts the primary instance in a Master/Slave configuration
 	The 'demote' operation stops the primary instance and starts the ERS instance
+    The 'reload' operation allows changed parameters (non-unique only) without restarting the service
 	The 'notify' operation always returns SUCCESS
 	The 'validate-all' operation reports whether the parameters are valid
 	The 'methods' operation reports on the methods $0 supports
@@ -224,6 +225,7 @@ The name of the SAP START profile. Specify this parameter, if you have changed t
 <action name="monitor" depth="0" timeout="60s" interval="119s" role="Master" />
 <action name="promote" timeout="320s" />
 <action name="demote" timeout="320s" />
+<action name="reload" timeout="320" />
 <action name="validate-all" timeout="5s" />
 <action name="meta-data" timeout="5s" />
 <action name="methods" timeout="5s" />
@@ -244,6 +246,7 @@ sapinstance_methods() {
 	monitor
         promote
         demote
+    reload
         notify
 	validate-all
 	methods
@@ -965,6 +968,9 @@ case "$ACTION" in
                                           exit $?;;
   validate-all)                           sapinstance_validate
                                           exit $?;;
+  reload )
+                     ocf_log info "reloading SAPInstance parameters"
+                     exit $OCF_SUCCESS;;
   *)                                      sapinstance_methods
                                           exit $OCF_ERR_UNIMPLEMENTED;;
 esac


### PR DESCRIPTION
The reload method is needed to avoid resource restarts after a non-unique parameter has been changed. This is in special for interest of the MONITOR_SERVICES parameter.