### PR TITLE
Add support for multiple VPC routing tables in routing_tables parameter

### DIFF
--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -103,9 +103,9 @@ Deprecated IP address param. Use the ip param instead.
 
 <parameter name="routing_table" required="1">
 <longdesc lang="en">
-Name of the routing table, where the route for the IP address should be changed, i.e. rtb-...
+Name of the routing table(s), where the route for the IP address should be changed. If declaring multiple routing tables they should be separated by comma. Example: rtb-XXXXXXXX,rtb-YYYYYYYYY
 </longdesc>
-<shortdesc lang="en">routing table name</shortdesc>
+<shortdesc lang="en">routing table name(s)</shortdesc>
 <content type="string" default="" />
 </parameter>
 

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -181,7 +181,7 @@ ec2ip_monitor() {
 				ocf_log warn "not routed to this instance ($EC2_INSTANCE_ID) but to instance $ROUTE_TO_INSTANCE on $rtb"
 				MON_RES="$MON_RES $rtb"
 			fi
-			sleep 0.5
+			sleep 1
 		done
 
 		if [ ! -z "$MON_RES" ]; then
@@ -228,7 +228,7 @@ ec2ip_get_and_configure() {
 			ocf_log warn "command failed, rc: $rc"
 			return $OCF_ERR_GENERIC
 		fi
-		sleep 0.5
+		sleep 1
 	done
 
 	# Reconfigure the local ip address

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -165,20 +165,29 @@ ec2ip_validate() {
 }
 
 ec2ip_monitor() {
+        MON_RES=""
 	if ocf_is_true ${OCF_RESKEY_monapi} || [ "$__OCF_ACTION" = "start" ] || ocf_is_probe; then
-		ocf_log info "monitor: check routing table (API call)"
-		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $OCF_RESKEY_routing_table --query RouteTables[*].Routes[?DestinationCidrBlock=='$OCF_RESKEY_ip/32'].InstanceId"
-		ocf_log debug "executing command: $cmd"
-		ROUTE_TO_INSTANCE=$($cmd)
-		ocf_log debug "Overlay IP is currently routed to ${ROUTE_TO_INSTANCE}"
-		if [ -z "$ROUTE_TO_INSTANCE" ]; then
-			ROUTE_TO_INSTANCE="<unknown>"
-		fi
+		for rtb in $(echo $OCF_RESKEY_routing_table | sed -e 's/,/ /g'); do
+			ocf_log info "monitor: check routing table (API call) - $rtb"
+			cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-route-tables --route-table-ids $rtb --query RouteTables[*].Routes[?DestinationCidrBlock=='$OCF_RESKEY_ip/32'].InstanceId"
+			ocf_log debug "executing command: $cmd"
+			ROUTE_TO_INSTANCE="$($cmd)"
+			ocf_log debug "Overlay IP is currently routed to ${ROUTE_TO_INSTANCE}"
+			if [ -z "$ROUTE_TO_INSTANCE" ]; then
+				ROUTE_TO_INSTANCE="<unknown>"
+			fi
 
-		if [ "$EC2_INSTANCE_ID" != "$ROUTE_TO_INSTANCE" ];then 
-			ocf_log warn "not routed to this instance ($EC2_INSTANCE_ID) but to instance $ROUTE_TO_INSTANCE"
+			if [ "$EC2_INSTANCE_ID" != "$ROUTE_TO_INSTANCE" ]; then 
+				ocf_log warn "not routed to this instance ($EC2_INSTANCE_ID) but to instance $ROUTE_TO_INSTANCE on $rtb"
+				MON_RES="$MON_RES $rtb"
+			fi
+			sleep 0.5
+		done
+
+		if [ ! -z "$MON_RES" ]; then
 			return $OCF_NOT_RUNNING
 		fi
+
 	else
 		ocf_log debug "monitor: Enhanced Monitoring disabled - omitting API call"
 	fi
@@ -210,19 +219,23 @@ ec2ip_drop() {
 }
 
 ec2ip_get_and_configure() {
-	# Adjusting the routing table
-	cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 replace-route --route-table-id $OCF_RESKEY_routing_table --destination-cidr-block ${OCF_RESKEY_ip}/32 --instance-id $EC2_INSTANCE_ID"
-	ocf_log debug "executing command: $cmd"
-	$cmd
-	rc=$?
-	if [ "$rc" != 0 ]; then
-		ocf_log warn "command failed, rc: $rc"
-		return $OCF_ERR_GENERIC
-	fi
+	for rtb in $(echo $OCF_RESKEY_routing_table | sed -e 's/,/ /g'); do
+		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 replace-route --route-table-id $rtb --destination-cidr-block ${OCF_RESKEY_ip}/32 --instance-id $EC2_INSTANCE_ID"
+		ocf_log debug "executing command: $cmd"
+		$cmd
+		rc=$?
+		if [ "$rc" != 0 ]; then
+			ocf_log warn "command failed, rc: $rc"
+			return $OCF_ERR_GENERIC
+		fi
+		sleep 0.5
+	done
 
 	# Reconfigure the local ip address
 	ec2ip_drop
-	ip addr add "${OCF_RESKEY_ip}/32" dev $OCF_RESKEY_interface
+	cmd="ip addr add ${OCF_RESKEY_ip}/32 dev $OCF_RESKEY_interface"
+	ocf_log debug "executing command: $cmd"
+	$cmd
 	rc=$?
 	if [ $rc != 0 ]; then
 		ocf_log warn "command failed, rc: $rc"


### PR DESCRIPTION
Hello,

This pull request is to add support for multiple AWS VPC routing tables within a single aws-vpc-move-ip cluster resource as requested by some customers.

Design options were discussed with different people and the options considered were:

a) A single aws-vpc-move-ip resource with a multiple routing tables in `routing_tables` parameter
b) Multiple aws-vpc-move-ip resources but including a "dummy" flag to the ones that were only supposed to manipulate routing tables and not local IPs - basically an aws-vpc-move-ip resource for managing routing tables only

We decided to go with option "A", as it keeps the cluster configuration and topology the way it is today and only modifies a single configuration parameter. For example:

```
primitive res_AWS_IP ocf:suse:aws-vpc-move-ip \
        params address=192.168.1.9 routing_table="rtb-XXXXXXXXXXXXXXXXXX,rtb-YYYYYYYYYYYYYYY" interface=eth0 profile=AWS_CLI_profile \
        op start interval=0 timeout=180 \
        op stop interval=0 timeout=180 \
        op monitor interval=60 timeout=60 \
        meta target-role=Started
```

Lines 236-238 from this request were changed to match coding standards already in place for ec2ip_monitor() and ec2ip_drop()

Example testing from command line is shown below.

To start:

```
OCF_RESKEY_address=192.168.1.9 OCF_RESKEY_routing_table=rtb-XXXXXXXXXXXXXXXXXX,rtb-YYYYYYYYYYYYYYY OCF_RESKEY_profile=AWS_CLI_profile OCF_RESKEY_interface=eth0 OCF_RESKEY_monapi=true OCF_ROOT=/usr/lib/ocf /usr/lib/ocf/resource.d/suse/aws-vpc-move-ip start
```

To monitor:

```
OCF_RESKEY_address=192.168.1.9 OCF_RESKEY_routing_table=rtb-XXXXXXXXXXXXXXXXXX,rtb-YYYYYYYYYYYYYYYOCF_RESKEY_profile=AWS_CLI_profile OCF_RESKEY_interface=eth0 OCF_RESKEY_monapi=true OCF_ROOT=/usr/lib/ocf /usr/lib/ocf/resource.d/suse/aws-vpc-move-ip monitor
```

To stop:

```
OCF_RESKEY_address=192.168.1.9 OCF_RESKEY_routing_table=rtb-XXXXXXXXXXXXXXXXXX,rtb-YYYYYYYYYYYYYYY OCF_RESKEY_profile=AWS_CLI_profile OCF_RESKEY_interface=eth0 OCF_RESKEY_monapi=true OCF_ROOT=/usr/lib/ocf /usr/lib/ocf/resource.d/suse/aws-vpc-move-ip stop
```