### PR TITLE
ZFS agent: check status without locks when possible

### DIFF
--- a/heartbeat/ZFS
+++ b/heartbeat/ZFS
@@ -141,7 +141,14 @@ zpool_monitor () {
     fi
 
     # Check the pool status
-    HEALTH=$(zpool list -H -o health "$OCF_RESKEY_pool")
+    # Since version 0.7.10 status can be obtained without locks
+    # https://github.com/zfsonlinux/zfs/pull/7563
+    if [ -f /proc/spl/kstat/zfs/$OCF_RESKEY_pool/state ] ; then
+        HEALTH=$(</proc/spl/kstat/zfs/$OCF_RESKEY_pool/state)
+    else
+        HEALTH=$(zpool list -H -o health "$OCF_RESKEY_pool")
+    fi
+
     case "$HEALTH" in
         ONLINE|DEGRADED) return $OCF_SUCCESS;;
         FAULTED)         return $OCF_NOT_RUNNING;;


### PR DESCRIPTION
`zpool list -H -o health "$OCF_RESKEY_pool"` may hang on heavy load (e.g. snapshot send, please see https://github.com/zfsonlinux/zfs/issues/7331). 
Since ZFS version 0.7.10 status can be obtained without locks (https://github.com/zfsonlinux/zfs/pull/7563), use it when possible.

Signed-off-by: George Melikov <mail@gmelikov.ru>