### PR TITLE
galera: Log message when changing content of grastate.dat file

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -686,6 +686,7 @@ galera_promote()
             # bootstrapping anyways
             if [ "$(get_safe_to_bootstrap)" = "0" ]; then
                 sed -ie 's/^\(safe_to_bootstrap:\) 0/\1 1/' ${OCF_RESKEY_datadir}/grastate.dat
+                ocf_log info "safe_to_bootstrap in ${OCF_RESKEY_datadir}/grastate.dat set to 1 on node ${NODENAME}"
             fi
             ocf_log info "Node <${NODENAME}> is bootstrapping the cluster"
             extra_opts="--wsrep-cluster-address=gcomm://"


### PR DESCRIPTION
There is one case in the RA which changes the grastate.dat file for
galera. Write a log message when the file is changed.
This is useful when trying to find out why "safe_to_bootstrap" was
set.