### PR TITLE
dev: ocf.py: depth is not a time parameter and shouldn't a suffix

### DIFF
--- a/heartbeat/ocf.py
+++ b/heartbeat/ocf.py
@@ -250,7 +250,7 @@ class Action(object):
 	def to_xml(self):
 		def opt(s, name, var):
 			if var is not None:
-				if type(var) == int:
+				if type(var) == int and name in ("timeout", "interval"):
 					var = "{}s".format(var)
 				return s + ' {}="{}"'.format(name, var)
 			return s


### PR DESCRIPTION
I'm not 100% sure this breaks Pacemaker, but it causes crmsh to warn about missing monitor action.