### PR TITLE
Exit with failure on MySQL replication failure

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -422,11 +422,11 @@ check_slave() {
             ocf_exit_reason "MySQL instance configured for replication, but replication has failed."
             ocf_log err "See $tmpfile for details"
 
-            # Just pull the reader VIP away, killing MySQL here would be pretty evil
-            # on a loaded server
+            # Just pull the reader VIP away and report the error. Even though killing MySQL evil on 
+            # a loaded server, having a split database is worse!
 
             set_reader_attr 0
-            exit $OCF_SUCCESS
+            exit $OCF_ERR_GENERIC
 
         fi
 


### PR DESCRIPTION
When we the resource agent runs into almost any error on the slave, it just
sets the "reader" attribute to 0 (which indicates "read only" IP resources
should migrate away), but doesn't do anything to prevent the node from being
promoted due to out of date data.

We've encountered an issue where replication failed, but the resource agent
simply reported success to Pacemaker, which meant that we had no idea one of
the masters was out of date, and we then failed over to an out of date master
which caused divergent database and customer downtime.

Change the return value of `check_slave()` from $OCF_SUCCESS to
$OCF_ERR_GENERIC, to denote failure with MySQL replication.

Addresses #1377 