### PR TITLE
CTDB: fix --logging/--logfile version string comparison

### DIFF
--- a/heartbeat/CTDB.in
+++ b/heartbeat/CTDB.in
@@ -580,7 +580,7 @@ ctdb_start() {
 	local log_option
 	# --logging supported from v4.3.0 and --logfile / --syslog support 
 	# has been removed from newer versions
-	version=$(ctdb version | awk '{print $NF}')
+	version=$(ctdb version | awk '{print $NF}' | sed "s/\.\?[[:alpha:]].*//")
 	ocf_version_cmp "$version" "4.2.14"
 	if [ "$?" -eq "2" ]; then
 		log_option="--logging=file:$OCF_RESKEY_ctdb_logfile"


### PR DESCRIPTION
As per "VERSION" in the Samba/CTDB source tree, versions may have:
- a beta/rc/etc string immediately following the third version
  component
  + e.g. 4.0.0rc1
- a -VENDOR trailer
  + e.g. 4.0.0-VendorVersion
- a .GIT.$sha hash trailers
  + e.g. 4.0.0.GIT.1a2b3c4d

Trim any of these possible strings with sed prior to performing the
--logging/--logfile version comparison.

Fixes: https://github.com/ClusterLabs/resource-agents/issues/1185

Signed-off-by: David Disseldorp <ddiss@suse.de>