### PR TITLE
Mid: pgsql: Fix to ignore Master's re-promote.

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -680,6 +680,7 @@ pgsql_start() {
 
 #pgsql_promote: Promote PostgreSQL
 pgsql_promote() {
+    local output
     local target
     local rc
 
@@ -687,6 +688,18 @@ pgsql_promote() {
         ocf_exit_reason "Not in a replication mode."
         return $OCF_ERR_CONFIGURED
     fi
+
+    output=`exec_sql "${CHECK_MS_SQL}"`
+    if [ $? -ne 0 ]; then
+        report_psql_error $rc $loglevel "Can't get PostgreSQL recovery status on promote."
+        return $OCF_ERR_GENERIC
+    fi
+
+    if [ "$output" = "f" ]; then
+        ocf_log info "PostgreSQL is alredy Master. Don't execute promote."
+        return $OCF_SUCCESS
+    fi
+
     rm -f ${XLOG_NOTE_FILE}.*
 
     for target in $NODE_LIST; do


### PR DESCRIPTION
The pgsql resource of replication mode will cause an error if it is promoted again to the master node.

```
[root@hpdb0301 ~]# crm_mon -1 -Af
Stack: corosync
Current DC: hpdb0301 (version 1.1.19-c3c624ea3d) - partition with quorum
Last updated: Tue Oct 16 16:27:20 2018
Last change: Tue Oct 16 16:27:12 2018 by root via crm_attribute on hpdb0301

2 nodes configured
11 resources configured

Online: [ hpdb0301 hpdb0401 ]
(snip)
Master/Slave Set: msPostgresql [pgsql]
     Masters: [ hpdb0301 ]
     Slaves: [ hpdb0401 ]
(snip)

[root@hpdb0301 ~]# crm_resource --force-promote -r msPostgresql --force                                                                                                                                     
resource msPostgresql is running on: hpdb0301 Master
resource msPostgresql is running on: hpdb0401 
Operation promote for pgsql:0 (ocf:heartbeat:pgsql) returned: 'unknown error' (1)
 >  stderr: INFO: Changing msPostgresql-data-status on hpdb0401 : ->DISCONNECT.
 >  stderr: INFO: Creating /var/lib/pgsql/tmp/PGSQL.lock.
 >  stderr: INFO: My master baseline : 00000001C1000300.
 >  stderr: ERROR: pg_ctl: cannot promote server; server is not in standby mode 
 >  stderr: ocf-exit-reason:Can't promote PostgreSQL.
```

Correct it so that it resembles the drbd resource and ignores it when promotion is executed again.

```
[root@hpdb0301 ~]# crm_resource --force-promote -r msPostgresql --force
resource msPostgresql is running on: hpdb0301 Master
resource msPostgresql is running on: hpdb0401 
Operation promote for pgsql:0 (ocf:heartbeat:pgsql) returned: 'ok' (0)
 >  stderr: INFO: PostgreSQL is alredy Master. Don't execute promote.
```

 - We hope to include this fix in the next release.(4.2.0).

Best Regards,
Hideo Yamauchi.
