### PR TITLE
pgsql: create replication slots after promoting master

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -699,15 +699,6 @@ pgsql_promote() {
     touch $PGSQL_LOCK
     show_master_baseline
 
-    # create replication slots on master before promotion
-    if use_replication_slot; then
-        create_replication_slots
-        if [ $? -eq $OCF_ERR_GENERIC ]; then
-            ocf_exit_reason "PostgreSQL can't create replication_slot."
-            return $OCF_ERR_GENERIC
-        fi
-    fi
-
     if ocf_is_true ${OCF_RESKEY_restart_on_promote}; then
         ocf_log info "Restarting PostgreSQL instead of promote."
         #stop : this function returns $OCF_SUCCESS only.
@@ -745,6 +736,15 @@ pgsql_promote() {
             ocf_log debug "PostgreSQL still hasn't promoted yet. Waiting..."
         done
         ocf_log info "PostgreSQL is promoted."
+    fi
+
+    # create replication slots on master after promotion
+    if use_replication_slot; then
+	create_replication_slots
+	if [ $? -eq $OCF_ERR_GENERIC ]; then
+	    ocf_exit_reason "PostgreSQL can't create replication_slot."
+	    return $OCF_ERR_GENERIC
+	fi
     fi
 
     change_data_status "$NODENAME" "LATEST"


### PR DESCRIPTION
A PostgreSQL instance can be promoted to master either with or without a
restart of the PostgreSQL service. When restart_on_promote=false
creation of replication slots works correctly, but with
restart_on_promote=true the replication slots are created upon promoting
the master (in pgsql_promote()) but they are deleted shortly afterwards
when PostgreSQL is restarted (in pgsql_real_start()).

This results in the slave node failing with an error indicating that it
cannot find the specified replication slot, because, indeed, no such
replication slot exists after it is deleted.

This change fixes that problem by moving the creation of replication
slots to a point in time *after* the PostgreSQL instance has been
promoted to master and thus after the service has been restarted if
restart_on_promote=true.

This will allow the slave to find and connect to the specified
replication slot after master has been promoted.

See thread in
https://github.com/ClusterLabs/resource-agents/pull/956#issuecomment-329899579
for a brief discussion.

Fixes #1056.