### PR TITLE
pgsql: Avoid the change of /dev/null to postgres owner/group

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1976,7 +1976,7 @@ pgsql_validate_all() {
 #
 
 check_log_file() {
-    if [ ! -f "$1" ]
+    if [ ! -e "$1" ]
     then
         touch $1 > /dev/null 2>&1
         chown $OCF_RESKEY_pgdba:`getent passwd $OCF_RESKEY_pgdba | cut -d ":" -f 4` $1


### PR DESCRIPTION
The check_log_file performs a -f test on the log file which is set to
/dev/null by default and it returns 1 for non-regular files.