### PR TITLE
Add option to override LIO backstore name

### DIFF
--- a/heartbeat/iSCSILogicalUnit.in
+++ b/heartbeat/iSCSILogicalUnit.in
@@ -62,7 +62,7 @@ OCF_RESKEY_scsi_sn_default=${sn:0:8}
 # set 0 as a default value for lio iblock device number
 OCF_RESKEY_lio_iblock_default=0
 OCF_RESKEY_lio_iblock=${OCF_RESKEY_lio_iblock:-$OCF_RESKEY_lio_iblock_default}
-
+OCF_RESKEY_backstore_name=${OCF_RESKEY_backstore_name:-$OCF_RESOURCE_INSTANCE}
 ## tgt specifics
 # tgt has "backing store type" and "backing store open flags",
 # as well as device-type.
@@ -145,6 +145,17 @@ The default is a hash of the resource name, truncated to 8 bytes.
 </longdesc>
 <shortdesc lang="en">SCSI serial number</shortdesc>
 <content type="string" default="${OCF_RESKEY_scsi_sn_default}"/>
+</parameter>
+
+<parameter name="backstore_name" required="0" unique="1">
+<longdesc lang="en">
+The name to be given to the LIO-T backing store for this Logical Unit.
+The first 16 bytes of this will be used in the SCSI INQUIRY response
+for the LUN
+The default is the resource name.
+</longdesc>
+<shortdesc lang="en">Backing Store Name</shortdesc>
+<content type="string" default="${OCF_RESOURCE_INSTANCE}"/>
 </parameter>
 
 <parameter name="emulate_tpu" required="0" unique="0">
@@ -363,26 +374,26 @@ iSCSILogicalUnit_start() {
 		# For lio, we first have to create a target device, then
 		# add it to the Target Portal Group as an LU.
 
-		block_configfs_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/udev_path"
+		block_configfs_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESKEY_backstore_name}/udev_path"
 		if [ ! -e "${block_configfs_path}" ]; then
-			ocf_run tcm_node --createdev=iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE} \
+			ocf_run tcm_node --createdev=iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESKEY_backstore_name} \
 				${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
 		elif [ -e "$block_configfs_path" ] && [ $(cat "$block_configfs_path") != "${OCF_RESKEY_path}" ]; then
-			ocf_exit_reason "Existing iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE} has incorrect path: $(cat "$block_configfs_path") != ${OCF_RESKEY_path}"
+			ocf_exit_reason "Existing iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESKEY_backstore_name} has incorrect path: $(cat "$block_configfs_path") != ${OCF_RESKEY_path}"
 			exit $OCF_ERR_GENERIC
 		else
 			ocf_log info "iscsi iblock already exists: ${block_configfs_path}"
 		fi
 
 		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
-			ocf_run tcm_node --setunitserial=iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE} \
+			ocf_run tcm_node --setunitserial=iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESKEY_backstore_name} \
 				${OCF_RESKEY_scsi_sn} || exit $OCF_ERR_GENERIC
 		fi
 
 		lun_configfs_path="/sys/kernel/config/target/iscsi/${OCF_RESKEY_target_iqn}/tpgt_1/lun/lun_${OCF_RESKEY_lun}/${OCF_RESOURCE_INSTANCE}/udev_path"
 		if [ ! -e "${lun_configfs_path}" ]; then
 			ocf_run lio_node --addlun=${OCF_RESKEY_target_iqn} 1 ${OCF_RESKEY_lun} \
-				${OCF_RESOURCE_INSTANCE} iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE} || exit $OCF_ERR_GENERIC
+				${OCF_RESOURCE_INSTANCE} iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESKEY_backstore_name} || exit $OCF_ERR_GENERIC
 		else
 			ocf_log info "iscsi lun already exists: ${lun_configfs_path}"
 		fi
@@ -402,14 +413,14 @@ iSCSILogicalUnit_start() {
 	lio-t)
 		ocf_take_lock $TARGETLOCKFILE
 		ocf_release_lock_on_exit $TARGETLOCKFILE
-		iblock_attrib_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/attrib"
+		iblock_attrib_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESKEY_backstore_name}/attrib"
 		# For lio, we first have to create a target device, then
 		# add it to the Target Portal Group as an LU.
-		ocf_run targetcli /backstores/block create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
+		ocf_run targetcli /backstores/block create name=${OCF_RESKEY_backstore_name} dev=${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
 		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
-			echo ${OCF_RESKEY_scsi_sn} > /sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/wwn/vpd_unit_serial
+			echo ${OCF_RESKEY_scsi_sn} > /sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESKEY_backstore_name}/wwn/vpd_unit_serial
 		fi
