### PR TITLE
Support build and install on RHEL 6

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,8 @@ MAINTAINERCLEANFILES	= Makefile.in aclocal.m4 configure DRF/config-h.in \
 			  DRF/stamp-h.in libtool.m4 ltdl.m4 libltdl.tar \
 			  compile config.guess config.sub depcomp
 
+ACLOCAL_AMFLAGS		= -I m4
+
 SPEC			= $(PACKAGE_NAME).spec
 
 TARFILES		= $(PACKAGE_NAME)-$(VERSION).tar.bz2 \

--- a/configure.ac
+++ b/configure.ac
@@ -514,15 +514,17 @@ fi
 AC_PYTHON_MODULE(googleapiclient)
 AC_PYTHON_MODULE(pyroute2)
 
+AS_VERSION_COMPARE([$PYTHON_VERSION], [2.7], [BUILD_OCF_PY=0], [BUILD_OCF_PY=1], [BUILD_OCF_PY=1])
+
 BUILD_AZURE_EVENTS=1
-if test -z "$PYTHON"; then
+if test -z "$PYTHON" || test $BUILD_OCF_PY -eq 0; then
     BUILD_AZURE_EVENTS=0
     AC_MSG_WARN("Not building azure-events")
 fi
 AM_CONDITIONAL(BUILD_AZURE_EVENTS, test $BUILD_AZURE_EVENTS -eq 1)
 
 BUILD_GCP_PD_MOVE=1
-if test -z "$PYTHON" || test "x${HAVE_PYMOD_GOOGLEAPICLIENT}" != xyes; then
+if test -z "$PYTHON" || test "x${HAVE_PYMOD_GOOGLEAPICLIENT}" != xyes || test $BUILD_OCF_PY -eq 0; then
     BUILD_GCP_PD_MOVE=0
     AC_MSG_WARN("Not building gcp-pd-move")
 fi
@@ -530,14 +532,14 @@ AM_CONDITIONAL(BUILD_GCP_PD_MOVE, test $BUILD_GCP_PD_MOVE -eq 1)
 
 BUILD_GCP_VPC_MOVE_ROUTE=1
 if test -z "$PYTHON" || test "x${HAVE_PYMOD_GOOGLEAPICLIENT}" != xyes || \
-   test "x${HAVE_PYMOD_PYROUTE2}" != xyes; then
+   test "x${HAVE_PYMOD_PYROUTE2}" != xyes || test $BUILD_OCF_PY -eq 0; then
     BUILD_GCP_VPC_MOVE_ROUTE=0
     AC_MSG_WARN("Not building gcp-vpc-move-route")
 fi
 AM_CONDITIONAL(BUILD_GCP_VPC_MOVE_ROUTE, test $BUILD_GCP_VPC_MOVE_ROUTE -eq 1)
 
 BUILD_GCP_VPC_MOVE_VIP=1
-if test -z "$PYTHON" || test "x${HAVE_PYMOD_GOOGLEAPICLIENT}" != xyes; then
+if test -z "$PYTHON" || test "x${HAVE_PYMOD_GOOGLEAPICLIENT}" != xyes || test $BUILD_OCF_PY -eq 0; then
     BUILD_GCP_VPC_MOVE_VIP=0
     AC_MSG_WARN("Not building gcp-vpc-move-vip")
 fi

--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -100,12 +100,13 @@ BuildRequires:  libxslt docbook_4 docbook-xsl-stylesheets
 Requires: /usr/bin/gawk
 Requires: /usr/bin/ps
 Requires: /usr/sbin/fuser /usr/bin/mount
+Requires: hostname
 %else
 Requires: /bin/gawk
 Requires: /bin/ps
 Requires: /sbin/fuser /bin/mount
+Requires: /bin/hostname
 %endif
-Requires: bash grep hostname sed
 Requires: /usr/bin/pkill /bin/netstat
 
 # Filesystem / fs.sh / netfs.sh

--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -107,6 +107,7 @@ Requires: /bin/ps
 Requires: /sbin/fuser /bin/mount
 Requires: /bin/hostname
 %endif
+Requires: bash grep sed
 Requires: /usr/bin/pkill /bin/netstat
 
 # Filesystem / fs.sh / netfs.sh

--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -100,14 +100,12 @@ BuildRequires:  libxslt docbook_4 docbook-xsl-stylesheets
 Requires: /usr/bin/gawk
 Requires: /usr/bin/ps
 Requires: /usr/sbin/fuser /usr/bin/mount
-Requires: hostname
 %else
 Requires: /bin/gawk
 Requires: /bin/ps
 Requires: /sbin/fuser /bin/mount
-Requires: /bin/hostname
 %endif
-Requires: /usr/bin/pkill /bin/netstat
+Requires: /usr/bin/pkill /bin/hostname /bin/netstat
 
 # Filesystem / fs.sh / netfs.sh
 %if 0%{?centos_ver} > 6 || 0%{?rhel} > 6

--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -100,12 +100,14 @@ BuildRequires:  libxslt docbook_4 docbook-xsl-stylesheets
 Requires: /usr/bin/gawk
 Requires: /usr/bin/ps
 Requires: /usr/sbin/fuser /usr/bin/mount
+Requires: hostname
 %else
 Requires: /bin/gawk
 Requires: /bin/ps
 Requires: /sbin/fuser /bin/mount
+Requires: /bin/hostname
 %endif
-Requires: /usr/bin/pkill /bin/hostname /bin/netstat
+Requires: /usr/bin/pkill /bin/netstat
 
 # Filesystem / fs.sh / netfs.sh
 %if 0%{?centos_ver} > 6 || 0%{?rhel} > 6


### PR DESCRIPTION
It corresponds to the https://github.com/ClusterLabs/resource-agents/issues/1292 that can not build and install on RHEL 6.
* https://github.com/ClusterLabs/resource-agents/commit/ba0d5e1aa919f8496f8846361314c5dcf2c90546 : fix the issue that AC_PYTHON_MODULE added in https://github.com/ClusterLabs/resource-agents/pull/1294 is not loaded.
* https://github.com/ClusterLabs/resource-agents/commit/edc3e6ba2374b86a1eb13b32529c84edd02b5d4f : in the environment of Python 2.6 or less, skip the build such as ```azure-events```, ```gcp-pd-move```, etc. that use [ocf.py which requires Python 2.7+](https://github.com/ClusterLabs/resource-agents/blob/v4.2.0/doc/dev-guides/writing-python-agents.md#introduction).
* https://github.com/ClusterLabs/resource-agents/commit/73cd7bbd331a5c10dff753a2483bc3382a2397f4 : there is no ```hostname package``` on RHEL 6.