### PR TITLE
Low: Filesystem: Fix missing mount point due to corrupted mount list

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -255,16 +255,26 @@ is_bind_mount() {
 }
 list_mounts() {
 	local inpf=""
+	local mount_list=""
+	local check_list="x"
+
 	if [ -e "/proc/mounts" ] && ! is_bind_mount; then
 		inpf=/proc/mounts
 	elif [ -f "/etc/mtab" -a -r "/etc/mtab" ]; then
 		inpf=/etc/mtab
 	fi
-	if [ "$inpf" ]; then
-		cut -d' ' -f1,2,3 < $inpf
-	else
-		$MOUNT | cut -d' ' -f1,3,5
-	fi
+
+	# Make sure that the mount list has not been changed while reading.
+	while [ "$mount_list" != "$check_list" ]; do
+		check_list=$mount_list
+		if [ "$inpf" ]; then
+			mount_list=$(cut -d' ' -f1,2,3 < $inpf)
+		else
+			mount_list=$($MOUNT | cut -d' ' -f1,3,5)
+		fi
+	done
+
+	echo "$mount_list"
 }
 
 determine_blockdevice() {


### PR DESCRIPTION
### Problem
I create 80 Filesystem resources in the my test environment and encountered the following problems.
- sometimes mount point remains after stop all Filesystem resources
- incorrect monitor error detected when  stop one of Filesystem resources

These problems are caused by corrupted mount list returned from list_mounts().
"grep -q " $MOUNTPOINT "" does not matches and missing mount point although the mount point exists.

### Reproduction procedure
- create many Filesystem resource(I create 80 resources)
- set "node-action-limit=80" and "batch-limit=80"
- stop all Filesystem resource using "crm node standby active-host"

Under the above conditions, issue occur about once every 100 times.
(It depends on the performance of the test environment)

### Cause and measures
Why list_mounts() returns corrupted mount list is that atomicity of read data from "/proc/mount" is not guaranteed.
cut(and others) command read 1 KByte data from "/proc/mounts" at a time using the read() system call.
But, the size of "/proc/mounts" exceeds 1Kbyte in the recent RHEL7 system and read() is performed in multiple parts.
If "/proc/mounts" changed in the performing read() system call, then remaining date from "/proc/mount" is affected.

To avoid this problem, it is necessary to ensure that "/proc/mounts" has not been changed during reading.
If "/proc/mounts" is changed, it will retry reading.