### PR TITLE
aws-vpc-move-ip: Fix broken shell quoting

### DIFF
--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -167,9 +167,9 @@ ec2ip_monitor() {
 		ocf_log debug "monitor: Enhanced Monitoring disabled - omitting API call"
 	fi
 
-	cmd="ip addr show to '$OCF_RESKEY_ip' up"
+	cmd="ip addr show to $OCF_RESKEY_ip up"
 	ocf_log debug "executing command: $cmd"
-	RESULT=$($cmd | grep '$OCF_RESKEY_ip')
+	RESULT=$($cmd | grep "$OCF_RESKEY_ip")
 	if [ -z "$RESULT" ]; then
 		ocf_log warn "IP $OCF_RESKEY_ip not assigned to running interface"
 		return $OCF_NOT_RUNNING


### PR DESCRIPTION
The argument 4th to `ip` is passed with single quotes around which
cannot be parsed as valid IP address. Furthermore, we need to expand the
$OCF_RESKEY_ip for grep. This breaks correct detection of the assigned
address.

Fixes 7632a85bcf642b484df52a25dbffbfa0031421bc.