### PR TITLE
IPsrcaddr: make proto optional to fix regression when used without NetworkManager

### DIFF
--- a/heartbeat/IPsrcaddr
+++ b/heartbeat/IPsrcaddr
@@ -50,11 +50,16 @@
 
 #######################################################################
 # Initialization:
-
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
 
+# Defaults
+OCF_RESKEY_proto_default=""
+
+: ${OCF_RESKEY_proto=${OCF_RESKEY_proto_default}}
 #######################################################################
+
+[ -z "$OCF_RESKEY_proto" ] && PROTO="" || PROTO="proto $OCF_RESKEY_proto"
 
 USAGE="usage: $0 {start|stop|status|monitor|validate-all|meta-data}";
 
@@ -96,6 +101,14 @@ dotted quad notation  255.255.255.0).
 </longdesc>
 <shortdesc lang="en">Netmask</shortdesc>
 <content type="string" default=""/>
+</parameter>
+
+<parameter name="proto">
+<longdesc lang="en">
+Proto to match when finding network. E.g. "kernel".
+</longdesc>
+<shortdesc lang="en">Proto</shortdesc>
+<content type="string" default="" />
 </parameter>
 </parameters>
 
@@ -172,7 +185,7 @@ srca_start() {
 		rc=$OCF_SUCCESS
 		ocf_log info "The ip route has been already set.($NETWORK, $INTERFACE, $ROUTE_WO_SRC)"
 	else
-		ip route replace $NETWORK dev $INTERFACE src $1 || \
+		$IP2UTIL route replace $NETWORK dev $INTERFACE src $1 || \
 			errorexit "command 'ip route replace $NETWORK dev $INTERFACE src $1' failed"
 
 		$CMDCHANGE $ROUTE_WO_SRC src $1 || \
@@ -204,7 +217,7 @@ srca_stop() {
 	  
 	[ $rc = 2 ] && errorexit "The address you specified to stop does not match the preferred source address"
 
-	ip route replace $NETWORK dev $INTERFACE || \
+	$IP2UTIL route replace $NETWORK dev $INTERFACE || \
 		errorexit "command 'ip route replace $NETWORK dev $INTERFACE' failed"
 
 	$CMDCHANGE $ROUTE_WO_SRC || \
@@ -473,7 +486,7 @@ rc=$?
 }
 
 INTERFACE=`echo $findif_out | awk '{print $1}'`
-NETWORK=`ip route list dev $INTERFACE scope link proto kernel match $ipaddress|grep -o '^[^ ]*'`
+NETWORK=`$IP2UTIL route list dev $INTERFACE scope link $PROTO match $ipaddress|grep -m 1 -o '^[^ ]*'`
 
 case $1 in
 	start)		srca_start $ipaddress


### PR DESCRIPTION
Also updated NETWORK to only return 1 match to avoid failing when there's more than 1 match.