-		ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns create /backstores/block/${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
+		ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns create /backstores/block/${OCF_RESKEY_backstore_name} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
 
 		if $(ip a | grep -q inet6); then
 			ocf_run -q targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/portals delete 0.0.0.0 3260
@@ -481,9 +492,9 @@ iSCSILogicalUnit_stop() {
 		if [ -e "${lun_configfs_path}" ]; then
 			ocf_run lio_node --dellun=${OCF_RESKEY_target_iqn} 1 ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
 		fi
-		block_configfs_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/udev_path"
+		block_configfs_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESKEY_backstore_name}/udev_path"
 		if [ -e "${block_configfs_path}" ]; then
-			ocf_run tcm_node --freedev=iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE} || exit $OCF_ERR_GENERIC
+			ocf_run tcm_node --freedev=iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESKEY_backstore_name} || exit $OCF_ERR_GENERIC
 		fi
 		;;
 	lio-t)
@@ -504,7 +515,7 @@ iSCSILogicalUnit_stop() {
 		# delete the backstore, then something is seriously
 		# wrong and we need to fail the stop operation
 		# (potentially causing fencing)
-		ocf_run targetcli /backstores/block delete ${OCF_RESOURCE_INSTANCE} || exit $OCF_ERR_GENERIC
+		ocf_run targetcli /backstores/block delete ${OCF_RESKEY_backstore_name} || exit $OCF_ERR_GENERIC
 		;;
 	esac
 
@@ -549,7 +560,7 @@ iSCSILogicalUnit_monitor() {
 		[ -e ${configfs_path} ] && [ `cat ${configfs_path}` = "${OCF_RESKEY_path}" ] && return $OCF_SUCCESS
 
 		# if we aren't activated, is a block device still left over?
-		block_configfs_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/udev_path"
+		block_configfs_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESKEY_backstore_name}/udev_path"
 		[ -e ${block_configfs_path} ] && ocf_log warn "existing block without an active lun: ${block_configfs_path}"
 		[ -e ${block_configfs_path} ] && return $OCF_ERR_GENERIC
 
@@ -559,7 +570,7 @@ iSCSILogicalUnit_monitor() {
 		[ -e ${configfs_path} ] && [ `cat ${configfs_path}` = "${OCF_RESKEY_path}" ] && return $OCF_SUCCESS
 
 		# if we aren't activated, is a block device still left over?
-		block_configfs_path="/sys/kernel/config/target/core/iblock_*/${OCF_RESOURCE_INSTANCE}/udev_path"
+		block_configfs_path="/sys/kernel/config/target/core/iblock_*/${OCF_RESKEY_backstore_name}/udev_path"
 		[ -e ${block_configfs_path} ] && ocf_log warn "existing block without an active lun: ${block_configfs_path}"
 		[ -e ${block_configfs_path} ] && return $OCF_ERR_GENERIC
 		;;
@@ -643,10 +654,10 @@ iSCSILogicalUnit_validate() {
 	iet)
 		# IET does not support setting the vendor and product ID
 		# (it always uses "IET" and "VIRTUAL-DISK")
-		unsupported_params="vendor_id product_id allowed_initiators lio_iblock tgt_bstype tgt_bsoflags tgt_bsopts tgt_device_type emulate_tpu emulate_3pc emulate_caw"
+		unsupported_params="vendor_id product_id allowed_initiators lio_iblock tgt_bstype tgt_bsoflags tgt_bsopts tgt_device_type emulate_tpu emulate_3pc emulate_caw backstore_name"
 		;;
 	tgt)
-		unsupported_params="allowed_initiators lio_iblock emulate_tpu emulate_3pc emulate_caw"
+		unsupported_params="allowed_initiators lio_iblock emulate_tpu emulate_3pc emulate_caw backstore_name"
 		;;
 	lio)
 		unsupported_params="scsi_id vendor_id product_id tgt_bstype tgt_bsoflags tgt_bsopts tgt_device_type emulate_tpu emulate_3pc emulate_caw"


### PR DESCRIPTION
By default, the LIO backing store is named after the resource name. When this backing store is mapped to a LUN, the SCSI INQUIRY reponse is derived from this truncated to the first 16 characters. As it is common to name resources within a group with a similar prefix, the first 16 characters are often less useful than those later on
Add an backstore_name option to allow a custom name to be specified, making it a little easier to identify LUNs on initiators