### PR TITLE
SAPDatabase: Improves the documentation about HANA usage

### DIFF
--- a/heartbeat/SAPDatabase
+++ b/heartbeat/SAPDatabase
@@ -92,16 +92,17 @@ Release: 7.20
 Patch Number: 90
 or compile time after: Dec 17 2011
 
-A single HANA is managed as a primitive resource by the SAPDatabase RA. Therefor the parameter MONITOR_SERVICES has to match the output service names of the command "sapcontrol -nr \$InstNr -function GetProcessList".
-"\$InstNr" has to be replaced by the respective instance number.
+To exemplify the usage, for a HANA database with SID "TST" and instance number "10", the resource configuration using crmsh syntax looks like:
 
-For an HANA database with SID "TST" and instance number "10", the resource configuration looks like:
 primitive rsc_SAPDatabase_TST_HDB10 ocf:heartbeat:SAPDatabase \\
  params DBTYPE="HDB" SID="TST" \\
- MONITOR_SERVICES="hdbindexserver|hdbnameserver" \\
  op start interval="0" timeout="3600" \\
  op monitor interval="120" timeout="700" \\
  op stop interval="0" timeout="600"
+
+Make sure to tune the operations timeout values accordingly with your chosen Database and available infrastructure.
+
+Note that the same configuration can be achieved using any other CLI tool for cluster configuration available, like pcs or cibadmin. 
 </longdesc>
 <shortdesc lang="en">Manages a SAP database instance as an HA resource.</shortdesc>
 <parameters>
@@ -159,7 +160,16 @@ Usually you can leave this empty. Then the default: /usr/sap/hostctrl/exe is use
  </parameter>
  <parameter name="MONITOR_SERVICES" unique="0" required="0">
   <longdesc lang="en">Defines which services are monitored by the SAPDatabase resource agent. Service names must correspond with the output of the 'saphostctrl -function GetDatabaseStatus' command.
-The default value is derived from the database type DBTYPE. For example, DBTYPE "ORA" sets MONITOR_SERVICES="Instance|Database|Listener".</longdesc>
+The default MONITOR_SERVICES value is derived from the database type DBTYPE. For reference:
+
+- DBTYPE "ORA" sets MONITOR_SERVICES="Instance|Database|Listener";
+- DBTYPE "HDB" sets MONITOR_SERVICES="hdbindexserver|hdbnameserver";
+- DBTYPE "ADA" sets MONITOR_SERVICES="Database";
+- DBTYPE "DB6" sets MONITOR_SERVICES="{SID}|{db2sid}";
+- DBTYPE "SYB" sets MONITOR_SERVICES="Server".
+
+This parameter should be set ONLY if is needed to monitor different services than the ones listed above.
+</longdesc>
   <shortdesc lang="en">Database services to monitor</shortdesc>
   <content type="string" default=""/>
  </parameter>


### PR DESCRIPTION
Exemplify the HANA Standalone usage and improves the Monitor Services
defaults documentation.