### PR TITLE
Low: LVM: Change of return code when start fails.

### DIFF
--- a/heartbeat/LVM
+++ b/heartbeat/LVM
@@ -238,7 +238,7 @@ LVM_start() {
 		return $OCF_SUCCESS 
 	else
 		ocf_exit_reason "LVM: $vg did not activate correctly"
-		return $OCF_NOT_RUNNING
+		return $OCF_ERR_GENERIC
 	fi
 }
 


### PR DESCRIPTION
Hi All,
 
We reviewed the return code of the start process of OCF resource agent in connection with the following Pacemaker fix.
 - https://github.com/ClusterLabs/pacemaker/pull/1748
 - https://bugs.clusterlabs.org/show_bug.cgi?id=5383

LVM start processing was not consistent with other resource agents.

It's not 'Must', but I think it's 'Better' to change the return code for consistency.

Best Regards,
Hideo Yamauchi.
