### PR TITLE
changing bashism to generic solution

### DIFF
--- a/heartbeat/ZFS
+++ b/heartbeat/ZFS
@@ -148,7 +148,7 @@ zpool_monitor () {
 	# Since version 0.7.10 status can be obtained without locks
 	# https://github.com/zfsonlinux/zfs/pull/7563
 	if [ -f /proc/spl/kstat/zfs/$OCF_RESKEY_pool/state ] ; then
-		HEALTH=$(</proc/spl/kstat/zfs/$OCF_RESKEY_pool/state)
+		HEALTH=$(cat /proc/spl/kstat/zfs/$OCF_RESKEY_pool/state)
 	else
 		HEALTH=$(zpool list -H -o health "$OCF_RESKEY_pool")
 	fi


### PR DESCRIPTION
The VAR=(< filename) syntax does not work in all situations (i.e. not on debian 10), changing it to VAR=(cat filename) does work.

Found this problem because I am using debian 10, will create a debian bug report that points to this request.