### PR TITLE
aws-vpc-move-ip - fix for defect making update of route table fail in case VM has multiple network interfaces

### DIFF
--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -222,25 +222,18 @@ ec2ip_get_and_configure() {
 	MAC_FILE="/sys/class/net/${OCF_RESKEY_interface}/address"
 	if [ -f $MAC_FILE ]; then
 		cmd="cat ${MAC_FILE}"
-		ocf_log debug "executing command: $cmd"
-		MAC_ADDR="$(eval $cmd)"
-		rc=$?
-		if [ $rc != 0 ]; then
-			ocf_log warn "command failed, rc: $rc"
-			return $OCF_ERR_GENERIC
-		fi
-		ocf_log debug "MAC address associated with interface ${OCF_RESKEY_interface}: ${MAC_ADDR}"
 	else
 		cmd="ip -br link show dev ${OCF_RESKEY_interface} | tr -s ' ' | cut -d' ' -f3"
-		ocf_log debug "executing command: $cmd"
-		MAC_ADDR="$(eval $cmd)"
-		rc=$?
-		if [ $rc != 0 ]; then
-			ocf_log warn "command failed, rc: $rc"
-			return $OCF_ERR_GENERIC
-		fi
-		ocf_log debug "MAC address associated with interface ${OCF_RESKEY_interface}: ${MAC_ADDR}"
 	fi
+
+	ocf_log debug "executing command: $cmd"
+	MAC_ADDR="$(eval $cmd)"
+	rc=$?
+	if [ $rc != 0 ]; then
+		ocf_log warn "command failed, rc: $rc"
+		return $OCF_ERR_GENERIC
+	fi
+	ocf_log debug "MAC address associated with interface ${OCF_RESKEY_interface}: ${MAC_ADDR}"
 
 	cmd="curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC_ADDR}/interface-id"
 	ocf_log debug "executing command: $cmd"

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -229,7 +229,7 @@ ec2ip_get_and_configure() {
 	fi
 	ocf_log debug "MAC address associated with interface ${OCF_RESKEY_interface}: ${MAC_ADDR}"
 
-	cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-instances --instance-ids $EC2_INSTANCE_ID --query 'Reservations[*].Instances[*].NetworkInterfaces[*].[NetworkInterfaceId,MacAddress]' | grep ${MAC_ADDR} | cut -f1"
+	cmd="curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC_ADDR}/interface-id"
 	ocf_log debug "executing command: $cmd"
 	EC2_NETWORK_INTERFACE_ID="$(eval $cmd)"
 	rc=$?

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -219,15 +219,28 @@ ec2ip_drop() {
 }
 
 ec2ip_get_and_configure() {
-	cmd="ip -br link show dev $OCF_RESKEY_interface | tr -s ' ' | cut -d' ' -f3"
-	ocf_log debug "executing command: $cmd"
-	MAC_ADDR="$(eval $cmd)"
-	rc=$?
-	if [ $rc != 0 ]; then
-		ocf_log warn "command failed, rc: $rc"
-		return $OCF_ERR_GENERIC
+	MAC_FILE="/sys/class/net/${OCF_RESKEY_interface}/address"
+	if [ -f $MAC_FILE ]; then
+		cmd="cat ${MAC_FILE}"
+		ocf_log debug "executing command: $cmd"
+		MAC_ADDR="$(eval $cmd)"
+		rc=$?
+		if [ $rc != 0 ]; then
+			ocf_log warn "command failed, rc: $rc"
+			return $OCF_ERR_GENERIC
+		fi
+		ocf_log debug "MAC address associated with interface ${OCF_RESKEY_interface}: ${MAC_ADDR}"
+	else
+		cmd="ip -br link show dev ${OCF_RESKEY_interface} | tr -s ' ' | cut -d' ' -f3"
+		ocf_log debug "executing command: $cmd"
+		MAC_ADDR="$(eval $cmd)"
+		rc=$?
+		if [ $rc != 0 ]; then
+			ocf_log warn "command failed, rc: $rc"
+			return $OCF_ERR_GENERIC
+		fi
+		ocf_log debug "MAC address associated with interface ${OCF_RESKEY_interface}: ${MAC_ADDR}"
 	fi
-	ocf_log debug "MAC address associated with interface ${OCF_RESKEY_interface}: ${MAC_ADDR}"
 
 	cmd="curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC_ADDR}/interface-id"
 	ocf_log debug "executing command: $cmd"

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -219,8 +219,28 @@ ec2ip_drop() {
 }
 
 ec2ip_get_and_configure() {
+	cmd="ip -br link show dev $OCF_RESKEY_interface | tr -s ' ' | cut -d' ' -f3"
+	ocf_log debug "executing command: $cmd"
+	MAC_ADDR="$(eval $cmd)"
+	rc=$?
+	if [ $rc != 0 ]; then
+		ocf_log warn "command failed, rc: $rc"
+		return $OCF_ERR_GENERIC
+	fi
+  ocf_log debug "MAC address associated with interface ${OCF_RESKEY_interface}: ${MAC_ADDR}"
+
+	cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-instances --instance-ids $EC2_INSTANCE_ID --query 'Reservations[*].Instances[*].NetworkInterfaces[*].[NetworkInterfaceId,MacAddress]' | grep ${MAC_ADDR} | cut -f1"
+	ocf_log debug "executing command: $cmd"
+	EC2_NETWORK_INTERFACE_ID="$(eval $cmd)"
+	rc=$?
+	if [ $rc != 0 ]; then
+		ocf_log warn "command failed, rc: $rc"
+		return $OCF_ERR_GENERIC
+	fi
+  ocf_log debug "network interface id associated MAC address ${MAC_ADDR}: ${EC2_NETWORK_INTERFACE_ID}"
+
 	for rtb in $(echo $OCF_RESKEY_routing_table | sed -e 's/,/ /g'); do
-		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 replace-route --route-table-id $rtb --destination-cidr-block ${OCF_RESKEY_ip}/32 --instance-id $EC2_INSTANCE_ID"
+		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 replace-route --route-table-id $rtb --destination-cidr-block ${OCF_RESKEY_ip}/32 --network-interface-id $EC2_NETWORK_INTERFACE_ID"
 		ocf_log debug "executing command: $cmd"
 		$cmd
 		rc=$?

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -227,7 +227,7 @@ ec2ip_get_and_configure() {
 		ocf_log warn "command failed, rc: $rc"
 		return $OCF_ERR_GENERIC
 	fi
-  ocf_log debug "MAC address associated with interface ${OCF_RESKEY_interface}: ${MAC_ADDR}"
+	ocf_log debug "MAC address associated with interface ${OCF_RESKEY_interface}: ${MAC_ADDR}"
 
 	cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 describe-instances --instance-ids $EC2_INSTANCE_ID --query 'Reservations[*].Instances[*].NetworkInterfaces[*].[NetworkInterfaceId,MacAddress]' | grep ${MAC_ADDR} | cut -f1"
 	ocf_log debug "executing command: $cmd"
@@ -237,7 +237,7 @@ ec2ip_get_and_configure() {
 		ocf_log warn "command failed, rc: $rc"
 		return $OCF_ERR_GENERIC
 	fi
-  ocf_log debug "network interface id associated MAC address ${MAC_ADDR}: ${EC2_NETWORK_INTERFACE_ID}"
+	ocf_log debug "network interface id associated MAC address ${MAC_ADDR}: ${EC2_NETWORK_INTERFACE_ID}"
 
 	for rtb in $(echo $OCF_RESKEY_routing_table | sed -e 's/,/ /g'); do
 		cmd="$OCF_RESKEY_awscli --profile $OCF_RESKEY_profile --output text ec2 replace-route --route-table-id $rtb --destination-cidr-block ${OCF_RESKEY_ip}/32 --network-interface-id $EC2_NETWORK_INTERFACE_ID"

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -225,7 +225,6 @@ ec2ip_get_and_configure() {
 	else
 		cmd="ip -br link show dev ${OCF_RESKEY_interface} | tr -s ' ' | cut -d' ' -f3"
 	fi
-
 	ocf_log debug "executing command: $cmd"
 	MAC_ADDR="$(eval $cmd)"
 	rc=$?


### PR DESCRIPTION
In case that AWS VM is having more that one network interface the following command with fail:
```
hostname01:/usr/lib/ocf/resource.d/suse # /usr/bin/aws --profile cluster --output text ec2 replace-route --route-table-id rtb-1234a567812a34567 --destination-cidr-block 192.168.1.1/32 --instance-id i-1234567890b012345

An error occurred (InvalidInstanceID) when calling the ReplaceRoute operation: There are multiple interfaces attached to instance 'i-1234567890b012345'. Please specify an interface ID for the operation instead.
```

In such case the command should use `--network-interface-id` parameter.

The adjustment is using value `$OCF_RESKEY_interface` that is already passed down and used in the code to determine MAC address of given network interface and this value is subsequently used to query AWS CLI to get associated network interface id.

This fix does not need any additional security policy privileges and should be non-disruptive to existing implementations.