### PR TITLE
galera: Ignore safe_to_bootstrap in grastate.dat in some cases

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -564,10 +564,21 @@ detect_first_master()
 detect_safe_to_bootstrap()
 {
     local safe_to_bootstrap=""
+    local uuid=""
+    local seqno=""
 
     if [ -f ${OCF_RESKEY_datadir}/grastate.dat ]; then
         ocf_log info "attempting to read safe_to_bootstrap flag from ${OCF_RESKEY_datadir}/grastate.dat"
         safe_to_bootstrap=$(sed -n 's/^safe_to_bootstrap:\s*\(.*\)$/\1/p' < ${OCF_RESKEY_datadir}/grastate.dat)
+        uuid=$(sed -n 's/^uuid:\s*\(.*\)$/\1/p' < ${OCF_RESKEY_datadir}/grastate.dat)
+        seqno=$(sed -n 's/^seqno:\s*\(.*\)$/\1/p' < ${OCF_RESKEY_datadir}/grastate.dat)
+    fi
+
+    if [ -z "$uuid" ] || [ -z "$seqno" ] || \
+       [ "$uuid" = "00000000-0000-0000-0000-000000000000" ] || \
+       [ "$seqno" = "-1" ]; then
+        clear_safe_to_bootstrap
+        return
     fi
 
     if [ "$safe_to_bootstrap" = "1" ] || [ "$safe_to_bootstrap" = "0" ]; then


### PR DESCRIPTION
We've seen a case where one node in the cluster had safe_to_bootstrap as
1 in grastate.dat, but apparently the UUID and the last commit (or
seqno) were 00000000-0000-0000-0000-000000000000 and -1 -- which matches
a fresh state.

In that case, we do not want to use that node as a bootstrap node, as it
causes a risk of losing everything.