### PR TITLE
SAPInstance: Improved SAP instance profile detection

### DIFF
--- a/heartbeat/SAPInstance
+++ b/heartbeat/SAPInstance
@@ -371,7 +371,11 @@ sapinstance_init() {
 
   if [ -z "$currentSTART_PROFILE" ]
   then
-    SAPSTARTPROFILE="$DIR_PROFILE/START_${InstanceName}_${SAPVIRHOST}"
+    if [ ! -r "$DIR_PROFILE/START_${InstanceName}_${SAPVIRHOST}" -a -r "$DIR_PROFILE/${SID}_${InstanceName}_${SAPVIRHOST}" ]; then
+      SAPSTARTPROFILE="$DIR_PROFILE/${SID}_${InstanceName}_${SAPVIRHOST}"
+    else
+      SAPSTARTPROFILE="$DIR_PROFILE/START_${InstanceName}_${SAPVIRHOST}"
+    fi
   else
     SAPSTARTPROFILE="$currentSTART_PROFILE"
   fi


### PR DESCRIPTION
SAPInstance has been initially written for NetWeaver 6.x and 7.0. In these times SAP instances have had a START_xx profile and a <SID>_xx parameter profile. Beginning with SAP NetWeaver 7.1 or 7.2 SAP removed the START_xx profile and added the content to the <SID>_xx parameter profile.
Since that change the automated detection of the start-profile failed and each cluster needed to use
the parameter setting for START_PROFILE. 
The given patch re-implements the automated profile detection. While the START_xx profile is still preferred to be backward compatible, SAP installations without an outdated START_xx profile could
now be detected via the <SID>_xx profile.