### PR TITLE
ldirectord: Remove /var/lock from systemd unit

### DIFF
--- a/ldirectord/systemd/ldirectord.service.in
+++ b/ldirectord/systemd/ldirectord.service.in
@@ -4,9 +4,7 @@ Documentation=man:ldirectord(8)
 
 [Service]
 ExecStart=@sbindir@/ldirectord start
-ExecStartPost=/usr/bin/touch /var/lock/subsys/ldirectord
 ExecStop=@sbindir@/ldirectord stop
-ExecStopPost=@RM@ -f /var/lock/subsys/ldirectord
 ExecReload=@sbindir@/ldirectord reload
 PIDFile=/var/run/ldirectord.ldirectord.pid
 Type=forking


### PR DESCRIPTION
The /var/lock/subsys/ directory is used in sysv init scripts, but are
not necessary in systemd services. If /var/lock/subsys/ does not exist,
the systemd service will fail to start due to the missing folder for the
ExecStartPost command. Since these locks are not required in systemd
services, we can safely remove them from the ldirectord unit file.