### PR TITLE
Medium: pgsql: Set an initial score for primary and hot standby in the prove.

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -974,11 +974,19 @@ pgsql_real_monitor() {
         case "$output" in
             f)  ocf_log debug "PostgreSQL is running as a primary."
                 if [ "$OCF_RESKEY_monitor_sql" = "$OCF_RESKEY_monitor_sql_default" ]; then
+                    if ocf_is_probe; then
+                        # Set initial score for primary.
+                        exec_with_retry 0 $CRM_MASTER -v $PROMOTE_ME
+                    fi
                     return $OCF_RUNNING_MASTER
                 fi
                 ;;
 
             t)  ocf_log debug "PostgreSQL is running as a hot standby."
+                if ocf_is_probe; then
+                    # Set initial score for hot standby.
+                    exec_with_retry 0 $CRM_MASTER -v $CAN_NOT_PROMOTE
+                fi
                 return $OCF_SUCCESS;;
 
             *)  ocf_exit_reason "$CHECK_MS_SQL output is $output"


### PR DESCRIPTION
Currently, pgsql RA does not set an initial score for primary and hot standby in the prove operation.
This behavior cause following problems.

1. If primary PostgreSQL instance detected in the probe operation, then pgsql RA have no chance to set a master score "1000" because pgsql_promote() is not executed.
   It cause unnecessary fail over in some situations. (E.g. restart Pacemaker in the maintenance mode)

2. If hot standby PostgreSQL instance detected in the probe operation, then control_slave_status() can't update master score for hot standby because master score for hot standby is null.
   It cause lack of master score for hot standby in the "crm_mon -A". 

This patch aim to avoid above problems by setting an initial score for primary and hot standby in the prove operation.