### PR TITLE
aws-vpc-route53.in: Add missing quotes in ec2ip_stop()

### DIFF
--- a/heartbeat/aws-vpc-route53.in
+++ b/heartbeat/aws-vpc-route53.in
@@ -251,7 +251,7 @@ ec2ip_stop() {
 	IPADDRESS="$(ec2metadata aws ip | grep local-ipv4 | /usr/bin/awk '{ print $2 }')"
 	ARECORD="$(aws $AWS_PROFILE_OPT route53 list-resource-record-sets --hosted-zone-id $OCF_RESKEY_hostedzoneid --query "ResourceRecordSets[?Name=='$OCF_RESKEY_fullname']" | grep RESOURCERECORDS | /usr/bin/awk '{ print $2 }' )"
 	ocf_log debug "Found IP address: $ARECORD ."
-	if [ ${ARECORD} != ${IPADDRESS} ]; then
+	if [ "${ARECORD}" != "${IPADDRESS}" ]; then
 		ocf_log debug "No ARECORD found"
 		return $OCF_SUCCESS
 	else


### PR DESCRIPTION
If AWS API returns an error for some reason (e.g. API unavailable or insufficient IAM rights), the stop function in aws-vpc-route53 resource agent will have a syntax error on line 254, because the ARECORD variable will be empty.

Adding quotes around the variables will prevent that. This is how the if condition is written in other places within the script e.g. in ec2ip_monitor() function.