### PR TITLE
nfsserver: mount rpc_pipefs

### DIFF
--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -177,6 +177,8 @@ esac
 fp="$OCF_RESKEY_nfs_shared_infodir"
 : ${OCF_RESKEY_nfs_notify_cmd="$DEFAULT_NOTIFY_CMD"}
 : ${OCF_RESKEY_nfs_notify_foreground="$DEFAULT_NOTIFY_FOREGROUND"}
+: ${OCF_RESKEY_rpcpipefs_dir="$DEFAULT_RPCPIPEFS_DIR"}
+OCF_RESKEY_rpcpipefs_dir=${OCF_RESKEY_rpcpipefs_dir%/}
 
 if [ -z ${OCF_RESKEY_rpcpipefs_dir} ]; then
 	rpcpipefs_make_dir=$fp/rpc_pipefs
@@ -616,6 +618,8 @@ nfsserver_start ()
 	is_redhat_based && set_env_args
 	prepare_directory
 	bind_tree
+
+	mount -t rpc_pipefs sunrpc $OCF_RESKEY_rpcpipefs_dir
 
 	# remove the sm-notify pid so sm-notify will be allowed to run again without requiring a reboot.
 	rm -f /var/run/sm-notify.pid


### PR DESCRIPTION
Without this rpc_pipefs gets unmounted during the stop-action, causing the next start to fail.