### PR TITLE
docker: Fix issues with stop operation

### DIFF
--- a/doc/dev-guides/ra-dev-guide.asc
+++ b/doc/dev-guides/ra-dev-guide.asc
@@ -1026,9 +1026,17 @@ foobar_migrate_from() {
 
 With notifications, instances of clones (and of master/slave
 resources, which are an extended kind of clones) can inform each other
-about their state. When notifications are enabled, any action on any
-instance of a clone carries a +pre+ and +post+ notification. Then, the
-cluster manager invokes the +notify+ operation on _all_ clone
+about their state. When notifications are enabled, certain actions on
+any instance of a clone carries a +pre+ and +post+ notification.
+
+List of actions that trigger notifications:
+
+* start
+* stop
+* promote
+* demote
+
+The cluster manager invokes the +notify+ operation on _all_ clone
 instances. For +notify+ operations, additional environment variables
 are passed into the resource agent during execution:
 

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -168,11 +168,12 @@ man_MANS	       = ocf_heartbeat_azure-events.7 \
                           ocf_heartbeat_slapd.7 \
                           ocf_heartbeat_sybaseASE.7 \
                           ocf_heartbeat_sg_persist.7 \
-			  ocf_heartbeat_mpathpersist.7 \
+                          ocf_heartbeat_mpathpersist.7 \
                           ocf_heartbeat_symlink.7 \
                           ocf_heartbeat_syslog-ng.7 \
                           ocf_heartbeat_tomcat.7 \
                           ocf_heartbeat_varnish.7 \
+                          ocf_heartbeat_vdo-vol.7 \
                           ocf_heartbeat_vmware.7 \
                           ocf_heartbeat_vsftpd.7 \
                           ocf_heartbeat_zabbixserver.7

--- a/heartbeat/Makefile.am
+++ b/heartbeat/Makefile.am
@@ -168,6 +168,7 @@ ocf_SCRIPTS	     = azure-events		\
 			syslog-ng		\
 			tomcat			\
 			varnish			\
+			vdo-vol			\
 			vmware			\
 			vsftpd			\
 			zabbixserver

--- a/heartbeat/SAPDatabase
+++ b/heartbeat/SAPDatabase
@@ -92,16 +92,17 @@ Release: 7.20
 Patch Number: 90
 or compile time after: Dec 17 2011
 
-A single HANA is managed as a primitive resource by the SAPDatabase RA. Therefor the parameter MONITOR_SERVICES has to match the output service names of the command "sapcontrol -nr \$InstNr -function GetProcessList".
-"\$InstNr" has to be replaced by the respective instance number.
+To exemplify the usage, for a HANA database with SID "TST" and instance number "10", the resource configuration using crmsh syntax looks like:
 
-For an HANA database with SID "TST" and instance number "10", the resource configuration looks like:
 primitive rsc_SAPDatabase_TST_HDB10 ocf:heartbeat:SAPDatabase \\
  params DBTYPE="HDB" SID="TST" \\
- MONITOR_SERVICES="hdbindexserver|hdbnameserver" \\
  op start interval="0" timeout="3600" \\
  op monitor interval="120" timeout="700" \\
  op stop interval="0" timeout="600"
+
+Make sure to tune the operations timeout values accordingly with your chosen Database and available infrastructure.
+
+Note that the same configuration can be achieved using any other CLI tool for cluster configuration available, like pcs or cibadmin. 
 </longdesc>
 <shortdesc lang="en">Manages a SAP database instance as an HA resource.</shortdesc>
 <parameters>
@@ -159,7 +160,16 @@ Usually you can leave this empty. Then the default: /usr/sap/hostctrl/exe is use
  </parameter>
  <parameter name="MONITOR_SERVICES" unique="0" required="0">
   <longdesc lang="en">Defines which services are monitored by the SAPDatabase resource agent. Service names must correspond with the output of the 'saphostctrl -function GetDatabaseStatus' command.
-The default value is derived from the database type DBTYPE. For example, DBTYPE "ORA" sets MONITOR_SERVICES="Instance|Database|Listener".</longdesc>
+The default MONITOR_SERVICES value is derived from the database type DBTYPE. For reference:
+
+- DBTYPE "ORA" sets MONITOR_SERVICES="Instance|Database|Listener";
+- DBTYPE "HDB" sets MONITOR_SERVICES="hdbindexserver|hdbnameserver";
+- DBTYPE "ADA" sets MONITOR_SERVICES="Database";
+- DBTYPE "DB6" sets MONITOR_SERVICES="{SID}|{db2sid}";
+- DBTYPE "SYB" sets MONITOR_SERVICES="Server".
+
+This parameter should be set ONLY if is needed to monitor different services than the ones listed above.
+</longdesc>
   <shortdesc lang="en">Database services to monitor</shortdesc>
   <content type="string" default=""/>
  </parameter>

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -103,9 +103,9 @@ Deprecated IP address param. Use the ip param instead.
 
 <parameter name="routing_table" required="1">
 <longdesc lang="en">
-Name of the routing table, where the route for the IP address should be changed, i.e. rtb-...
+Name of the routing table(s), where the route for the IP address should be changed. If declaring multiple routing tables they should be separated by comma. Example: rtb-XXXXXXXX,rtb-YYYYYYYYY
 </longdesc>
-<shortdesc lang="en">routing table name</shortdesc>
+<shortdesc lang="en">routing table name(s)</shortdesc>
 <content type="string" default="" />
 </parameter>
 

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -181,7 +181,7 @@ ec2ip_monitor() {
 				ocf_log warn "not routed to this instance ($EC2_INSTANCE_ID) but to instance $ROUTE_TO_INSTANCE on $rtb"
 				MON_RES="$MON_RES $rtb"
 			fi
-			sleep 0.5
+			sleep 1
 		done
 
 		if [ ! -z "$MON_RES" ]; then
@@ -228,7 +228,7 @@ ec2ip_get_and_configure() {
 			ocf_log warn "command failed, rc: $rc"
 			return $OCF_ERR_GENERIC
 		fi
-		sleep 0.5
+		sleep 1
 	done
 
 	# Reconfigure the local ip address

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -167,9 +167,10 @@ ec2ip_validate() {
 ec2ip_monitor() {
 	if ocf_is_true ${OCF_RESKEY_monapi} || [ "$__OCF_ACTION" = "start" ] || ocf_is_probe; then
 		ocf_log info "monitor: check routing table (API call)"
-		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $OCF_RESKEY_routing_table"
+		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $OCF_RESKEY_routing_table --query RouteTables[*].Routes[?DestinationCidrBlock=='$OCF_RESKEY_ip/32'].InstanceId"
 		ocf_log debug "executing command: $cmd"
-		ROUTE_TO_INSTANCE="$($cmd | grep $OCF_RESKEY_ip | awk '{ print $3 }')"
+		ROUTE_TO_INSTANCE=$($cmd)
+		ocf_log debug "Overlay IP is currently routed to ${ROUTE_TO_INSTANCE}"
 		if [ -z "$ROUTE_TO_INSTANCE" ]; then
 			ROUTE_TO_INSTANCE="<unknown>"
 		fi

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -165,20 +165,29 @@ ec2ip_validate() {
 }
 
 ec2ip_monitor() {
+        MON_RES=""
 	if ocf_is_true ${OCF_RESKEY_monapi} || [ "$__OCF_ACTION" = "start" ] || ocf_is_probe; then
-		ocf_log info "monitor: check routing table (API call)"
-		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $OCF_RESKEY_routing_table --query RouteTables[*].Routes[?DestinationCidrBlock=='$OCF_RESKEY_ip/32'].InstanceId"
-		ocf_log debug "executing command: $cmd"
-		ROUTE_TO_INSTANCE=$($cmd)
-		ocf_log debug "Overlay IP is currently routed to ${ROUTE_TO_INSTANCE}"
-		if [ -z "$ROUTE_TO_INSTANCE" ]; then
-			ROUTE_TO_INSTANCE="<unknown>"
-		fi
+		for rtb in $(echo $OCF_RESKEY_routing_table | sed -e 's/,/ /g'); do
+			ocf_log info "monitor: check routing table (API call) - $rtb"
+			cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $rtb --query RouteTables[*].Routes[?DestinationCidrBlock=='$OCF_RESKEY_ip/32'].InstanceId"
+			ocf_log debug "executing command: $cmd"
+			ROUTE_TO_INSTANCE="$($cmd)"
+			ocf_log debug "Overlay IP is currently routed to ${ROUTE_TO_INSTANCE}"
+			if [ -z "$ROUTE_TO_INSTANCE" ]; then
+				ROUTE_TO_INSTANCE="<unknown>"
+			fi
 
-		if [ "$EC2_INSTANCE_ID" != "$ROUTE_TO_INSTANCE" ];then 
-			ocf_log warn "not routed to this instance ($EC2_INSTANCE_ID) but to instance $ROUTE_TO_INSTANCE"
+			if [ "$EC2_INSTANCE_ID" != "$ROUTE_TO_INSTANCE" ]; then 
+				ocf_log warn "not routed to this instance ($EC2_INSTANCE_ID) but to instance $ROUTE_TO_INSTANCE on $rtb"
+				MON_RES="$MON_RES $rtb"
+			fi
+			sleep 0.5
+		done
+
+		if [ ! -z "$MON_RES" ]; then
 			return $OCF_NOT_RUNNING
 		fi
+
 	else
 		ocf_log debug "monitor: Enhanced Monitoring disabled - omitting API call"
 	fi
@@ -210,19 +219,23 @@ ec2ip_drop() {
 }
 
 ec2ip_get_and_configure() {
-	# Adjusting the routing table
-	cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 replace-route --route-table-id $OCF_RESKEY_routing_table --destination-cidr-block ${OCF_RESKEY_ip}/32 --instance-id $EC2_INSTANCE_ID"
-	ocf_log debug "executing command: $cmd"
-	$cmd
-	rc=$?
-	if [ "$rc" != 0 ]; then
-		ocf_log warn "command failed, rc: $rc"
-		return $OCF_ERR_GENERIC
-	fi
+	for rtb in $(echo $OCF_RESKEY_routing_table | sed -e 's/,/ /g'); do
+		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 replace-route --route-table-id $rtb --destination-cidr-block ${OCF_RESKEY_ip}/32 --instance-id $EC2_INSTANCE_ID"
+		ocf_log debug "executing command: $cmd"
+		$cmd
+		rc=$?
+		if [ "$rc" != 0 ]; then
+			ocf_log warn "command failed, rc: $rc"
+			return $OCF_ERR_GENERIC
+		fi
+		sleep 0.5
+	done
 
 	# Reconfigure the local ip address
 	ec2ip_drop
-	ip addr add "${OCF_RESKEY_ip}/32" dev $OCF_RESKEY_interface
+	cmd="ip addr add ${OCF_RESKEY_ip}/32 dev $OCF_RESKEY_interface"
+	ocf_log debug "executing command: $cmd"
+	$cmd
 	rc=$?
 	if [ $rc != 0 ]; then
 		ocf_log warn "command failed, rc: $rc"

--- a/heartbeat/docker
+++ b/heartbeat/docker
@@ -215,7 +215,7 @@ monitor_cmd_exec()
 		out=$(docker exec ${CONTAINER} $OCF_RESKEY_monitor_cmd 2>&1)
 		rc=$?
 	else
-		out=$(echo "$OCF_RESKEY_monitor_cmd" | nsenter --target $(docker inspect --format {{.State.Pid}} ${CONTAINER}) --mount --uts --ipc --net --pid 2>&1)
+		out=$(echo "$OCF_RESKEY_monitor_cmd" | nsenter --target $(docker inspect --type=container --format {{.State.Pid}} ${CONTAINER}) --mount --uts --ipc --net --pid 2>&1)
 		rc=$?
 	fi
 
@@ -236,7 +236,25 @@ monitor_cmd_exec()
 
 container_exists()
 {
-	docker inspect --format {{.State.Running}} $CONTAINER | egrep '(true|false)' >/dev/null 2>&1
+	local err
+
+	err=$(docker inspect --type=container $CONTAINER 2>&1 >/dev/null)
+
+	if [ $? -ne $OCF_SUCCESS ]; then
+		case $err in
+			*"No such container"*)
+				# Return failure instead of exiting if container does not exist
+				return 1
+				;;
+			*)
+				# Exit if error running command
+				ocf_exit_reason "$err"
+				exit $OCF_ERR_GENERIC
+				;;
+		esac
+	fi
+
+	return $OCF_SUCCESS
 }
 
 remove_container()
@@ -265,7 +283,7 @@ docker_simple_status()
 	fi
 
 	# retrieve the 'Running' attribute for the container
-	val=$(docker inspect --format {{.State.Running}} $CONTAINER 2>/dev/null)
+	val=$(docker inspect --type=container --format {{.State.Running}} $CONTAINER 2>/dev/null)
 	if [ $? -ne 0 ]; then
 		#not running as a result of container not being found
 		return $OCF_NOT_RUNNING
@@ -295,7 +313,7 @@ docker_health_status()
                 # if starting takes longer than monitor timeout then upstream will make this fail.
                 while
 
-                        val=$(docker inspect --format {{.State.Health.Status}} $CONTAINER 2>/dev/null)
+                        val=$(docker inspect --type=container --format {{.State.Health.Status}} $CONTAINER 2>/dev/null)
                         if [ $? -ne 0 ]; then
                                 #not healthy as a result of container not being found
                                 return $OCF_NOT_RUNNING

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -39,7 +39,7 @@ get_os_ver() {
 		VER=$(cat $_DEBIAN_VERSION_FILE)
 	elif [ -f $_REDHAT_RELEASE_FILE ]; then
 		OS=RedHat  # redhat or similar
-		VER= # here some complex sed script
+		VER=$(sed "s/.* release \([^ ]\+\).*/\1/" $_REDHAT_RELEASE_FILE)
 	else
 		OS=$(uname -s)
 		VER=$(uname -r)

--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -257,7 +257,7 @@ ha_log()
 
 ha_debug() {
 
-        if [ "x${HA_debug}" = "x0" ] ; then
+        if [ "x${HA_debug}" = "x0" ] || [ -z "${HA_debug}" ] ; then
                 return 0
         fi
 	if tty >/dev/null; then

--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -184,6 +184,7 @@ rmq_app_running() {
 		return $OCF_SUCCESS
 	else
 		ocf_log debug "RabbitMQ application is stopped"
+		rmq_delete_nodename
 		return $OCF_NOT_RUNNING
 	fi
 }
@@ -194,6 +195,7 @@ rmq_node_alive() {
 		return $OCF_SUCCESS
 	else
 		ocf_log debug "RabbitMQ node is down"
+		rmq_delete_nodename
 		return $OCF_NOT_RUNNING
 	fi
 }
@@ -554,6 +556,7 @@ rmq_stop() {
 		sleep 1
 	done
 
+	rmq_delete_nodename
 	remove_pid
 	return $OCF_SUCCESS
 }

--- a/heartbeat/tomcat
+++ b/heartbeat/tomcat
@@ -613,7 +613,6 @@ TOMCAT_NAME="${OCF_RESKEY_tomcat_name-tomcat}"
 TOMCAT_CONSOLE="${OCF_RESKEY_script_log-/var/log/$TOMCAT_NAME.log}"
 RESOURCE_TOMCAT_USER="${OCF_RESKEY_tomcat_user-root}"
 RESOURCE_STATUSURL="${OCF_RESKEY_statusurl-http://127.0.0.1:8080}"
-OCF_RESKEY_force_systemd_default=0
 
 JAVA_HOME="${OCF_RESKEY_java_home}"
 JAVA_OPTS="${OCF_RESKEY_java_opts}"
@@ -628,6 +627,13 @@ if [ -z "$CATALINA_PID" ]; then
 		chown ${RESOURCE_TOMCAT_USER} "${HA_RSCTMP}/${TOMCAT_NAME}_tomcatstate/"
 	fi
 	CATALINA_PID="${HA_RSCTMP}/${TOMCAT_NAME}_tomcatstate/catalina.pid"
+fi
+
+# Only default to true for RedHat systems without catalina.sh
+if [ -e "$CATALINA_HOME/bin/catalina.sh" ] || ! is_redhat_based; then
+	OCF_RESKEY_force_systemd_default=0
+else
+	OCF_RESKEY_force_systemd_default=1
 fi
 
 MAX_STOP_TIME="${OCF_RESKEY_max_stop_time}"

--- a/heartbeat/vdo-vol
+++ b/heartbeat/vdo-vol
@@ -1,0 +1,234 @@
+#!/bin/sh
+#
+#  License:      GNU General Public License (GPL)
+#  (c) 2018 O. Albrigtsen
+#           and Linux-HA contributors
+#
+# -----------------------------------------------------------------------------
+#      O C F    R E S O U R C E    S C R I P T   S P E C I F I C A T I O N
+# -----------------------------------------------------------------------------
+#
+# NAME
+#       vdo-vol : OCF resource agent script for VDO (Virtual Data Optimizer)
+#
+
+# Initialization:
+: ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
+. ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
+
+# Defaults
+OCF_RESKEY_volume_default=""
+
+: ${OCF_RESKEY_volume=${OCF_RESKEY_volume_default}}
+
+
+vdo_usage() {
+  cat <<END
+    usage: $0 (start|stop|validate-all|meta-data|help|usage|monitor)
+    $0 manages VDO (Virtual Data Optimizer) volume(s) as an OCF HA resource.
+    The 'start' operation starts the instance.
+    The 'stop' operation stops the instance.
+    The 'status' operation reports whether the instance is running
+    The 'monitor' operation reports whether the instance seems to be working
+    The 'validate-all' operation reports whether the parameters are valid
+END
+}
+
+vdo_meta_data() {
+        cat <<END
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="vdo-vol">
+<version>0.75</version>
+
+<longdesc lang="en">
+OCF Resource script for VDO (Virtual Data Optimizer) volume(s). It manages VDO volume(s) as a HA resource.
+
+The configuration file needs to be synced to all nodes, and the systemd vdo service must be disabled when
+using this agent.
+</longdesc>
+<shortdesc lang="en">VDO resource agent</shortdesc>
+
+<parameters>
+
+<parameter name="config">
+    <longdesc lang="en">Configuration file</longdesc>
+    <shortdesc lang="en">Config file</shortdesc>
+    <content type="string" default="${OCF_RESKEY_config_default}" />
+</parameter>
+
+<parameter name="volume">
+    <longdesc lang="en">VDO Volume (leave empty for all)</longdesc>
+    <shortdesc lang="en">Volume (empty for all)</shortdesc>
+    <content type="string" default="${OCF_RESKEY_volume_default}" />
+</parameter>
+
+</parameters>
+
+<actions>
+<action name="start" timeout="60s" />
+<action name="stop" timeout="20s" />
+<action name="status" timeout="20s" />
+<action name="monitor" depth="0" timeout="20s" interval="10s" start-delay="10s" />
+<action name="validate-all" timeout="20s" />
+<action name="meta-data" timeout="20s" />
+</actions>
+</resource-agent>
+END
+}
+
+
+rebuild() {
+		ocf_log warn "${OCF_RESKEY_volume} is in $MODE mode, starting in rebuild mode"
+
+		vdo stop $OPTIONS
+
+		while vdo_monitor skiprocheck; do
+			sleep 1
+		done
+
+		vdo start $OPTIONS --forceRebuild
+
+		while ! vdo_monitor; do
+			sleep 1
+		done
+
+		return $?
+}
+
+vdo_start() {
+	# if resource is already running,no need to continue code after this.
+	if vdo_monitor; then
+		ocf_log info "VDO volume(s): ${OCF_RESKEY_volume} is already active"
+		return $OCF_SUCCESS
+	fi
+
+	vdo activate $OPTIONS
+	vdo start $OPTIONS
+
+	while ! vdo_monitor skiprocheck; do
+		sleep 1
+	done
+
+	MODE=$(vdostats --verbose ${OCF_RESKEY_volume} | grep "operating mode" | awk '{print $NF}')
+	if [ $(echo "$MODE" | grep -v "normal" | wc -l) -gt 0 ]; then
+		rebuild
+	fi
+
+	if [ $? -eq $OCF_SUCCESS ]; then
+		ocf_log info "VDO volume(s): ${OCF_RESKEY_volume} activated"
+		return ${OCF_SUCCESS}
+	fi
+
+	return $?
+}
+
+vdo_stop() {
+	vdo_monitor skiprocheck
+	if [ $? -ne $OCF_SUCCESS ]; then
+		# Currently not running. Nothing to do.
+		ocf_log info "VDO volume(s): ${OCF_RESKEY_volume} already deactivated"
+
+		return $OCF_SUCCESS
+	fi
+
+	vdo stop $OPTIONS
+	vdo deactivate $OPTIONS
+
+	# Wait for process to stop
+	while vdo_monitor skiprocheck; do
+		sleep 1
+	done
+
+	return $OCF_SUCCESS
+}
+
+vdo_monitor(){
+	status=$(vdo status $OPTIONS 2>&1)
+	MODE=$(vdostats --verbose ${OCF_RESKEY_volume} | grep "operating mode" | awk '{print $NF}')
+
+	case "$status" in
+		*"Device mapper status: not available"*)
+			return $OCF_NOT_RUNNING
+			;;
+		*"Device mapper status: "*online*)
+			if [ "$MODE" = "read-only" ] && [ "$1" != "skiprocheck" ]; then
+				ocf_log err "VDO volume(s): ${OCF_RESKEY_volume} is in $MODE mode."
+				return $OCF_ERR_GENERIC
+			else
+				return $OCF_SUCCESS
+			fi
+			;;
+		*)
+			ocf_log err "VDO volume(s): ${OCF_RESKEY_volume} failed\n$status"
+			return $OCF_ERR_GENERIC;;
+	esac
+}
+
+vdo_validate_all(){
+	check_binary "vdo"
+
+	if systemctl is-enabled vdo > /dev/null 2>&1; then
+		ocf_exit_reason "systemd service vdo needs to be disabled"
+		exit $OCF_ERR_CONFIGURED
+	fi
+
+	if [ -n "${OCF_RESKEY_config}" ] && [ ! -f "${OCF_RESKEY_config}" ]; then
+		ocf_exit_reason "Configuration file: ${OCF_RESKEY_config} not found"
+		exit $OCF_ERR_CONFIGURED
+	fi
+
+	return $OCF_SUCCESS
+}
+
+
+# **************************** MAIN SCRIPT ************************************
+
+# Make sure meta-data and usage always succeed
+case $__OCF_ACTION in
+	meta-data)
+		vdo_meta_data
+		exit $OCF_SUCCESS
+		;;
+	usage|help)
+		vdo_usage
+		exit $OCF_SUCCESS
+		;;
+esac
+
+# This OCF agent script need to be run as root user.
+if ! ocf_is_root; then
+        echo  "$0 agent script need to be run as root user."
+        ocf_log debug "$0 agent script need to be run as root user."
+        exit $OCF_ERR_GENERIC
+fi
+
+if [ -z "${OCF_RESKEY_volume}" ]; then
+	OPTIONS="-a"
+else
+	OPTIONS="-n ${OCF_RESKEY_volume}"
+fi
+
+if [ -n "${OCF_RESKEY_config}" ]; then
+	OPTIONS="$OPTIONS -f ${OCF_RESKEY_config}"
+fi
+
+# Translate each action into the appropriate function call
+case $__OCF_ACTION in
+	start)
+		vdo_validate_all
+		vdo_start;;
+	stop)
+		vdo_stop;;
+	status|monitor)
+		vdo_monitor;;
+	validate-all)
+		;;
+	*)
+		vdo_usage
+                exit $OCF_ERR_UNIMPLEMENTED;;
+esac
+
+exit $?
+
+# End of this script


### PR DESCRIPTION
The docker RA's stop operation doesn't behave properly in some cases.

1. It returns a false success code in case of an error response from
the daemon.
2. It fails at `remove_container()` if the container does not exist
but another docker object of the same name does exist.

In case 1, the `container_exists()` function returns the same exit code
(1) if the container is not found (an expected error) or if there is an
error response from the docker daemon (an unexpected error). These types
of errors should be handled differently.

In case 2, the `docker inspect` calls do not limit their search to
containers. So if a non-container object is found with a matching name,
the RA attempts to remove a container by that name. Such a container may
not exist.

This patch fixes these issues as follows:
1. Match an error response in `container_exists()` against the string
"No such container".
2. Add `--type=container` to the `docker inspect` calls to restrict
the match.