### PR TITLE
spec: fix broken reliance on systemd_requires defined in SRPM build time

### DIFF
--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -14,6 +14,22 @@
 %global numcomm @numcomm@
 %global dirty @dirty@
 
+# Whether this platform defaults to using systemd as an init system
+# (needs to be evaluated prior to BuildRequires being enumerated and
+# installed as it's intended to conditionally select some of these, and
+# for that there are only few indicators with varying reliability:
+# - presence of systemd-defined macros (when building in a full-fledged
+#   environment, which is not the case with ordinary mock-based builds)
+# - systemd-aware rpm as manifested with the presence of particular
+#   macro (rpm itself will trivially always be present when building)
+# - existence of /usr/lib/os-release file, which is something heavily
+#   propagated by systemd project
+# - when not good enough, there's always a possibility to check
+#   particular distro-specific macros (incl. version comparison)
+%define systemd_native (%{?_unitdir:1}%{!?_unitdir:0}%{nil \
+  } || %{?__transaction_systemd_inhibit:1}%{!?__transaction_systemd_inhibit:0}%{nil \
+  } || %(test -f /usr/lib/os-release; test $? -ne 0; echo $?))
+
 #
 # Since this spec file supports multiple distributions, ensure we
 # use the correct group for each.
@@ -162,10 +178,10 @@ Requires:	perl-Net-IMAP-Simple-SSL
 Requires(post):	/sbin/chkconfig
 Requires(preun):/sbin/chkconfig
 %endif
-%if %{defined systemd_requires}
+%if %{systemd_native}
 BuildRequires:  systemd
-%{?systemd_requires}
 %endif
+%{?systemd_requires}
 
 %description -n ldirectord
 The Linux Director Daemon (ldirectord) was written by Jacob Rief.


### PR DESCRIPTION
Actually orthogonal to how buildroot (usually used also for building
source packages alone) looks like/which packages are always present.
In a container, for instance, may not be any systemd (and hence its
RPM macros) at all.

Still rather fragile but working "is systemd a native platform where
you build this SRPM" detecting macro borrowed from upstream pacemaker
spec (I happen to author there, for completeness and as a reminder,
please keep these snippets in sync if at all possible).

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>