### PR TITLE
redis: Filter warning from stderr when calling 'redis-cli -a'

### DIFF
--- a/heartbeat/redis.in
+++ b/heartbeat/redis.in
@@ -302,7 +302,9 @@ set_score()
 redis_client() {
 	ocf_log debug "redis_client: '$REDIS_CLIENT' -s '$REDIS_SOCKET' $*"
 	if [ -n "$clientpasswd" ]; then
-		"$REDIS_CLIENT" -s "$REDIS_SOCKET" -a "$clientpasswd" "$@" | sed 's/\r//'
+		# Starting with 4.0.10 there is a warning on stderr when using a pass
+		# Once we stop supporting versions < 5.0.0 we can add --no-auth-warning here
+		("$REDIS_CLIENT" -s "$REDIS_SOCKET" -a "$clientpasswd" "$@" 2>&1 >&3 3>&- | grep -v "Using a password" >&2 3>&-) 3>&1 | sed 's/\r//'
 	else
 		"$REDIS_CLIENT" -s "$REDIS_SOCKET" "$@" | sed 's/\r//'
 	fi


### PR DESCRIPTION
In some versions of redis (starting with 4.0.10) we have commits [1] and
[2] which add a warning on stderr which will be printed out every single
time a monitor operation takes place:

  foo pacemaker-remoted[57563]:  notice: redis_monitor_20000:1930:stderr
  [ Warning: Using a password with '-a' option on the command line interface may not be safe. ]

Later on commit [3] (merged with 5.0rc4) was merged which added the option
'--no-auth-warning' to disable said warning since it broke a bunch of
scripts [4]. I tried to forcibly either try the command twice (first
with --no-auth-warning and then without in case of errors) but it is
impossible to distinguish between error due to missing param and other
errors.

So instead of inspecting the version of the redis-cli tool and do the following:
- >= 5.0.0 use --no-auth-warning all the time
- >= 4.0.10 & < 5.0.0 filter the problematic line from stderr only
- else do it like before

We simply filter out from stderr the 'Using a password' message
unconditionally while making sure we keep stdout just the same.

Tested on a redis 4.0.10 cluster and confirmed that it is working as
intended.

All this horror and pain is due to the fact that redis does not support
any other means to pass a password (we could in theory first connect to
the server and then issue an AUTH command, but that seems even more
complex and error prone). See [5] for more info (or [6] for extra fun)

[1] https://github.com/antirez/redis/commit/c082221aefbb2a472c7193dbdbb90900256ce1a2
[2] https://github.com/antirez/redis/commit/ef931ef93e909b4f504e8c6fbed350ed70c1c67c
[3] https://github.com/antirez/redis/commit/a4ef94d2f71a32f73ce4ebf154580307a144b48f
[4] https://github.com/antirez/redis/issues/5073
[5] https://github.com/antirez/redis/issues/3483
[6] https://github.com/antirez/redis/pull/2413

Signed-off-by: Michele Baldessari <michele@acksyn.org>