### PR TITLE
[Oracle] Modification of Oracle RA.

### DIFF
--- a/heartbeat/oracle
+++ b/heartbeat/oracle
@@ -345,7 +345,7 @@ db_backup_mode() {
 	echo "select 'COUNT'||count(*) from v\$backup where status='ACTIVE';"
 }
 is_clear_backupmode_set(){
-	[ x"${clear_backupmode}" = x"true" ]
+	ocf_is_true "${clear_backupmode}"
 }
 is_instance_in_backup_mode() {
 	local count

--- a/heartbeat/oracle
+++ b/heartbeat/oracle
@@ -645,11 +645,15 @@ oracle_start() {
 
 	# check/create the monitor profile
 	if ! check_mon_profile; then
+		# dbopen was failed if there is any $output
+		[ -n "$output" ] && ocf_exit_reason "oracle $ORACLE_SID can not be opened: $output"
 		return $OCF_ERR_GENERIC
 	fi
 
 	# check/create the monitor user
 	if ! check_mon_user; then
+		# dbopen was failed if there is any $output
+		[ -n "$output" ] && ocf_exit_reason "oracle $ORACLE_SID can not be opened: $output"
 		return $OCF_ERR_GENERIC
 	fi
 


### PR DESCRIPTION
Hi All,

This PR was modified by Mr.Mori(@kskmori) and I performed the test.
(I should have put out this PR a long time ago, but I forgot.)

Since the clear_backmode parameter of Oracle RA corresponds only to lowercase letters, we fixed it.

Also, the current RA does not output the cause details when a startup error occurs in backupmode.

This fix makes it possible to guess that it was bakupmode because it will appear in the error log of ORA - 10873.

```

May 14 09:29:12 rh74-ora1 oracle(prmOracle)[27920]: ERROR: oracle test1 can not be opened: alter database open#012*#012ERROR at line 1:#012ORA-10873: file 1 needs to be either taken out of backup mode or media#012recovered#012ORA-01110: data file 1:#012'/u01/app/oracle/oradata/TEST1/datafile/o1_mf_system_fgz28zyo_.dbf'                                                                                                  

```

We corrected to output errors simply.

 - It is a simple fix, but we would like to include this fix in the next release(4.2.0).

Best Regards,
Hideo Yamauchi.

