### PR TITLE
Do not use the absolute path in redis' pidof calls

### DIFF
--- a/heartbeat/redis.in
+++ b/heartbeat/redis.in
@@ -316,7 +316,7 @@ simple_status() {
 	fi
 
 	pid="$(<"$REDIS_PIDFILE")"
-	pidof "$REDIS_SERVER" | grep -q "\<$pid\>" || return $OCF_NOT_RUNNING
+	pidof $(basename "$REDIS_SERVER") | grep -q "\<$pid\>" || return $OCF_NOT_RUNNING
 
 	ocf_log debug "monitor: redis-server running under pid $pid"
 
@@ -465,7 +465,7 @@ redis_start() {
 			break
 		elif (( info[loading] == 1 )); then
 			sleep "${info[loading_eta_seconds]}"
-		elif pidof "$REDIS_SERVER" >/dev/null; then
+		elif pidof $(basename "$REDIS_SERVER") >/dev/null; then
 			# unknown error, but the process still exists.
 			# This check is mainly because redis daemonizes before it starts listening, causing `redis-cli` to fail
 			#   See https://github.com/antirez/redis/issues/2368


### PR DESCRIPTION
The reason for this is that newer kernels (we saw this on a 4.18 kernel)
can limit access to /proc/<pid>/{cwd,exe,root} and so pidof will fail to
identify the process when using the full path names.
This access limitation happens even with the root user:
()[root@ra1 /]$ ls -l /proc/32/ |grep redis-server
ls: cannot read symbolic link '/proc/32/cwd': Permission denied
ls: cannot read symbolic link '/proc/32/root': Permission denied
ls: cannot read symbolic link '/proc/32/exe': Permission denied

For this reason the 'pidof /usr/bin/redis-server' calls will fail
when running inside containers that have this kernel protection
mechanism.

We tested this change and successfuly obtained a running redis cluster:
 podman container set: redis-bundle [192.168.222.1:5000/redis:latest]
   Replica[0]
      redis-bundle-podman-0     (ocf::heartbeat:podman):        Started ra1
      redis-bundle-0    (ocf::pacemaker:remote):        Started ra1
      redis     (ocf::heartbeat:redis): Master redis-bundle-0
   Replica[1]
      redis-bundle-podman-1     (ocf::heartbeat:podman):        Started ra2
      redis-bundle-1    (ocf::pacemaker:remote):        Started ra2
      redis     (ocf::heartbeat:redis): Slave redis-bundle-1
   Replica[2]
      redis-bundle-podman-2     (ocf::heartbeat:podman):        Started ra3
      redis-bundle-2    (ocf::pacemaker:remote):        Started ra3
      redis     (ocf::heartbeat:redis): Slave redis-bundle-2

Signed-off-By: Damien Ciabrini <dciabrin@redhat.com>
Signed-off-by: Michele Baldessari <michele@acksyn.org>