### PR TITLE
sfex_lib.c: restrict strncpy by size of target, not of source. Fixes gcc error/warning

### DIFF
--- a/tools/sfex_lib.c
+++ b/tools/sfex_lib.c
@@ -426,7 +426,7 @@ read_lockdata (const sfex_controldata * cdata, sfex_lockdata * ldata,
     return -1;
   }
   ldata->count = atoi ((char *) (block->count));
-  strncpy ((char *) (ldata->nodename), (const char *) (block->nodename), sizeof(block->nodename) - 0);
+  strncpy ((char *) (ldata->nodename), (const char *) (block->nodename), sizeof(ldata->nodename));
 
 #ifdef SFEX_DEBUG
   cl_log(LOG_INFO, "status: %c\n", ldata->status);


### PR DESCRIPTION
Fixes a compiler warning. There's not going to be any discernable effect on the application because both fields are 256 byte long.