### PR TITLE
Xen: Set utilization for cpu and hv_memory

### DIFF
--- a/heartbeat/Xen
+++ b/heartbeat/Xen
@@ -275,16 +275,15 @@ set_util_attr() {
 
 	cval=$(crm_resource -Q -r $OCF_RESOURCE_INSTANCE -z -g $attr 2>/dev/null)
 	if [ $? -ne 0 ] && [ -z "$cval" ]; then
-		crm_resource -Q -r $OCF_RESOURCE_INSTANCE -z -g $attr 2>&1 | grep -e "not connected" > /dev/null 2>&1
-		if [ $? -eq 0 ]; then
-			ocf_log debug "Unable to set utilization attribute, cib is not available"
+		if crm_resource -Q -r $OCF_RESOURCE_INSTANCE -z -g $attr 2>&1 | grep -q "not connected"; then
+			ocf_log debug "Unable to get utilization attribute $attr: cib is not available"
 			return
 		fi
 	fi
 
 	if [ "$cval" != "$val" ]; then
-		outp=$(crm_resource -r $OCF_RESOURCE_INSTANCE -z -p $attr -v $val 2>&1) ||
-		ocf_log warn "crm_resource failed to set utilization attribute $attr: $outp"
+		outp=$(crm_resource -r $OCF_RESOURCE_INSTANCE -z -p $attr -v $val 2>&1) || \
+		ocf_log warn "Unable to set utilization attribute $attr: $outp"
 	fi
 }
 

--- a/heartbeat/Xen
+++ b/heartbeat/Xen
@@ -43,6 +43,8 @@ END
 : ${OCF_RESKEY_shutdown_acpi=0}
 : ${OCF_RESKEY_allow_mem_management=0}
 : ${OCF_RESKEY_reserved_Dom0_memory=512}
+: ${OCF_RESKEY_autoset_utilization_cpu="true"}
+: ${OCF_RESKEY_autoset_utilization_hv_memory="true"}
 
 # prefer xl
 xentool=$(which xl 2> /dev/null || which xm)
@@ -156,6 +158,25 @@ for the dom0. The default minimum memory is 512MB.
 <shortdesc lang="en">Minimum Dom0 memory</shortdesc>
 <content type="string" default="512" />
 </parameter>
+
+<parameter name="autoset_utilization_cpu" unique="0" required="0">
+<longdesc lang="en">
+If set true, the agent will detect the number of domain's vCPUs from Xen, and put it
+into the CPU utilization of the resource when the monitor is executed.
+</longdesc>
+<shortdesc lang="en">Enable auto-setting the CPU utilization of the resource</shortdesc>
+<content type="boolean" default="true" />
+</parameter>
+
+<parameter name="autoset_utilization_hv_memory" unique="0" required="0">
+<longdesc lang="en">
+If set true, the agent will detect the number of memory from Xen, and put it
+into the hv_memory utilization of the resource when the monitor is executed.
+</longdesc>
+<shortdesc lang="en">Enable auto-setting the hv_memory utilization of the resource</shortdesc>
+<content type="boolean" default="true" />
+</parameter>
+
 <parameter name="monitor_scripts" unique="0" required="0">
 <longdesc lang="en">
 To additionally monitor services within the unprivileged domain,
@@ -248,6 +269,45 @@ Xen_Status_with_Retry() {
 	return $rc
 }
 
+set_util_attr() {
+	local attr=$1 val=$2
+	local cval outp
+
+	cval=$(crm_resource -Q -r $OCF_RESOURCE_INSTANCE -z -g $attr 2>/dev/null)
+	if [ $? -ne 0 ] && [ -z "$cval" ]; then
+		crm_resource -Q -r $OCF_RESOURCE_INSTANCE -z -g $attr 2>&1 | grep -e "not connected" > /dev/null 2>&1
+		if [ $? -eq 0 ]; then
+			ocf_log debug "Unable to set utilization attribute, cib is not available"
+			return
+		fi
+	fi
+
+	if [ "$cval" != "$val" ]; then
+		outp=$(crm_resource -r $OCF_RESOURCE_INSTANCE -z -p $attr -v $val 2>&1) ||
+		ocf_log warn "crm_resource failed to set utilization attribute $attr: $outp"
+	fi
+}
+
+Xen_Update_Utilization() {
+	local dom_status dom_cpu dom_mem
+
+	if ocf_is_true "$OCF_RESKEY_autoset_utilization_cpu" || \
+	   ocf_is_true "$OCF_RESKEY_autoset_utilization_hv_memory"
+	then
+		dom_status=$($xentool list ${DOMAIN_NAME} | awk 'NR==2 {print $4, $3}')
+	fi
+
+	if ocf_is_true "$OCF_RESKEY_autoset_utilization_cpu"; then
+		dom_cpu=${dom_status% *}
+		test -n "$dom_cpu" && set_util_attr cpu $dom_cpu
+	fi
+
+	if ocf_is_true "$OCF_RESKEY_autoset_utilization_hv_memory"; then
+		dom_mem=${dom_status#* }
+		test -n "$dom_mem" && set_util_attr hv_memory "$dom_mem"
+	fi
+}
+
 Xen_Adjust_Memory() {
 	if ocf_is_true "${OCF_RESKEY_allow_mem_management}"; then
 		CNTNEW=$1
@@ -294,6 +354,7 @@ Xen_Monitor() {
 		ocf_log err "Xen domain $DOMAIN_NAME stopped"
 		return ${OCF_NOT_RUNNING}
 	fi
+	Xen_Update_Utilization
 	if [ "X${OCF_RESKEY_monitor_scripts}" = "X" ]; then
 		return ${OCF_SUCCESS}
 	fi

--- a/heartbeat/Xen
+++ b/heartbeat/Xen
@@ -290,11 +290,7 @@ set_util_attr() {
 Xen_Update_Utilization() {
 	local dom_status dom_cpu dom_mem
 
-	if ocf_is_true "$OCF_RESKEY_autoset_utilization_cpu" || \
-	   ocf_is_true "$OCF_RESKEY_autoset_utilization_hv_memory"
-	then
-		dom_status=$($xentool list ${DOMAIN_NAME} | awk 'NR==2 {print $4, $3}')
-	fi
+	dom_status=$($xentool list ${DOMAIN_NAME} | awk 'NR==2 {print $4, $3}')
 
 	if ocf_is_true "$OCF_RESKEY_autoset_utilization_cpu"; then
 		dom_cpu=${dom_status% *}
@@ -353,7 +349,11 @@ Xen_Monitor() {
 		ocf_log err "Xen domain $DOMAIN_NAME stopped"
 		return ${OCF_NOT_RUNNING}
 	fi
-	Xen_Update_Utilization
+	if ocf_is_true "$OCF_RESKEY_autoset_utilization_cpu" || \
+	   ocf_is_true "$OCF_RESKEY_autoset_utilization_hv_memory"
+	then
+		Xen_Update_Utilization
+	fi
 	if [ "X${OCF_RESKEY_monitor_scripts}" = "X" ]; then
 		return ${OCF_SUCCESS}
 	fi


### PR DESCRIPTION
Set resource utilization attributes in the monitor
action like it is done for KVM in VirtualDomain agent.