### PR TITLE
Add clean shmems/queues/semaphores for sybase user

### DIFF
--- a/heartbeat/sybaseASE.in
+++ b/heartbeat/sybaseASE.in
@@ -437,6 +437,11 @@ ase_start()
 	then
 		rm -f $CONSOLE_LOG
 	fi
+        
+        ocf_log debug "Clean shmems/semaphores/queues for '$OCF_RESKEY_sybase_user'"
+        su $OCF_RESKEY_sybase_user -c ksh << EOF
+		ipcrm -a
+EOF
 
 	ocf_log debug "sybaseASE: Starting '$OCF_RESKEY_server_name'..."
 


### PR DESCRIPTION
Add cleaner to prevent the error when resource failback.