### PR TITLE
Mid: apache: Retry pid check.

### DIFF
--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -131,14 +131,32 @@ ProcessRunning() {
 }
 silent_status() {
 	local pid
+	local rc=false
+	local retries=0
 
-	pid=`get_pid`
-	if [ -n "$pid" ]; then
-		ProcessRunning $pid
-	else
-		: No pid file
-		false
+	# Set a retry when apache's Graceful restart is applied and the pid file can not be acquired.
+	if [ "$__OCF_ACTION" = "monitor" ] && ! ocf_is_probe; then
+		retries=5
 	fi
+
+	while true; do
+		pid=`get_pid`
+		if [ -n "$pid" ]; then
+			ProcessRunning $pid
+			rc=$?
+			break
+		fi
+		
+		: No pid file
+		if [ $retries -le 0 ]; then
+			break
+		fi
+
+		sleep 1
+		retries=`expr $retries - 1`
+	done
+
+	return $rc
 }
 
 # May be useful to add other distros in future


### PR DESCRIPTION
Hi All,

The apache's monitor may cause "not runnnig" by graceful restart.
This is because apache shortens the contents of the PID file for a moment when rewriting the PID file at a short time.

It may change in the future, but the previous versions of apache are treated in the same way.

 - httpd-2.2.15-39.el6/ server/log.c
-----------------------------------------------------------------------
    771 AP_DECLARE(void) ap_log_pid(apr_pool_t *p, const char *filename)
    772 {
    773     apr_file_t *pid_file = NULL;
     :
    807     if ((rv = apr_file_open(&pid_file, fname,
    808                             APR_WRITE | APR_CREATE | APR_TRUNCATE,
    809                             APR_UREAD | APR_UWRITE | APR_GREAD | APR_WREAD, p))
    810         != APR_SUCCESS) {
    811         ap_log_error(APLOG_MARK, APLOG_ERR, rv, NULL,
    812                      "could not create %s", fname);
    813         ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
    814                      "%s: could not log pid to file %s",
    815                      ap_server_argv0, fname);
    816         exit(1);
    817     }
    818     apr_file_printf(pid_file, "%ld" APR_EOL_STR, (long)mypid);
    819     apr_file_close(pid_file);
    820     saved_pid = mypid;
    821 }
-----------------------------------------------------------------------

It is a very rare issue, but just in case, it's better to retry checking the PID file.

Best Regards,
Hideo Yamauchi.
