### PR TITLE
lxc: Add Support for lxc-stop

### DIFF
--- a/heartbeat/lxc.in
+++ b/heartbeat/lxc.in
@@ -179,8 +179,7 @@ LXC_start() {
 
 
 LXC_stop() {
-	local shutdown_timeout
-	local now
+	
 	LXC_status
 	if [ $? -eq $OCF_NOT_RUNNING ]; then
 		ocf_log debug "Resource $OCF_RESOURCE_INSTANCE is already stopped"
@@ -213,90 +212,56 @@ LXC_stop() {
 		# If the container is running "init" and is able to perform and orderly shutdown, then it should be done.
 		# It is 'assumed' that the 'init' system will do an orderly shudown if presented with a 'kill -PWR' signal.
 		# On a 'sysvinit' this would require the container to have an inittab file containing "p0::powerfail:/sbin/init 0"
+		local shutdown_timeout
+		local now
 		declare -i PID=0
 		declare CMD=
 
-		# LXC prior 1.0.0
-		if ocf_version_cmp "`lxc_version`" 1.0.0 ; then
-			# This should work for traditional 'sysvinit' and 'upstart'
-			lxc-ps --name "${OCF_RESKEY_container}" -- -C init -o pid,comm |while read CN PID CMD ;do
-				[ $PID -gt 1 ] || continue
-				[ "$CMD" = "init" ] || continue
-				ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"sysV init\" or \"upstart\""
-				kill -PWR $PID
-			done
-			# This should work for containers using 'systemd' instead of 'init'
-			lxc-ps --name "${OCF_RESKEY_container}" -- -C systemd -o pid,comm |while read CN PID CMD ;do
-				[ $PID -gt 1 ] || continue
-				[ "$CMD" = "systemd" ] || continue
-				ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"systemd\""
-				kill -PWR $PID
-			done
-		else
-			PID=$(lxc-info --name "${OCF_RESKEY_container}" -p -H)
+		# This should work for traditional 'sysvinit' and 'upstart'
+		lxc-ps --name "${OCF_RESKEY_container}" -- -C init -o pid,comm |while read CN PID CMD ;do
+			[ $PID -gt 1 ] || continue
+			[ "$CMD" = "init" ] || continue
+			ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"sysV init\" or \"upstart\""
+			kill -PWR $PID
+		done
+		# This should work for containers using 'systemd' instead of 'init'
+		lxc-ps --name "${OCF_RESKEY_container}" -- -C systemd -o pid,comm |while read CN PID CMD ;do
+			[ $PID -gt 1 ] || continue
+			[ "$CMD" = "systemd" ] || continue
+			ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"systemd\""
+			kill -PWR $PID
+		done
+		
+		# The "shutdown_timeout" we use here is the operation
+		# timeout specified in the CIB, minus 5 seconds
+		now=$(date +%s)
+		shutdown_timeout=$(( $now + ($OCF_RESKEY_CRM_meta_timeout/1000) -5 ))
+		# Loop on status until we reach $shutdown_timeout
+		while [ $now -lt $shutdown_timeout ]; do
+			LXC_status
+			status=$?
+			case $status in
+			"$OCF_NOT_RUNNING")
+				ocf_run rm -f $TRANS_RES_STATE
+				return $OCF_SUCCESS
+				;;
+			"$OCF_SUCCESS")
+				# Container is still running, keep waiting (until
+				# shutdown_timeout expires)
+				sleep 1
+				;;
+			*)
+				# Something went wrong. Bail out and
+				# resort to forced stop (destroy).
+				break;
+			esac
+			now=$(date +%s)
+		done
 
-			# If there is no PID the container seems to be down which
-			# shouldn't happen.
-			if [ $PID -eq 0 ]; then
-				ocf_log err "${OCF_RESKEY_container} seems to run, but has no PID."
-				exit $OCF_ERR_GENERIC
-			fi
-
-			# Rescue me.
-			if [ $PID -eq 1 ]; then
-				ocf_log err "${OCF_RESKEY_container} seems to run with PID 1 which cannot be."
-				PID=0
-				CMD=
-			else
-				CMD=$(ps -o comm= -p $PID)
-			fi
-
-			# This should work for traditional 'sysvinit' and 'upstart'
-			if [ "$CMD" = "init" ]; then
-				ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"sysV init\" or \"upstart\""
-				kill -PWR $PID
-			fi
-
-			# This should work for containers using 'systemd' instead of 'init'
-			if [ "$CMD" = "systemd" ]; then
-				ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"systemd\""
-				kill -PWR $PID
-			fi
-		fi
-	fi
-	# The "shutdown_timeout" we use here is the operation
-	# timeout specified in the CIB, minus 5 seconds
-	now=$(date +%s)
-	shutdown_timeout=$(( $now + ($OCF_RESKEY_CRM_meta_timeout/1000) -5 ))
-	# Loop on status until we reach $shutdown_timeout
-	while [ $now -lt $shutdown_timeout ]; do
-	    LXC_status
-	    status=$?
-	    case $status in
-		"$OCF_NOT_RUNNING")
-		    ocf_run rm -f $TRANS_RES_STATE
-		    return $OCF_SUCCESS
-		    ;;
-		"$OCF_SUCCESS")
-		    # Container is still running, keep waiting (until
-		    # shutdown_timeout expires)
-		    sleep 1
-		    ;;
-		*)
-		    # Something went wrong. Bail out and
-		    # resort to forced stop (destroy).
-		    break;
-	    esac
-	    now=$(date +%s)
-	done
-
-	# If the container is still running, it will be stopped now. regardless of state!
-	# LXC prior 1.0.0
-	if ocf_version_cmp "`lxc_version`" 1.0.0 ; then
+		# If the container is still running, it will be stopped now. regardless of state!
 		ocf_run lxc-stop -n ${OCF_RESKEY_container} || exit $OCF_ERR_GENERIC
