### PR TITLE
Do not log at debug log level when HA_debug is unset

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -257,7 +257,7 @@ ha_log()
 
 ha_debug() {
 
-        if [ "x${HA_debug}" = "x0" ] ; then
+        if [ "x${HA_debug}" = "x0" ] || [ -z "${HA_debug}" ] ; then
                 return 0
         fi
 	if tty >/dev/null; then


### PR DESCRIPTION
There might be situations (e.g. bundles) where the HA_debug variable
is unset. It makes little sense to enable debug logging when the HA_debug env
variable is unset.
So let's skip debug logs when HA_debug is set to 0 or is unset.

Tested inside a bundle and observed that previously seen 'ocf_log debug'
calls are now correctly suppressed (w/ HA_debug being unset inside the
container)

Signed-off-by: Michele Baldessari <michele@acksyn.org>