### PR TITLE
ethmonitor: check if interface exists by link

### DIFF
--- a/heartbeat/ethmonitor
+++ b/heartbeat/ethmonitor
@@ -206,8 +206,8 @@ is_interface() {
 	#
 	# List interfaces but exclude FreeS/WAN ipsecN virtual interfaces
 	#
-	local iface=`$IP2UTIL -o -f inet addr show | grep " $1 " \
-		| cut -d ' ' -f2 | sort -u | grep -v '^ipsec[0-9][0-9]*$'`
+	local iface=`$IP2UTIL -o -f link addr show | grep " $1 " \
+		| cut -d ' ' -f2 | tr -d ':' | sort -u | grep -v '^ipsec[0-9][0-9]*$'`
 		[ "$iface" != "" ]
 }
 


### PR DESCRIPTION
This patch changes the '-f inet' parameter to '-f link' so that all
interfaces are listed correctly in the is_interface() function. Since
this changes output from 'ip' slightly, we also remove a trailing
semicolon from the interface name.

The is_interface() function in ethmonitor tries to match an interface
to a list obtained from the 'ip' tool. It lists interfaces using the
'inet' family, which omits interfaces that don't have an IP address
assigned:

$ ip -a -o -f inet addr show | cut -d ' ' -f2 | sort -u \
  | grep -v '^ipsec[0-9][0-9]*$'
lo
lxdbr0
tun0
virbr0
wlp3s0

If the interface that we're looking for is e.g. a VLAN bridge that does
not have an IP address, it won't show up in the listing and
is_interface() will return false. If we list available interfaces by
link instead, we also get the ones that don't currently have an
address:

$ ip -a -o -f link addr show | cut -d ' ' -f2 | sort -u \
  | grep -v '^ipsec[0-9][0-9]*$' | tr -d ':'
enp0s31f6
lo
lxdbr0
tun0
vethSW7OU3@if37
virbr0
virbr0-nic
vnet0
wlp3s0