### PR TITLE
tomcat: use systemd on newer RHEL where catalina.sh is unavailable

### DIFF
--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -39,7 +39,7 @@ get_os_ver() {
 		VER=$(cat $_DEBIAN_VERSION_FILE)
 	elif [ -f $_REDHAT_RELEASE_FILE ]; then
 		OS=RedHat  # redhat or similar
-		VER= # here some complex sed script
+		VER=$(sed "s/.* release \([^ ]\+\).*/\1/" $_REDHAT_RELEASE_FILE)
 	else
 		OS=$(uname -s)
 		VER=$(uname -r)

--- a/heartbeat/tomcat
+++ b/heartbeat/tomcat
@@ -613,7 +613,6 @@ TOMCAT_NAME="${OCF_RESKEY_tomcat_name-tomcat}"
 TOMCAT_CONSOLE="${OCF_RESKEY_script_log-/var/log/$TOMCAT_NAME.log}"
 RESOURCE_TOMCAT_USER="${OCF_RESKEY_tomcat_user-root}"
 RESOURCE_STATUSURL="${OCF_RESKEY_statusurl-http://127.0.0.1:8080}"
-OCF_RESKEY_force_systemd_default=0
 
 JAVA_HOME="${OCF_RESKEY_java_home}"
 JAVA_OPTS="${OCF_RESKEY_java_opts}"
@@ -628,6 +627,13 @@ if [ -z "$CATALINA_PID" ]; then
 		chown ${RESOURCE_TOMCAT_USER} "${HA_RSCTMP}/${TOMCAT_NAME}_tomcatstate/"
 	fi
 	CATALINA_PID="${HA_RSCTMP}/${TOMCAT_NAME}_tomcatstate/catalina.pid"
+fi
+
+# Only default to true for RedHat systems without catalina.sh
+if [ -e "$CATALINA_HOME/bin/catalina.sh" ] || ! is_redhat_based; then
+	OCF_RESKEY_force_systemd_default=0
+else
+	OCF_RESKEY_force_systemd_default=1
 fi
 
 MAX_STOP_TIME="${OCF_RESKEY_max_stop_time}"


### PR DESCRIPTION
without this patch it falls back to running the command manually which fails due to missing PID-file.

The -e check might be a bit confusing, but it'll avoid issues if it's backported to older RHEL where it's setup with catalina.sh available.