### PR TITLE
CTDB: fix version string with vendor trailer comparison

### DIFF
--- a/heartbeat/CTDB.in
+++ b/heartbeat/CTDB.in
@@ -588,7 +588,7 @@ ctdb_start() {
 	local log_option
 	# --logging supported from v4.3.0 and --logfile / --syslog support 
 	# has been removed from newer versions
-	version=$(ctdb version | awk '{print $NF}' | sed "s/\.\?[[:alpha:]].*//")
+	version=$(ctdb version | awk '{print $NF}' | sed "s/[-\.]\?[[:alpha:]].*//")
 	ocf_version_cmp "$version" "4.2.14"
 	if [ "$?" -eq "2" ]; then
 		log_option="--logging=file:$OCF_RESKEY_ctdb_logfile"


### PR DESCRIPTION
commit 4a31eb7 should handle a -VENDOR trailer
+ e.g. 4.0.0-VendorVersion

however when using the sed from 4a31eb7 on a version string with vendor trailer e.g.

echo "4.0.0-VendorVersion" | awk '{print $NF}' | sed "s/.?[[:alpha:]].*//"

yields

4.0.0-

after fix

echo "4.0.0rc1" | awk '{print $NF}' | sed "s/[-\.]\?[[:alpha:]].*//"
4.0.0

echo "4.0.0-VendorVersion" | awk '{print $NF}' | sed "s/[-\.]\?[[:alpha:]].*//"
4.0.0

echo "4.0.0.GIT.1a2b3c4d" | awk '{print $NF}' | sed "s/[-\.]\?[[:alpha:]].*//"
4.0.0

Fixes: https://github.com/ClusterLabs/resource-agents/issues/1333

Signed-off-by: Noel Power <noel.power@suse.com>