### PR TITLE
Filesystem: Support symlink as mountpoint directory

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -580,7 +580,7 @@ Filesystem_stop()
 #
 Filesystem_status()
 {
-	if list_mounts | grep -q " $MOUNTPOINT " >/dev/null 2>&1; then
+	if list_mounts | grep -q " $(readlink -f $MOUNTPOINT) " >/dev/null 2>&1; then
 		rc=$OCF_SUCCESS
 		msg="$MOUNTPOINT is mounted (running)"
 	else


### PR DESCRIPTION
#### Issue
Filesystem monitor operation fails when the `directory` attribute is a
symlink.

The monitor operation calls the `list_mounts` function, which cats
`/proc/mounts` if it exists, else cats `/etc/mtab` if it exists, else
runs the `mount` command. It then greps for `" $MOUNTPOINT "` in the
output, where `$MOUNTPOINT` is the value of the `directory` attribute.

`/proc/mounts`, `/etc/mtab`, and the `mount` command resolve symlinks
to their canonical targets. So while the monitor operation greps for
the symlink path (surrounded by spaces) as defined in the directory
attribute, the symlink will not be present in the `list_mounts` output.
Only the symlink's target will be present.

This patch uses `readlink -f $MOUNTPOINT` to resolve the symlink to its
canonical name before using it as a grep pattern in the
`Filesystem_status` function.

#### Impact
This can cause fencing loops.

- With a single-node filesystem:
  - Filesystem starts.
  - Filesystem monitor operation returns `OCF_NOT_RUNNING`.
  - Filesystem stop operation succeeds, without actually unmounting the filesystem, because its initial status check incorrectly shows that the filesystem is not mounted.
  - Filesystem tries to restart. It fails, because the device is already mounted.
  - Filesystem stop operation succeeds.
  - LVM resource tries to stop so that the resource group can fail over. The stop operation fails because the device is busy.
  - Failed stop operation triggers fencing.
- With a GFS2 filesystem:
  - Filesystem starts.
  - Filesystem monitor operation returns `OCF_NOT_RUNNING`.
  - In a standard GFS2 configuration, the Filesystem resource has `op monitor on-fail=fence`. So the failed monitor operation triggers fencing.

#### Reproducer
1. In a two-node cluster, create the mountpoint and a symlink to the mountpoint on both nodes.
```
    # mkdir /opt/testmnt
    # ln -s /opt/testmnt /testmnt
```

2. Create an LVM resource and format one of the logical volumes.
```
    # pcs resource create cluster_vg LVM volgrpname=cluster_vg exclusive=true --group clusgrp
    # mkfs.xfs /dev/cluster_vg/cluster_lv
```

3. Create a Filesystem resource in Disabled mode (to prevent fencing due to failed LVM stop later), setting the directory attribute to the symlink directory.
```
    # pcs resource create cluster_fs Filesystem device=/dev/cluster_vg/cluster_lv directory=/testmnt fstype=xfs meta target-role=Stopped --group clusgrp
```

4. On the node where the LVM resource is running, debug-start the Filesystem resource.
```
    # pcs resource debug-start cluster_fs --full
    Operation start for cluster_fs (ocf:heartbeat:Filesystem) returned: 'ok' (0)
     >  stderr: INFO: Running start for /dev/cluster_vg/cluster_lv on /testmnt
```

5. Observe that `/proc/mounts` and the `mount` command have resolved the symlink from `/testmnt` to `/opt/testmnt`.
```
    # grep testmnt /proc/mounts
    /dev/mapper/cluster_vg-cluster_lv /opt/testmnt xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0

    # mount | grep testmnt
    /dev/mapper/cluster_vg-cluster_lv on /opt/testmnt type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
```

6. Run debug-monitor and observe that it fails with `OCF_NOT_RUNNING`.
```
    # pcs resource debug-monitor cluster_fs --full
Operation monitor for cluster_fs (ocf:heartbeat:Filesystem) returned: 'not running' (7)
```

7. Unmount the filesystem manually, since debug-stop will detect that it is already stopped.
```
    # umount /dev/cluster_vg/cluster_lv
```

--------------------

Actual results:
```
    # pcs resource debug-monitor cluster_fs --full
Operation monitor for cluster_fs (ocf:heartbeat:Filesystem) returned: 'not running' (7)
```

--------------------

Expected results:
```
    # pcs resource debug-monitor cluster_fs --full
    Operation monitor for cluster_fs (ocf:heartbeat:Filesystem) returned: 'ok' (0)
```