-	else
-		ocf_run lxc-stop -n ${OCF_RESKEY_container} -k || exit $OCF_ERR_GENERIC
 	fi
+	
 	ocf_log info "Container" ${OCF_RESKEY_container} "stopped"
 	ocf_run rm -f $TRANS_RES_STATE
 

--- a/heartbeat/lxc.in
+++ b/heartbeat/lxc.in
@@ -47,7 +47,7 @@ OCF_RESKEY_use_lxc_stop_default="false"
 
 : ${OCF_RESKEY_log=${OCF_RESKEY_log_default}}
 : ${OCF_RESKEY_use_screen=${OCF_RESKEY_use_screen_default}}
-: ${OCF_RESKEY_use_lxc-stop=${OCF_RESKEY_use_lxc_stop_default}}
+: ${OCF_RESKEY_use_lxc_stop=${OCF_RESKEY_use_lxc_stop_default}}
 
 # Set default TRANS_RES_STATE (temporary file to "flag" if resource was stated but not stopped)
 TRANS_RES_STATE="${HA_RSCTMP}/${OCF_RESOURCE_INSTANCE}.state"

--- a/heartbeat/lxc.in
+++ b/heartbeat/lxc.in
@@ -196,8 +196,17 @@ LXC_stop() {
 
 	if ! ocf_version_cmp "`lxc_version`" 1.0.0 ; then
 		# Use lxc-stop if we are newer than 1.0.0
+		timeout=$(( ($OCF_RESKEY_CRM_meta_timeout/1000) -5 ))
 		ocf_log info "Stopping Container ${OCF_RESKEY_container} using lxc-stop"
-		ocf_run lxc-stop --name "${OCF_RESKEY_container}" || exit $OCF_ERR_GENERIC
+		# lxc-stop will return failure even if it reached the timeout and sucessfully hard-stopped the 
+		# Container so we check below if the Container is really stopped instead of using || exit $OCF_ERR_GENERIC
+		ocf_run lxc-stop -n "${OCF_RESKEY_container}" -t ${timeout}
+		
+		LXC_status
+		if [ $? -eq $OCF_SUCCESS ]; then
+			# Try to manually hard-stop if the Container is still running
+			ocf_run lxc-stop -n "${OCF_RESKEY_container}" -k || exit $OCF_ERR_GENERIC
+		fi
 		
 	else
 		# Use kill -PWR

--- a/heartbeat/lxc.in
+++ b/heartbeat/lxc.in
@@ -43,11 +43,9 @@
 # Defaults
 OCF_RESKEY_log_default="${HA_RSCTMP}/${OCF_RESOURCE_INSTANCE}.log"
 OCF_RESKEY_use_screen_default="false"
-OCF_RESKEY_use_lxc_stop_default="false"
 
 : ${OCF_RESKEY_log=${OCF_RESKEY_log_default}}
 : ${OCF_RESKEY_use_screen=${OCF_RESKEY_use_screen_default}}
-: ${OCF_RESKEY_use_lxc_stop=${OCF_RESKEY_use_lxc_stop_default}}
 
 # Set default TRANS_RES_STATE (temporary file to "flag" if resource was stated but not stopped)
 TRANS_RES_STATE="${HA_RSCTMP}/${OCF_RESOURCE_INSTANCE}.state"
@@ -91,12 +89,6 @@ To see the screen output run 'screen -r {container name}'
 The default value is set to 'false', change to 'true' to activate this option</longdesc>
 <shortdesc lang="en">Use 'screen' for container 'root console' output</shortdesc>
 <content type="boolean" default="${OCF_RESKEY_use_screen_default}"/>
-</parameter>
-
-<parameter name="use_lxc_stop" required="0" unique="0">
-<longdesc lang="en">Use lxc-stop instead of the default to shutdown the Container</longdesc>
-<shortdesc lang="en">Use lxc-stop to shutdown the Container</shortdesc>
-<content type="boolean" default="${OCF_RESKEY_use_lxc-stop_default}"/>
 </parameter>
 
 </parameters>
@@ -202,8 +194,8 @@ LXC_stop() {
 		exit $OCF_ERR_GENERIC
 	fi
 
-	if ocf_is_true $OCF_RESKEY_use_lxc_stop; then
-		# Use lxc-stop
+	if ! ocf_version_cmp "`lxc_version`" 1.0.0 ; then
+		# Use lxc-stop if we are newer than 1.0.0
 		ocf_log info "Stopping Container ${OCF_RESKEY_container} using lxc-stop"
 		ocf_run lxc-stop --name "${OCF_RESKEY_container}" || exit $OCF_ERR_GENERIC
 		

--- a/heartbeat/lxc.in
+++ b/heartbeat/lxc.in
@@ -57,8 +57,7 @@ cat <<END
 <resource-agent name="lxc">
 <version>0.1</version>
 <longdesc lang="en">Allows LXC containers to be managed by the cluster.
-There are two types of shutdown procedures, the default is to send the PWR Signal to PID 1 in the Container (see the Notes below) and the other uses lxc-stop (chooseable via the use_lxc_stop Parameter).
-Notes for the Default shutdown procedure:
+Notes for lxc Versions before 1.0.0, where the Container is stopped using kill -PWR instead of lxc-stop:
 It is 'assumed' that the 'init' system will do an orderly shudown if presented with a 'kill -PWR' signal.
 On a 'sysvinit' this would require the container to have an inittab file containing "p0::powerfail:/sbin/init 0"
 </longdesc>

--- a/heartbeat/lxc.in
+++ b/heartbeat/lxc.in
@@ -43,10 +43,11 @@
 # Defaults
 OCF_RESKEY_log_default="${HA_RSCTMP}/${OCF_RESOURCE_INSTANCE}.log"
 OCF_RESKEY_use_screen_default="false"
+OCF_RESKEY_use_lxc_stop_default="false"
 
 : ${OCF_RESKEY_log=${OCF_RESKEY_log_default}}
 : ${OCF_RESKEY_use_screen=${OCF_RESKEY_use_screen_default}}
-
+: ${OCF_RESKEY_use_lxc-stop=${OCF_RESKEY_use_lxc_stop_default}}
 
 # Set default TRANS_RES_STATE (temporary file to "flag" if resource was stated but not stopped)
 TRANS_RES_STATE="${HA_RSCTMP}/${OCF_RESOURCE_INSTANCE}.state"
@@ -58,10 +59,11 @@ cat <<END
 <resource-agent name="lxc">
 <version>0.1</version>
 <longdesc lang="en">Allows LXC containers to be managed by the cluster.
-If the container is running "init" it will also perform an orderly shutdown.
+There are two types of shutdown procedures, the default is to send the PWR Signal to PID 1 in the Container (see the Notes below) and the other uses lxc-stop (chooseable via the use_lxc_stop Parameter).
+Notes for the Default shutdown procedure:
 It is 'assumed' that the 'init' system will do an orderly shudown if presented with a 'kill -PWR' signal.
 On a 'sysvinit' this would require the container to have an inittab file containing "p0::powerfail:/sbin/init 0"
-I have absolutely no idea how this is done with 'upstart' or 'systemd', YMMV if your container is using one of them.</longdesc>
+</longdesc>
 <shortdesc lang="en">Manages LXC containers</shortdesc>
 
 <parameters>
@@ -91,6 +93,11 @@ The default value is set to 'false', change to 'true' to activate this option</l
 <content type="boolean" default="${OCF_RESKEY_use_screen_default}"/>
 </parameter>
 
+<parameter name="use_lxc_stop" required="0" unique="0">
+<longdesc lang="en">Use lxc-stop instead of the default to shutdown the Container</longdesc>
+<shortdesc lang="en">Use lxc-stop to shutdown the Container</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_use_lxc-stop_default}"/>
+</parameter>
 
 </parameters>
 
@@ -195,57 +202,65 @@ LXC_stop() {
 		exit $OCF_ERR_GENERIC
 	fi
 
-	# If the container is running "init" and is able to perform and orderly shutdown, then it should be done.
-	# It is 'assumed' that the 'init' system will do an orderly shudown if presented with a 'kill -PWR' signal.
-	# On a 'sysvinit' this would require the container to have an inittab file containing "p0::powerfail:/sbin/init 0"
-	declare -i PID=0
-	declare CMD=
-
-	# LXC prior 1.0.0
-	if ocf_version_cmp "`lxc_version`" 1.0.0 ; then
-		# This should work for traditional 'sysvinit' and 'upstart'
-		lxc-ps --name "${OCF_RESKEY_container}" -- -C init -o pid,comm |while read CN PID CMD ;do
-			[ $PID -gt 1 ] || continue
-			[ "$CMD" = "init" ] || continue
-			ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"sysV init\" or \"upstart\""
-			kill -PWR $PID
-		done
-		# This should work for containers using 'systemd' instead of 'init'
-		lxc-ps --name "${OCF_RESKEY_container}" -- -C systemd -o pid,comm |while read CN PID CMD ;do
-			[ $PID -gt 1 ] || continue
-			[ "$CMD" = "systemd" ] || continue
-			ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"systemd\""
-			kill -PWR $PID
-		done
+	if ocf_is_true $OCF_RESKEY_use_lxc_stop; then
+		# Use lxc-stop
+		ocf_log info "Stopping Container ${OCF_RESKEY_container} using lxc-stop"
+		ocf_run lxc-stop --name "${OCF_RESKEY_container}" || exit $OCF_ERR_GENERIC
+		
 	else
-		PID=$(lxc-info --name "${OCF_RESKEY_container}" -p -H)
+		# Use kill -PWR
+		# If the container is running "init" and is able to perform and orderly shutdown, then it should be done.
+		# It is 'assumed' that the 'init' system will do an orderly shudown if presented with a 'kill -PWR' signal.
+		# On a 'sysvinit' this would require the container to have an inittab file containing "p0::powerfail:/sbin/init 0"
+		declare -i PID=0
+		declare CMD=
 
-		# If there is no PID the container seems to be down which
-		# shouldn't happen.
-		if [ $PID -eq 0 ]; then
-			ocf_log err "${OCF_RESKEY_container} seems to run, but has no PID."
-			exit $OCF_ERR_GENERIC
-		fi
-
-		# Rescue me.
-		if [ $PID -eq 1 ]; then
-			ocf_log err "${OCF_RESKEY_container} seems to run with PID 1 which cannot be."
-			PID=0
-			CMD=
+		# LXC prior 1.0.0
+		if ocf_version_cmp "`lxc_version`" 1.0.0 ; then
+			# This should work for traditional 'sysvinit' and 'upstart'
+			lxc-ps --name "${OCF_RESKEY_container}" -- -C init -o pid,comm |while read CN PID CMD ;do
+				[ $PID -gt 1 ] || continue
+				[ "$CMD" = "init" ] || continue
+				ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"sysV init\" or \"upstart\""
+				kill -PWR $PID
+			done
+			# This should work for containers using 'systemd' instead of 'init'
+			lxc-ps --name "${OCF_RESKEY_container}" -- -C systemd -o pid,comm |while read CN PID CMD ;do
+				[ $PID -gt 1 ] || continue
+				[ "$CMD" = "systemd" ] || continue
+				ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"systemd\""
+				kill -PWR $PID
+			done
 		else
-			CMD=$(ps -o comm= -p $PID)
-		fi
+			PID=$(lxc-info --name "${OCF_RESKEY_container}" -p -H)
 
-		# This should work for traditional 'sysvinit' and 'upstart'
-		if [ "$CMD" = "init" ]; then
-			ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"sysV init\" or \"upstart\""
-			kill -PWR $PID
-		fi
+			# If there is no PID the container seems to be down which
+			# shouldn't happen.
+			if [ $PID -eq 0 ]; then
+				ocf_log err "${OCF_RESKEY_container} seems to run, but has no PID."
+				exit $OCF_ERR_GENERIC
+			fi
 
-		# This should work for containers using 'systemd' instead of 'init'
-		if [ "$CMD" = "systemd" ]; then
-			ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"systemd\""
-			kill -PWR $PID
+			# Rescue me.
+			if [ $PID -eq 1 ]; then
+				ocf_log err "${OCF_RESKEY_container} seems to run with PID 1 which cannot be."
+				PID=0
+				CMD=
+			else
+				CMD=$(ps -o comm= -p $PID)
+			fi
+
+			# This should work for traditional 'sysvinit' and 'upstart'
+			if [ "$CMD" = "init" ]; then
+				ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"sysV init\" or \"upstart\""
+				kill -PWR $PID
+			fi
+
+			# This should work for containers using 'systemd' instead of 'init'
+			if [ "$CMD" = "systemd" ]; then
+				ocf_log info "Sending \"OS shut down\" instruction to" ${OCF_RESKEY_container} "as it was found to be using \"systemd\""
+				kill -PWR $PID
+			fi
 		fi
 	fi
 	# The "shutdown_timeout" we use here is the operation


### PR DESCRIPTION
This adds an "use_lxc_stop" switch which enables stopping
the container using lxc-stop instead of kill -PWR.

This was tested on a two node pacemaker cluster with drbd.

I wonder why it isn't already used and if we could change it to the default stop action.