### PR TITLE
Iscsi target stop in failed resource state

### DIFF
--- a/heartbeat/iSCSILogicalUnit.in
+++ b/heartbeat/iSCSILogicalUnit.in
@@ -448,10 +448,6 @@ iSCSILogicalUnit_start() {
 }
 
 iSCSILogicalUnit_stop() {
-	iSCSILogicalUnit_monitor
-	if [ $? -eq $OCF_NOT_RUNNING ]; then
-		return $OCF_SUCCESS
-	fi
 
 	case $OCF_RESKEY_implementation in
 

--- a/heartbeat/iSCSILogicalUnit.in
+++ b/heartbeat/iSCSILogicalUnit.in
@@ -402,22 +402,19 @@ iSCSILogicalUnit_start() {
 	lio-t)
 		ocf_take_lock $TARGETLOCKFILE
 		ocf_release_lock_on_exit $TARGETLOCKFILE
-		if [ -d /sys/kernel/config/target/core/fileio_${OCF_RESKEY_lio_iblock} ]; then
-			iblock_path="/sys/kernel/config/target/core/fileio_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}"
-		else
-			iblock_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}"
-		fi
-		iblock_attrib_path="$iblock_path/attrib"
 		# For lio, we first have to create a target device, then
 		# add it to the Target Portal Group as an LU.
 		local backstore_type
 		if [ -b "${OCF_RESKEY_path}" ]; then
 			ocf_run targetcli /backstores/block create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
+			iblock_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}"
 			backstore_type=block
 		else
 			ocf_run targetcli /backstores/fileio create name=${OCF_RESOURCE_INSTANCE} file_or_dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
+			iblock_path="/sys/kernel/config/target/core/fileio_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}"
 			backstore_type=fileio
 		fi
+		iblock_attrib_path="$iblock_path/attrib"
 		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
 			echo ${OCF_RESKEY_scsi_sn} > $iblock_path/wwn/vpd_unit_serial
 		fi

--- a/heartbeat/iSCSILogicalUnit.in
+++ b/heartbeat/iSCSILogicalUnit.in
@@ -501,7 +501,7 @@ iSCSILogicalUnit_stop() {
 		# gone. Log a warning and still push ahead.
 		
 		local backstore_type
-		if targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns/lun${OCF_RESKEY_lun} status | grep ' fileio/' >/dev/null; then
+		if targetcli /backstores/fileio/${OCF_RESOURCE_INSTANCE} status >/dev/null 2>&1 ; then
 			backstore_type=fileio
 		else
 			backstore_type=block

--- a/heartbeat/iSCSILogicalUnit.in
+++ b/heartbeat/iSCSILogicalUnit.in
@@ -407,13 +407,12 @@ iSCSILogicalUnit_start() {
 		local backstore_type
 		if [ -b "${OCF_RESKEY_path}" ]; then
 			ocf_run targetcli /backstores/block create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
-			iblock_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}"
 			backstore_type=block
 		else
 			ocf_run targetcli /backstores/fileio create name=${OCF_RESOURCE_INSTANCE} file_or_dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
-			iblock_path="/sys/kernel/config/target/core/fileio_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}"
 			backstore_type=fileio
 		fi
+		iblock_path=`ls -1d /sys/kernel/config/target/core/*/${OCF_RESOURCE_INSTANCE}`
 		iblock_attrib_path="$iblock_path/attrib"
 		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
 			echo ${OCF_RESKEY_scsi_sn} > $iblock_path/wwn/vpd_unit_serial

--- a/heartbeat/iSCSILogicalUnit.in
+++ b/heartbeat/iSCSILogicalUnit.in
@@ -402,14 +402,26 @@ iSCSILogicalUnit_start() {
 	lio-t)
 		ocf_take_lock $TARGETLOCKFILE
 		ocf_release_lock_on_exit $TARGETLOCKFILE
-		iblock_attrib_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/attrib"
+		if [ -d /sys/kernel/config/target/core/fileio_${OCF_RESKEY_lio_iblock} ]; then
+			iblock_path="/sys/kernel/config/target/core/fileio_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}"
+		else
+			iblock_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}"
+		fi
+		iblock_attrib_path="$iblock_path/attrib"
 		# For lio, we first have to create a target device, then
 		# add it to the Target Portal Group as an LU.
-		ocf_run targetcli /backstores/block create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
-		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
-			echo ${OCF_RESKEY_scsi_sn} > /sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/wwn/vpd_unit_serial
+		local backstore_type
+		if [ -b "${OCF_RESKEY_path}" ]; then
+			ocf_run targetcli /backstores/block create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
+			backstore_type=block
+		else
+			ocf_run targetcli /backstores/fileio create name=${OCF_RESOURCE_INSTANCE} file_or_dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
+			backstore_type=fileio
 		fi
