### PR TITLE
ipsec: Add tunnel fallback option

### DIFF
--- a/heartbeat/ipsec
+++ b/heartbeat/ipsec
@@ -109,7 +109,7 @@ END
 
 ipsec_start() {
 	ipsec auto --add "${OCF_RESKEY_tunnel}"
-	ipsec whack --listen &>> /tmp/ipsec-agent.log
+	ipsec whack --listen
 	local return_code=$?
 	if [ $return_code -eq  1 -o $return_code -eq 10 ]; then
 		ocf_log warn "${OCF_RESOURCE_INSTANCE} : Unable to add tunnel ${OCF_RESKEY_tunnel} with return code ${return_code}"
@@ -123,7 +123,7 @@ ipsec_stop() {
 	ipsec auto --down "${OCF_RESKEY_tunnel}"
 	local return_code=$?
 	ocf_log info "${OCF_RESOURCE_INSTANCE} : Put down tunnel ${OCF_RESKEY_tunnel} with return code ${return_code}"
-	ipsec whack --listen &>> /tmp/ipsec-agent.log
+	ipsec whack --listen
 	if [ -n "${OCF_RESKEY_fallbacktunnel}" ]; then
 		# Run this in a subshell and let it run, This will end the stop
 		# operation And the start of the tunnel will hopefully start on the

--- a/heartbeat/ipsec
+++ b/heartbeat/ipsec
@@ -75,6 +75,13 @@ The directory where the IPSEC tunnel configurations can be found.
 <shortdesc lang="en">Tunnel name</shortdesc>
 <content type="string" default="${OCF_RESKEY_confdir_default}" />
 </parameter>
+<parameter name="fallbacktunnel" unique="1">
+<longdesc lang="en">
+The name of the tunnel to fall back to when the main tunnel is put down.
+</longdesc>
+<shortdesc lang="en">Tunnel name to fall back to</shortdesc>
+<content type="string" default="" />
+</parameter>
 </parameters>
 
 <actions>
@@ -116,6 +123,16 @@ ipsec_stop() {
 	ipsec auto --down "${OCF_RESKEY_tunnel}"
 	local return_code=$?
 	ocf_log info "${OCF_RESOURCE_INSTANCE} : Put down tunnel ${OCF_RESKEY_tunnel} with return code ${return_code}"
+	ipsec whack --listen &>> /tmp/ipsec-agent.log
+	if [ -n "${OCF_RESKEY_fallbacktunnel}" ]; then
+		# Run this in a subshell and let it run, This will end the stop
+		# operation And the start of the tunnel will hopefully start on the
+		# other node. Meanwhile, this will keep trying to put up the
+		# fallback tunnel up, and will eventually succeed or timeout in the
+		# background.
+		(ipsec auto --up "${OCF_RESKEY_fallbacktunnel}") &
+		disown
+	fi
 	return $OCF_SUCCESS
 }
 


### PR DESCRIPTION
This option makes brings up a fallback tunnel if the main tracked tunnel
goes down. This is useful for when there is a failover in the VIP (which
is our main tunnel), and then we need to establish a tunnel to the new
node that has the VIP.

The fallback mechanism is a little bit hacky, but it's the only way I
could get it to work... basically it's put up in a background process,
which will keep trying retry putting up the fallback node. Meanwhile,
the resource agent will keep doing its job and put up the main node on
the host that received the VIP. eventually, a retry on the original node
will bring up the fallback tunnel.