### PR TITLE
LVM-activate: fix dmsetup check

### DIFF
--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -715,9 +715,9 @@ lvm_status() {
 	if [ -n "${LV}" ]; then
 		# dmsetup ls? It cannot accept device name. It's
 		# too heavy to list all DM devices.
-		dm_count=$(dmsetup info --noheadings --noflush -c -S "vgname=${VG} && lvname=${LV}" |  wc -l )
+		dm_count=$(dmsetup info --noheadings --noflush -c -S "vgname=${VG} && lvname=${LV}" | grep -c -v '^No devices found')
 	else
-		dm_count=$(dmsetup info --noheadings --noflush -c -S "vgname=${VG}" 2>/dev/null | wc -l )
+		dm_count=$(dmsetup info --noheadings --noflush -c -S "vgname=${VG}" | grep -c -v '^No devices found')
 	fi
 
 	if [ $dm_count -eq 0 ]; then


### PR DESCRIPTION
When there are no devices in the system dmsetup outputs one line:

  # dmsetup info -c
  No devices found