### PR TITLE
galera: Add "check_passwd_use_empty" parameter

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -82,6 +82,13 @@ elif [ -f "/etc/default/clustercheck" ]; then
 fi
 
 #######################################################################
+# Defaults:
+
+OCF_RESKEY_check_passwd_use_empty_default=0
+
+: ${OCF_RESKEY_check_passwd_use_empty=${OCF_RESKEY_check_passwd_use_empty_default}}
+
+#######################################################################
 
 usage() {
   cat <<UEND
@@ -243,10 +250,21 @@ Cluster check user.
 
 <parameter name="check_passwd" unique="0" required="0">
 <longdesc lang="en">
-Cluster check user password
+Cluster check user password. Empty passwords are ignored unless
+the parameter "check_passwd_use_empty" is set to 1.
 </longdesc>
 <shortdesc lang="en">check password</shortdesc>
 <content type="string" default="" />
+</parameter>
+
+<parameter name="check_passwd_use_empty" unique="0" required="0">
+<longdesc lang="en">
+Use an empty "check_passwd" password. If this parameter is set to 1,
+"check_passwd" will be ignored and an empty password is used
+when calling the "mysql" client binary.
+</longdesc>
+<shortdesc lang="en">check password use empty</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_check_passwd_use_empty_default}"/>
 </parameter>
 
 </parameters>
@@ -955,7 +973,10 @@ fi
 : ${OCF_RESKEY_check_user="root"}
 
 MYSQL_OPTIONS_CHECK="-nNE --user=${OCF_RESKEY_check_user}"
-if [ -n "${OCF_RESKEY_check_passwd}" ]; then
+
+if ocf_is_true "${OCF_RESKEY_check_passwd_use_empty}"; then
+    MYSQL_OPTIONS_CHECK="$MYSQL_OPTIONS_CHECK --password=''"
+elif [ -n "${OCF_RESKEY_check_passwd}" ]; then
     MYSQL_OPTIONS_CHECK="$MYSQL_OPTIONS_CHECK --password=${OCF_RESKEY_check_passwd}"
 fi
 


### PR DESCRIPTION
When using a custom "check_user" without a "check_password" *and* the
user has a .my.cnf file in its home directory, the monitoring fails
like:

Operation promote for galera:0 (ocf:heartbeat:galera) returned: 'unknown error' (1)
 >  stderr: INFO: Node <d52-54-77-77-01-02> is bootstrapping the cluster
 >  stderr: ERROR: MySQL is not running
 >  stderr: INFO: Waiting on node <d52-54-77-77-01-01> to report database status before Master instances can start.
 >  stderr: INFO: MySQL is not running
 >  stderr: INFO: MySQL is not running
 >  stderr: ERROR 1045 (28000): Access denied for user 'monitoring'@'localhost' (using password: YES)
 >  stderr: ocf-exit-reason:Unable to retrieve wsrep_cluster_status, verify check_user 'monitoring' has permissions to view status
 >  stderr: ocf-exit-reason:local node <d52-54-77-77-01-02> is started, but not in primary mode. Unknown state.
 >  stderr: ocf-exit-reason:Failed initial monitor action

This happens because the credentials from ~/.my.cnf are used. Adding
the "--no-defaults" parameter to the mysql client call solves this.