### PR TITLE
pgsql: enhance checks in pgsql_real_start to prevent incorrect status…

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -483,7 +483,7 @@ runasowner() {
             "-q")
                 quietrun="-q"
                 shift 1;;
-            "warn"|"err")
+            "info"|"warn"|"err")
                 loglevel="-$1"
                 shift 1;;
             *)
@@ -544,7 +544,9 @@ pgsql_real_start() {
     local postgres_options
     local rc
 
-    if pgsql_status; then
+    pgsql_real_monitor info
+    rc=$?
+    if [ $rc -eq $OCF_SUCCESS -o $rc -eq $OCF_RUNNING_MASTER ]; then
         ocf_log info "PostgreSQL is already running. PID=`cat $PIDFILE`"
         if is_replication; then
             return $OCF_ERR_GENERIC


### PR DESCRIPTION
In a container environment, there are many cases in which a startup check by PID incorrectly determines that PostgreSQL is running.
### environment
```
Stack: corosync
Current DC: bl460g9n9 (version 1.1.19-1.el7-c3c624e) - partition WITHOUT quorum
Last updated: Thu May  9 10:02:29 2019
Last change: Thu May  9 10:00:12 2019 by root via cibadmin on bl460g9n9

2 nodes configured
6 resources configured

Node bl460g9n9: online
    ipmi                               (stonith:external/ipmi):        Started
    filesystem                         (ocf::heartbeat:Filesystem):    Started
    bundle-ip-192.168.201.141          (ocf::heartbeat:IPaddr2):       Started
    bundle-docker-0                    (ocf::heartbeat:docker):        Started
GuestNode bundle-0@bl460g9n9: online
    pgsql                              (ocf::heartbeat:pgsql):         Started

No inactive resources

```
* PostgreSQL data is placed on a shared disk, mounted on a host, and mapping to the container.
```
    <resources>
      <primitive id="filesystem" class="ocf" provider="heartbeat" type="Filesystem">
        <instance_attributes id="filesystem-instance_attributes">
          <nvpair name="fstype" value="xfs" id="filesystem-instance_attributes-fstype"/>
          <nvpair name="device" value="/dev/mapper/mpatha5" id="filesystem-instance_attributes-device"/>
          <nvpair name="directory" value="/dbfp" id="filesystem-instance_attributes-directory"/>
        </instance_attributes>
      </primitive>
      <bundle id="bundle">
        <docker image="ha:postgres" replicas="1" replicas-per-host="1" options="--log-driver=journald"/>
        <network ip-range-start="192.168.201.141" host-interface="bond0" host-netmask="24">
          <port-mapping id="pg-port" port="5432"/>
        </network>
        <storage>
          <storage-mapping id="pg" source-dir="/dbfp" target-dir="/dbfp" options="rw"/>
          <storage-mapping id="pg-log" source-dir="/var/log/pg_log" target-dir="/var/log/pg_log" options="rw"/>
          <storage-mapping id="pg-ralog" source-dir="/dev/log" target-dir="/dev/log" options="rw"/>
        </storage>
        <primitive class="ocf" id="pgsql" provider="heartbeat" type="pgsql">
          <instance_attributes id="pgsql-attrs">
            <nvpair id="pgctl-attrs" name="pgctl" value="/usr/pgsql-11/bin/pg_ctl"/>
            <nvpair id="psql-attrs" name="psql" value="/usr/pgsql-11/bin/psql"/>
            <nvpair id="pgdata-attrs" name="pgdata" value="/dbfp/pgdata/data"/>
            <nvpair id="pgdba-attrs" name="pgdba" value="postgres"/>
            <nvpair id="pgport-attrs" name="pgport" value="5432"/>
            <nvpair id="pgdb-attrs" name="pgdb" value="template1"/>
          </instance_attributes>
          <operations>
            <op id="pgsql-monitor" name="monitor" interval="60s" timeout="60s" on-fail="fence"/>
          </operations>
        </primitive>
      </bundle>
```
### failure event
If **postmaster.pid is not deleted** due to abnormal termination of the postgres process, etc., the bundle and pgsql start events will be repeated.
```
# grep -E "pgsql\(|crmd\[" /var/log/ha-log
 :
   ## abnormal termination of postgres process is detected.
May  9 10:05:21 bl460g9n9 pgsql(pgsql)[763]: ERROR: command failed: runuser postgres -c cd /dbfp/pgdata/data; kill -s 0 191 >/dev/null 2>&1
May  9 10:05:21 bl460g9n9 pgsql(pgsql)[763]: INFO: PostgreSQL is down
May  9 10:05:21 bl460g9n9 crmd[29121]:    info: Result of monitor operation for pgsql on bundle-0: 7 (not running)
May  9 10:05:21 bl460g9n9 crmd[29121]:    info: Transition aborted by operation pgsql_monitor_60000 'create' on bl460g9n9: Inactive graph
May  9 10:05:21 bl460g9n9 crmd[29121]:    info: Updating failcount for pgsql on bundle-0 after failed monitor: rc=7 (update=value++, time=1557363921)
May  9 10:05:21 bl460g9n9 crmd[29121]:    info: Detected action (2.19) pgsql_monitor_60000.9=not running: failed
May  9 10:05:21 bl460g9n9 crmd[29121]:    info: Transition aborted by transient_attributes.bundle-0 'create': Transient attribute change
May  9 10:05:21 bl460g9n9 crmd[29121]:    info: Transition aborted by status-bundle-0-last-failure-pgsql.monitor_60000 doing create last-failure-pgsql#monitor_60000=1557363921: Transient attribute change
May  9 10:05:21 bl460g9n9 crmd[29121]:  notice: Initiating stop operation bundle-0_stop_0 locally on bl460g9n9
May  9 10:05:21 bl460g9n9 crmd[29121]:    info: Performing key=12:4:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-0_stop_0
May  9 10:05:21 bl460g9n9 crmd[29121]:  notice: Node bundle-0 state is now lost
May  9 10:05:21 bl460g9n9 crmd[29121]:    info: Remote node bundle-0 is now lost (was member)
May  9 10:05:21 bl460g9n9 crmd[29121]:  notice: Result of stop operation for bundle-0 on bl460g9n9: 0 (ok)
May  9 10:05:21 bl460g9n9 crmd[29121]:    info: Action bundle-0_stop_0 (12) confirmed on bl460g9n9 (rc=0)
May  9 10:05:21 bl460g9n9 crmd[29121]:  notice: Initiating stop operation bundle-docker-0_stop_0 locally on bl460g9n9
May  9 10:05:21 bl460g9n9 crmd[29121]:    info: Performing key=10:4:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-docker-0_stop_0
May  9 10:05:21 bl460g9n9 crmd[29121]:    info: Result of monitor operation for bundle-docker-0 on bl460g9n9: Cancelled
May  9 10:05:32 bl460g9n9 crmd[29121]:  notice: Result of stop operation for bundle-docker-0 on bl460g9n9: 0 (ok)
May  9 10:05:32 bl460g9n9 crmd[29121]:    info: Action bundle-docker-0_stop_0 (10) confirmed on bl460g9n9 (rc=0)
May  9 10:05:32 bl460g9n9 crmd[29121]:  notice: Initiating start operation bundle-docker-0_start_0 locally on bl460g9n9
May  9 10:05:32 bl460g9n9 crmd[29121]:    info: Performing key=11:4:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-docker-0_start_0
May  9 10:05:32 bl460g9n9 crmd[29121]:  notice: Result of start operation for bundle-docker-0 on bl460g9n9: 0 (ok)
May  9 10:05:32 bl460g9n9 crmd[29121]:    info: Action bundle-docker-0_start_0 (11) confirmed on bl460g9n9 (rc=0)
May  9 10:05:32 bl460g9n9 crmd[29121]:  notice: Initiating monitor operation bundle-docker-0_monitor_60000 locally on bl460g9n9
May  9 10:05:32 bl460g9n9 crmd[29121]:    info: Performing key=2:4:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-docker-0_monitor_60000
May  9 10:05:32 bl460g9n9 crmd[29121]:  notice: Initiating start operation bundle-0_start_0 locally on bl460g9n9
May  9 10:05:32 bl460g9n9 crmd[29121]:    info: Performing key=13:4:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-0_start_0
May  9 10:05:33 bl460g9n9 crmd[29121]:    info: Result of monitor operation for bundle-docker-0 on bl460g9n9: 0 (ok)
May  9 10:05:33 bl460g9n9 crmd[29121]:    info: Action bundle-docker-0_monitor_60000 (2) confirmed on bl460g9n9 (rc=0)
May  9 10:05:33 bl460g9n9 crmd[29121]:    info: Announcing pacemaker_remote node bundle-0
May  9 10:05:33 bl460g9n9 crmd[29121]:  notice: Node bundle-0 state is now member
May  9 10:05:33 bl460g9n9 crmd[29121]:    info: Remote node bundle-0 is now member (was lost)
May  9 10:05:33 bl460g9n9 crmd[29121]:  notice: Result of start operation for bundle-0 on bl460g9n9: 0 (ok)
May  9 10:05:33 bl460g9n9 crmd[29121]:    info: Action bundle-0_start_0 (13) confirmed on bl460g9n9 (rc=0)
   ## probe determines that "PostgreSQL is down". (No problem with this)
May  9 10:05:33 bl460g9n9 crmd[29121]:  notice: Initiating monitor operation pgsql:0_monitor_0 locally on bundle-0
May  9 10:05:33 bl460g9n9 crmd[29121]:    info: Performing key=4:5:7:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=pgsql_monitor_0
May  9 10:05:33 bl460g9n9 crmd[29121]:  notice: Initiating monitor operation bundle-0_monitor_60000 locally on bl460g9n9
May  9 10:05:33 bl460g9n9 crmd[29121]:    info: Performing key=13:5:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-0_monitor_60000
May  9 10:05:34 bl460g9n9 crmd[29121]:    info: Result of monitor operation for bundle-0 on bl460g9n9: 0 (ok)
May  9 10:05:34 bl460g9n9 crmd[29121]:    info: Action bundle-0_monitor_60000 (13) confirmed on bl460g9n9 (rc=0)
May  9 10:05:34 bl460g9n9 pgsql(pgsql)[20]: INFO: Don't check /dbfp/pgdata/data during probe
May  9 10:05:34 bl460g9n9 pgsql(pgsql)[20]: ERROR: command failed: runuser postgres -c cd /dbfp/pgdata/data; kill -s 0 191 >/dev/null 2>&1
May  9 10:05:34 bl460g9n9 pgsql(pgsql)[20]: INFO: PostgreSQL is down
May  9 10:05:34 bl460g9n9 crmd[29121]:  notice: Result of probe operation for pgsql on bundle-0: 7 (not running)
May  9 10:05:34 bl460g9n9 crmd[29121]:    info: Action pgsql_monitor_0 (4) confirmed on bundle-0 (rc=7)
   ## however, start **erroneously** determines that "PostgreSQL is already running",
May  9 10:05:34 bl460g9n9 crmd[29121]:  notice: Initiating start operation pgsql:0_start_0 locally on bundle-0
May  9 10:05:34 bl460g9n9 crmd[29121]:    info: Performing key=18:5:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=pgsql_start_0
May  9 10:05:35 bl460g9n9 pgsql(pgsql)[109]: INFO: PostgreSQL is already running. PID=191#012/dbfp/pgdata/data#0121557363616#0125432#012/var/run/postgresql#012*#012  5432001         0#012ready
May  9 10:05:35 bl460g9n9 crmd[29121]:  notice: Result of start operation for pgsql on bundle-0: 0 (ok)
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Action pgsql_start_0 (18) confirmed on bundle-0 (rc=0)
   ## as a result, an error occurs in first monitor.
May  9 10:05:35 bl460g9n9 crmd[29121]:  notice: Initiating monitor operation pgsql:0_monitor_60000 locally on bundle-0
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Performing key=19:5:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=pgsql_monitor_60000
May  9 10:05:35 bl460g9n9 pgsql(pgsql)[197]: ERROR: command failed: runuser postgres -c cd /dbfp/pgdata/data; kill -s 0 191 >/dev/null 2>&1
May  9 10:05:35 bl460g9n9 pgsql(pgsql)[197]: INFO: PostgreSQL is down
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Result of monitor operation for pgsql on bundle-0: 7 (not running)
May  9 10:05:35 bl460g9n9 crmd[29121]: warning: Action 19 (pgsql:0_monitor_60000) on bundle-0 failed (target: 0 vs. rc: 7): Error
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Action pgsql_monitor_60000 (19) confirmed on bundle-0 (rc=7)
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Updating failcount for pgsql on bundle-0 after failed monitor: rc=7 (update=value++, time=1557363935)
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Detected action (5.19) pgsql_monitor_60000.9=not running: failed
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Transition aborted by transient_attributes.bundle-0 'create': Transient attribute change
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Transition aborted by status-bundle-0-last-failure-pgsql.monitor_60000 doing create last-failure-pgsql#monitor_60000=1557363935: Transient attribute change
May  9 10:05:35 bl460g9n9 crmd[29121]:  notice: Initiating stop operation bundle-0_stop_0 locally on bl460g9n9
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Performing key=12:7:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-0_stop_0
May  9 10:05:35 bl460g9n9 crmd[29121]:  notice: Node bundle-0 state is now lost
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Remote node bundle-0 is now lost (was member)
May  9 10:05:35 bl460g9n9 crmd[29121]:  notice: Result of stop operation for bundle-0 on bl460g9n9: 0 (ok)
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Action bundle-0_stop_0 (12) confirmed on bl460g9n9 (rc=0)
May  9 10:05:35 bl460g9n9 crmd[29121]:  notice: Initiating stop operation bundle-docker-0_stop_0 locally on bl460g9n9
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Performing key=10:7:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-docker-0_stop_0
May  9 10:05:35 bl460g9n9 crmd[29121]:    info: Result of monitor operation for bundle-docker-0 on bl460g9n9: Cancelled
May  9 10:05:46 bl460g9n9 crmd[29121]:  notice: Result of stop operation for bundle-docker-0 on bl460g9n9: 0 (ok)
May  9 10:05:46 bl460g9n9 crmd[29121]:    info: Action bundle-docker-0_stop_0 (10) confirmed on bl460g9n9 (rc=0)
May  9 10:05:46 bl460g9n9 crmd[29121]:  notice: Initiating start operation bundle-docker-0_start_0 locally on bl460g9n9
May  9 10:05:46 bl460g9n9 crmd[29121]:    info: Performing key=11:7:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-docker-0_start_0
May  9 10:05:47 bl460g9n9 crmd[29121]:  notice: Result of start operation for bundle-docker-0 on bl460g9n9: 0 (ok)
May  9 10:05:47 bl460g9n9 crmd[29121]:    info: Action bundle-docker-0_start_0 (11) confirmed on bl460g9n9 (rc=0)
May  9 10:05:47 bl460g9n9 crmd[29121]:  notice: Initiating monitor operation bundle-docker-0_monitor_60000 locally on bl460g9n9
May  9 10:05:47 bl460g9n9 crmd[29121]:    info: Performing key=2:7:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-docker-0_monitor_60000
May  9 10:05:47 bl460g9n9 crmd[29121]:  notice: Initiating start operation bundle-0_start_0 locally on bl460g9n9
May  9 10:05:47 bl460g9n9 crmd[29121]:    info: Performing key=13:7:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-0_start_0
May  9 10:05:47 bl460g9n9 crmd[29121]:    info: Result of monitor operation for bundle-docker-0 on bl460g9n9: 0 (ok)
May  9 10:05:47 bl460g9n9 crmd[29121]:    info: Action bundle-docker-0_monitor_60000 (2) confirmed on bl460g9n9 (rc=0)
May  9 10:05:47 bl460g9n9 crmd[29121]:    info: Announcing pacemaker_remote node bundle-0
May  9 10:05:47 bl460g9n9 crmd[29121]:  notice: Node bundle-0 state is now member
May  9 10:05:47 bl460g9n9 crmd[29121]:    info: Remote node bundle-0 is now member (was lost)
May  9 10:05:47 bl460g9n9 crmd[29121]:  notice: Result of start operation for bundle-0 on bl460g9n9: 0 (ok)
May  9 10:05:47 bl460g9n9 crmd[29121]:    info: Action bundle-0_start_0 (13) confirmed on bl460g9n9 (rc=0)
   ## probe -> "PostgreSQL is down"
May  9 10:05:47 bl460g9n9 crmd[29121]:  notice: Initiating monitor operation pgsql:0_monitor_0 locally on bundle-0
May  9 10:05:48 bl460g9n9 crmd[29121]:    info: Performing key=4:8:7:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=pgsql_monitor_0
May  9 10:05:48 bl460g9n9 crmd[29121]:  notice: Initiating monitor operation bundle-0_monitor_60000 locally on bl460g9n9
May  9 10:05:48 bl460g9n9 crmd[29121]:    info: Performing key=13:8:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=bundle-0_monitor_60000
May  9 10:05:48 bl460g9n9 crmd[29121]:    info: Result of monitor operation for bundle-0 on bl460g9n9: 0 (ok)
May  9 10:05:48 bl460g9n9 crmd[29121]:    info: Action bundle-0_monitor_60000 (13) confirmed on bl460g9n9 (rc=0)
May  9 10:05:48 bl460g9n9 pgsql(pgsql)[20]: INFO: Don't check /dbfp/pgdata/data during probe
May  9 10:05:48 bl460g9n9 pgsql(pgsql)[20]: ERROR: command failed: runuser postgres -c cd /dbfp/pgdata/data; kill -s 0 191 >/dev/null 2>&1
May  9 10:05:48 bl460g9n9 pgsql(pgsql)[20]: INFO: PostgreSQL is down
May  9 10:05:48 bl460g9n9 crmd[29121]:  notice: Result of probe operation for pgsql on bundle-0: 7 (not running)
May  9 10:05:48 bl460g9n9 crmd[29121]:    info: Action pgsql_monitor_0 (4) confirmed on bundle-0 (rc=7)
   ## start -> "PostgreSQL is already running"
May  9 10:05:48 bl460g9n9 crmd[29121]:  notice: Initiating start operation pgsql:0_start_0 locally on bundle-0
May  9 10:05:48 bl460g9n9 crmd[29121]:    info: Performing key=18:8:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=pgsql_start_0
May  9 10:05:49 bl460g9n9 pgsql(pgsql)[109]: INFO: PostgreSQL is already running. PID=191#012/dbfp/pgdata/data#0121557363616#0125432#012/var/run/postgresql#012*#012  5432001         0#012ready
May  9 10:05:49 bl460g9n9 crmd[29121]:  notice: Result of start operation for pgsql on bundle-0: 0 (ok)
May  9 10:05:49 bl460g9n9 crmd[29121]:    info: Action pgsql_start_0 (18) confirmed on bundle-0 (rc=0)
   ## monitor -> "PostgreSQL is down"
May  9 10:05:49 bl460g9n9 crmd[29121]:  notice: Initiating monitor operation pgsql:0_monitor_60000 locally on bundle-0
May  9 10:05:49 bl460g9n9 crmd[29121]:    info: Performing key=19:8:0:535e7c82-e025-4b4f-97ba-3a6b00d6cf74 op=pgsql_monitor_60000
May  9 10:05:50 bl460g9n9 pgsql(pgsql)[197]: ERROR: command failed: runuser postgres -c cd /dbfp/pgdata/data; kill -s 0 191 >/dev/null 2>&1
May  9 10:05:50 bl460g9n9 pgsql(pgsql)[197]: INFO: PostgreSQL is down
May  9 10:05:50 bl460g9n9 crmd[29121]:    info: Result of monitor operation for pgsql on bundle-0: 7 (not running)
May  9 10:05:50 bl460g9n9 crmd[29121]: warning: Action 19 (pgsql:0_monitor_60000) on bundle-0 failed (target: 0 vs. rc: 7): Error
 :
```
### cause
This is because a PID recorded in postmaster.pid matches a bash PID for checking the PID.

take an example,
 * *before* abnormal termination of postgres process :
   * postgres PID in the container is 191 (in my environment this is roughly this ID), so `191` is recorded in postmaster.pid.
```
[bl460g9n9 ~]# docker exec -it 753025bf234f /bin/bash
[root@bundle-0 /]# ps -ef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 04:54 ?        00:00:00 pcmk-init
root         7     1  0 04:54 ?        00:00:00 /usr/sbin/pacemaker_remoted
postgres   191     1  1 04:54 ?        00:00:00 /usr/pgsql-11/bin/postgres -D /dbfp/pgdata/data -c config_file=/dbfp/pgdata/data/postgresql.conf
postgres   236   191  0 04:54 ?        00:00:00 postgres: logger
postgres   238   191  0 04:54 ?        00:00:00 postgres: checkpointer
postgres   239   191  0 04:54 ?        00:00:00 postgres: background writer
postgres   240   191  0 04:54 ?        00:00:00 postgres: walwriter
postgres   241   191  0 04:54 ?        00:00:00 postgres: autovacuum launcher
postgres   242   191  0 04:54 ?        00:00:00 postgres: archiver
postgres   243   191  0 04:54 ?        00:00:00 postgres: stats collector
```
 * *after* abnormal termination of postgres process :
   * if a PID of bash that executes  ``kill -s 0 191``(L915 *1 called from pgsql_real_start *2) is 191, it is incorrectly determined that a postgres process exists.
   * *1 https://github.com/ClusterLabs/resource-agents/blob/25f2052bc077e49369950a35e009ee11f0bf50e6/heartbeat/pgsql#L911-L921
   * *2 https://github.com/ClusterLabs/resource-agents/blob/25f2052bc077e49369950a35e009ee11f0bf50e6/heartbeat/pgsql#L542-L554
   * in fact, because the following state, it is incorrectly determined that a postgres process exists.
```
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 05:22 ?        00:00:00 pcmk-init
root         7     1  2 05:22 ?        00:00:00 /usr/sbin/pacemaker_remoted
root       109     7 55 05:22 ?        00:00:00 /bin/sh -x /usr/lib/ocf/resource.d/heartbeat/pgsql start
root       189   109  0 05:22 ?        00:00:00 /bin/sh -x /usr/lib/ocf/resource.d/heartbeat/pgsql start
root       190   189  0 05:22 ?        00:00:00 runuser postgres -c cd /dbfp/pgdata/data; ps -ef >>/var/log/pg_log/pid.log; kill -s 0 191 >/dev/null 2>&1
postgres   191   190  0 05:22 ?        00:00:00 bash -c cd /dbfp/pgdata/data; ps -ef >>/var/log/pg_log/pid.log; kill -s 0 191 >/dev/null 2>&1
postgres   192   191  0 05:22 ?        00:00:00 ps -ef
```