### PR TITLE
ethmonitor: fix is_interface() regression

### DIFF
--- a/heartbeat/ethmonitor
+++ b/heartbeat/ethmonitor
@@ -206,7 +206,7 @@ is_interface() {
 	#
 	# List interfaces but exclude FreeS/WAN ipsecN virtual interfaces
 	#
-	local iface=`$IP2UTIL -o -f link addr show | grep " $1 " \
+	local iface=`$IP2UTIL -o -f link addr show | grep " $1:" \
 		| cut -d ' ' -f2 | tr -d ':' | sort -u | grep -v '^ipsec[0-9][0-9]*$'`
 		[ "$iface" != "" ]
 }


### PR DESCRIPTION
Commit 40d05029ce0b changed is_interface() to list by link instead of address. We need to adjust the grep filter for the new output format, else we'll miss interfaces.

Apologies for missing this previously. This commit should fix is_interface() to behave as expected for all interfaces:
$ ip -o -f link a | grep " lo "

$ ip -o -f link a | grep " lo:"
1: lo: <LOOPBACK,UP,LOWER_UP> ...