### PR TITLE
Try to enable use of ss wherever netstat is used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ tools/ocft/ocft
 *.upgrade.xml
 py-compile
 ylwrap
+__pycache__
 
 # BEAM Entries
 *.beam

--- a/heartbeat/Squid.in
+++ b/heartbeat/Squid.in
@@ -192,10 +192,17 @@ get_pids()
 	fi
 
 	# Seek by port
-	SQUID_PIDS[2]=$(
-		netstat -apn |
-		awk '/tcp.*:'$SQUID_PORT' .*LISTEN/ && $7~/^[1-9]/ {
-			sub("\\/.*", "", $7); print $7; exit}')
+	if have_binary netstat; then
+		SQUID_PIDS[2]=$(
+			netstat -apn |
+			awk '/tcp.*:'$SQUID_PORT' .*LISTEN/ && $7~/^[1-9]/ {
+				sub("\\/.*", "", $7); print $7; exit}')
+	else
+		SQUID_PIDS[2]=$(
+			ss -apn |
+			awk '/tcp.*LISTEN.*:'$SQUID_PORT'/ {
+				sub(".*pid=", "", $7); sub(",fd=.*", "", $7); print $7 }')
+	fi
 }
 
 are_all_pids_found()

--- a/heartbeat/garbd
+++ b/heartbeat/garbd
@@ -263,6 +263,17 @@ garbd_status()
     fi
 }
 
+_port_by_pid()
+{
+    local pid
+    pid="$1"
+    if have_binary "netstat"; then
+        netstat -tnp 2>/dev/null | grep -s -q "ESTABLISHED.*${pid}/"
+    else
+        ss -Htnp 2>/dev/null | grep -s -q "^ESTAB.*pid=${pid}"
+    fi
+}
+
 garbd_monitor()
 {
     local rc
@@ -289,7 +300,7 @@ garbd_monitor()
     # garbd will always be connected to the right partition
     if [ $rc -eq $OCF_SUCCESS ]; then
         pid=`cat $OCF_RESKEY_pid 2> /dev/null `
-        netstat -tnp 2>/dev/null | grep -s -q "ESTABLISHED.*${pid}/"
+        _port_by_pid $pid
         if [ $? -ne 0 ]; then
             ocf_log $loglevel "garbd disconnected from cluster \"${OCF_RESKEY_wsrep_cluster_name}\""
             rc=$OCF_ERR_GENERIC
@@ -334,8 +345,10 @@ garbd_validate()
     fi
 
     if ! have_binary "netstat"; then
-        ocf_exit_reason "Setup problem: couldn't find command: netstat"
-        return $OCF_ERR_INSTALLED;
+        if ! have_binary "ss"; then
+            ocf_exit_reason "Setup problem: couldn't find command: netstat or ss"
+            return $OCF_ERR_INSTALLED;
+        fi
     fi
 
     if [ -z "$OCF_RESKEY_wsrep_cluster_address" ]; then

--- a/heartbeat/portblock
+++ b/heartbeat/portblock
@@ -278,6 +278,12 @@ tickle_local()
 	[ -z "$OCF_RESKEY_tickle_dir" ] && return
 	f=$OCF_RESKEY_tickle_dir/$OCF_RESKEY_ip
 	[ -r $f ] || return
+
+	checkcmd="netstat -tn"
+	if ! have_binary "netstat"; then
+		checkcmd="ss -Htn"
+	fi
+
 	# swap "local" and "remote" address,
 	# so we tickle ourselves.
 	# We set up a REJECT with tcp-reset before we do so, so we get rid of
@@ -286,11 +292,11 @@ tickle_local()
 	# the way if we switch-over and then switch-back in quick succession.
 	local i
 	awk '{ print $2, $1; }' $f | $TICKLETCP
-	netstat -tn | grep -Fw $OCF_RESKEY_ip || return
+	$checkcmd | grep -Fw $OCF_RESKEY_ip || return
 	for i in 0.1 0.5 1 2 4 ; do
 		sleep $i
 		awk '{ print $2, $1; }' $f | $TICKLETCP
-		netstat -tn | grep -Fw $OCF_RESKEY_ip || break
+		$checkcmd | grep -Fw $OCF_RESKEY_ip || break
 	done
 }
 


### PR DESCRIPTION
So netstat has been deprecated on Linux for a long time, but we still have a lot of agents that need it.

It should be possible to replace any use of netstat with ss.

These commits don't fix all of the uses, but a few.
