### PR TITLE
Enable --query flag in DescribeRouteTable API 

### DIFF
--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -167,7 +167,7 @@ ec2ip_validate() {
 ec2ip_monitor() {
 	if ocf_is_true ${OCF_RESKEY_monapi} || [ "$__OCF_ACTION" = "start" ] || ocf_is_probe; then
 		ocf_log info "monitor: check routing table (API call)"
-		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $OCF_RESKEY_routing_table --query RouteTables[*].Routes[?DestinationCidrBlock==\`$OCF_RESKEY_address/32\`].InstanceId"
+		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $OCF_RESKEY_routing_table --query RouteTables[*].Routes[?DestinationCidrBlock=='$OCF_RESKEY_ip/32'].InstanceId"
 		ocf_log debug "executing command: $cmd"
 		ROUTE_TO_INSTANCE=$($cmd)
 		ocf_log debug "Overlay IP is currently routed to ${ROUTE_TO_INSTANCE}"

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -167,7 +167,7 @@ ec2ip_validate() {
 ec2ip_monitor() {
 	if ocf_is_true ${OCF_RESKEY_monapi} || [ "$__OCF_ACTION" = "start" ] || ocf_is_probe; then
 		ocf_log info "monitor: check routing table (API call)"
-                cmd=''$OCF_RESKEY_awscli' --profile '$OCF_RESKEY_profile' --output text ec2 describe-route-tables --route-table-ids '$OCF_RESKEY_routing_table' --query 'RouteTables[*].Routes[?DestinationCidrBlock==\`$OCF_RESKEY_address/32\`].InstanceId''
+                cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $OCF_RESKEY_routing_table --query RouteTables[*].Routes[?DestinationCidrBlock==\`$OCF_RESKEY_address/32\`].InstanceId"
 		ocf_log debug "executing command: $cmd"
                 ROUTE_TO_INSTANCE=$($cmd)
                 ocf_log debug "Overlay IP is currently routed to ${ROUTE_TO_INSTANCE}"

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -167,9 +167,10 @@ ec2ip_validate() {
 ec2ip_monitor() {
 	if ocf_is_true ${OCF_RESKEY_monapi} || [ "$__OCF_ACTION" = "start" ] || ocf_is_probe; then
 		ocf_log info "monitor: check routing table (API call)"
-		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $OCF_RESKEY_routing_table"
+                cmd=''$OCF_RESKEY_awscli' --profile '$OCF_RESKEY_profile' --output text ec2 describe-route-tables --route-table-ids '$OCF_RESKEY_routing_table' --query 'RouteTables[*].Routes[?DestinationCidrBlock==\`$OCF_RESKEY_address/32\`].InstanceId''
 		ocf_log debug "executing command: $cmd"
-		ROUTE_TO_INSTANCE="$($cmd | grep $OCF_RESKEY_ip | awk '{ print $3 }')"
+                ROUTE_TO_INSTANCE=$($cmd)
+                ocf_log debug "Overlay IP is currently routed to ${ROUTE_TO_INSTANCE}"
 		if [ -z "$ROUTE_TO_INSTANCE" ]; then
 			ROUTE_TO_INSTANCE="<unknown>"
 		fi

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -167,10 +167,10 @@ ec2ip_validate() {
 ec2ip_monitor() {
 	if ocf_is_true ${OCF_RESKEY_monapi} || [ "$__OCF_ACTION" = "start" ] || ocf_is_probe; then
 		ocf_log info "monitor: check routing table (API call)"
-                cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $OCF_RESKEY_routing_table --query RouteTables[*].Routes[?DestinationCidrBlock==\`$OCF_RESKEY_address/32\`].InstanceId"
+		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $OCF_RESKEY_routing_table --query RouteTables[*].Routes[?DestinationCidrBlock==\`$OCF_RESKEY_address/32\`].InstanceId"
 		ocf_log debug "executing command: $cmd"
-                ROUTE_TO_INSTANCE=$($cmd)
-                ocf_log debug "Overlay IP is currently routed to ${ROUTE_TO_INSTANCE}"
+		ROUTE_TO_INSTANCE=$($cmd)
+		ocf_log debug "Overlay IP is currently routed to ${ROUTE_TO_INSTANCE}"
 		if [ -z "$ROUTE_TO_INSTANCE" ]; then
 			ROUTE_TO_INSTANCE="<unknown>"
 		fi


### PR DESCRIPTION
This is a proposed fix to avoid a race condition with "grep" while parsing the results from AWS CLI. 

Currently, "grep" will match for IPs that don't belong tho the cluster resource. For example, if your cluster resource IP address is "192.168.1.1", "grep" will match "192.168.1.1*" (192.168.1.1,10,11,...,111).

This could have been fixed by a simple "grep -w" but we (AWS) thought it is more elegant to directly use the API to query for the IP.

I also included a debug log line.