### PR TITLE
Fails docker RA gracefully when command not found or daemon is not running

### DIFF
--- a/heartbeat/docker
+++ b/heartbeat/docker
@@ -33,6 +33,11 @@
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
 
+# Parameter defaults
+
+OCF_RESKEY_daemon_pidfile_default="/var/run/docker.pid"
+: ${OCF_RESKEY_daemon_pidfile=${OCF_RESKEY_daemon_pidfile_default}}
+
 #######################################################################
 
 meta_data()
@@ -176,6 +181,16 @@ container to be considered healthy.
 <content type="boolean"/>
 </parameter>
 
+<parameters>
+<parameter name="daemon_pidfile" required="0" unique="0">
+<longdesc lang="en">
+The RA will report not running status on hosts where the docker daemon
+is not running.
+</longdesc>
+<shortdesc lang="en">Name of the docker daemon pid file</shortdesc>
+<content type="string" default="${OCF_RESKEY_daemon_pidfile_default}"/>
+</parameter>
+
 </parameters>
 
 <actions>
@@ -276,6 +291,16 @@ remove_container()
 docker_simple_status()
 {
 	local val
+
+	if [ ! -x "$(command -v docker)" ]; then 
+		ocf_log err "docker is not installed on this host"
+		return $OCF_ERR_INSTALLED
+	fi
+
+	if [ ! -e "$OCF_RESKEY_daemon_pidfile" ]; then
+		ocf_log err "docker daemon is not running, pid file $OCF_RESKEY_daemon_pidfile not exists"
+		return $OCF_NOT_RUNNING
+	fi
 
 	container_exists
 	if [ $? -ne 0 ]; then

--- a/heartbeat/docker
+++ b/heartbeat/docker
@@ -181,7 +181,6 @@ container to be considered healthy.
 <content type="boolean"/>
 </parameter>
 
-<parameters>
 <parameter name="daemon_pidfile" required="0" unique="0">
 <longdesc lang="en">
 The RA will report not running status on hosts where the docker daemon


### PR DESCRIPTION
Using the docker RA, when a docker resource is configured then the cluster reports the following error from all nodes without docker:

```
* docker-tutorial1_stop_0 on mgr 'unknown error' (1): call=253, status=complete, exitreason='/usr/lib/ocf/resource.d/heartbeat/docker:241: /usr/lib/ocf/resource.d/heartbeat/docker: docker: not found',
    last-rc-change='Thu May 16 12:56:14 2019', queued=0ms, exec=35ms
```

This is caused by `container_exists` which does not catch this error when running `docker inspect`.

Other RAs (e.g.: mysql, jboss) fail more gracefully on nodes where the commands are not available.

This patch adds 2 more checks to the monitor action:
* Checks if the `docker` command is available on the node. If not, fails with `OCF_ERR_INSTALLED`
* Checks if the docker daemon is runnig by checking the pid file (similar to what the mysql RA does). If not, then fails with `OCF_NOT_RUNNING`

This patch introduces a new optional parameter:
* `daemon_pidfile` which defaults to `/var/run/docker.pid`