-		ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns create /backstores/block/${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
+		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
+			echo ${OCF_RESKEY_scsi_sn} > $iblock_path/wwn/vpd_unit_serial
+		fi
+		ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns create /backstores/$backstore_type/${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
 
 		if $(ip a | grep -q inet6); then
 			ocf_run -q targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/portals delete 0.0.0.0 3260
@@ -491,6 +503,14 @@ iSCSILogicalUnit_stop() {
 		ocf_release_lock_on_exit $TARGETLOCKFILE
 		# "targetcli delete" will fail if the LUN is already
 		# gone. Log a warning and still push ahead.
+		
+		local backstore_type
+		if targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns/lun${OCF_RESKEY_lun} status | grep ' fileio/' >/dev/null; then
+			backstore_type=fileio
+		else
+			backstore_type=block
+		fi
+		
 		ocf_run -warn targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns delete ${OCF_RESKEY_lun}
 		if [ -n "${OCF_RESKEY_allowed_initiators}" ]; then
 			for initiator in ${OCF_RESKEY_allowed_initiators}; do
@@ -504,7 +524,7 @@ iSCSILogicalUnit_stop() {
 		# delete the backstore, then something is seriously
 		# wrong and we need to fail the stop operation
 		# (potentially causing fencing)
-		ocf_run targetcli /backstores/block delete ${OCF_RESOURCE_INSTANCE} || exit $OCF_ERR_GENERIC
+		ocf_run targetcli /backstores/$backstore_type delete ${OCF_RESOURCE_INSTANCE} || exit $OCF_ERR_GENERIC
 		;;
 	esac
 
@@ -559,7 +579,7 @@ iSCSILogicalUnit_monitor() {
 		[ -e ${configfs_path} ] && [ `cat ${configfs_path}` = "${OCF_RESKEY_path}" ] && return $OCF_SUCCESS
 
 		# if we aren't activated, is a block device still left over?
-		block_configfs_path="/sys/kernel/config/target/core/iblock_*/${OCF_RESOURCE_INSTANCE}/udev_path"
+		block_configfs_path="/sys/kernel/config/target/core/{iblock,fileio}_*/${OCF_RESOURCE_INSTANCE}/udev_path"
 		[ -e ${block_configfs_path} ] && ocf_log warn "existing block without an active lun: ${block_configfs_path}"
 		[ -e ${block_configfs_path} ] && return $OCF_ERR_GENERIC
 		;;

--- a/heartbeat/iSCSITarget.in
+++ b/heartbeat/iSCSITarget.in
@@ -391,6 +391,7 @@ iSCSITarget_start() {
 			done
 		else
 			ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/ set attribute authentication=0 demo_mode_write_protect=0 generate_node_acls=1 cache_dynamic_acls=1 || exit $OCF_ERR_GENERIC
+			ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/ set auth userid=${OCF_RESKEY_incoming_username} password=${OCF_RESKEY_incoming_password} || exit $OCF_ERR_GENERIC
 		fi
 		;;
 	esac

--- a/heartbeat/iSCSITarget.in
+++ b/heartbeat/iSCSITarget.in
@@ -390,8 +390,10 @@ iSCSITarget_start() {
 				fi
 			done
 		else
-			ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/ set attribute authentication=0 demo_mode_write_protect=0 generate_node_acls=1 cache_dynamic_acls=1 || exit $OCF_ERR_GENERIC
-			ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/ set auth userid=${OCF_RESKEY_incoming_username} password=${OCF_RESKEY_incoming_password} || exit $OCF_ERR_GENERIC
+			if [ -n "${OCF_RESKEY_incoming_username}" ]; then
+				ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/ set attribute authentication=0 demo_mode_write_protect=0 generate_node_acls=1 cache_dynamic_acls=1 || exit $OCF_ERR_GENERIC
+				ocf_run targetcli /iscsi/${OCF_RESKEY_iqn}/tpg1/ set auth userid=${OCF_RESKEY_incoming_username} password=${OCF_RESKEY_incoming_password} || exit $OCF_ERR_GENERIC
+			fi
 		fi
 		;;
 	esac


### PR DESCRIPTION
When the LUN resource is in failed state e.g. the backing store file or device is not available, this prevented targetcli cleanup.

When the backing store file or device comes back online and admin issues resource cleanup this resulted in targetcli config being partially present and start operation failing.

I'm not sure why this block is there in the first place because subsequent code is prepared for partial targetcli config status.

Is there a reason for stop operation to return success every time the resource is not-running?