### PR TITLE
Low: ora-common: Properly output message when sid parameter is invalid.

### DIFF
--- a/heartbeat/ora-common.sh
+++ b/heartbeat/ora-common.sh
@@ -59,10 +59,6 @@ ora_common_getconfig() {
 
 ora_common_validate_all() {
 	#	Let's make sure a few important things are set...
-	if [ x = "x$ORACLE_HOME" ]; then
-		ocf_log info "ORACLE_HOME not set"
-		return $OCF_ERR_INSTALLED
-	fi
 	if [ x = "x$ORACLE_OWNER" ]; then
 		ocf_log info "ORACLE_OWNER not set"
 		return $OCF_ERR_INSTALLED

--- a/heartbeat/ora-common.sh
+++ b/heartbeat/ora-common.sh
@@ -26,8 +26,14 @@ ora_common_getconfig() {
 	TNS_ADMIN=$4
 
 	# get ORACLE_HOME from /etc/oratab if not set
-	[ x = "x$ORACLE_HOME" ] &&
+	if [ x = "x$ORACLE_HOME" ];then
 		ORACLE_HOME=`awk -F: "/^$ORACLE_SID:/"'{print $2}' /etc/oratab`
+		if [ -f /etc/oratab ]; then
+			if  [ x = "x$ORACLE_HOME" ];then
+				handle_invalid_env $OCF_ERR_CONFIGURED "ORACLE_HOME could not be obtained from /etc/oratab. Please check the sid parameter."
+			fi
+		fi
+	fi
 
 	# there a better way to find out ORACLE_OWNER?
 	[ x = "x$ORACLE_OWNER" ] &&


### PR DESCRIPTION
Hi All,

If user specify the sid parameter of oracle / oralsnr incorrectly without specifying the OCF_RESKEY_home parameter, "sqlplus: required binary not installed" is displayed as an error message.
With this error, it is very difficult for the user to understand the sid mistake.


The following display of crm_mon is an example when the sid parameter is specified incorrectly.

```
Stack: corosync
Current DC: rh76-oracle2 (version 1.1.21-1.el7-f14e36f) - partition with quorum
Last updated: Mon Aug 19 11:07:03 2019
Last change: Mon Aug 19 11:06:46 2019 by root via cibadmin on rh76-oracle1

2 nodes configured
1 resource configured

Online: [ rh76-oracle1 rh76-oracle2 ]

No active resources


Node Attributes:
* Node rh76-oracle1:
* Node rh76-oracle2:

Migration Summary:
* Node rh76-oracle1:
   prmOracle: migration-threshold=1 fail-count=1000000 last-failure='Mon Aug 19 11:06:55 2019'
* Node rh76-oracle2:
   prmOracle: migration-threshold=1 fail-count=1000000 last-failure='Mon Aug 19 11:06:54 2019'

Failed Resource Actions:
* prmOracle_start_0 on rh76-oracle1 'not installed' (5): call=6, status=complete, exitreason='sqlplus: required binary not installed',
    last-rc-change='Mon Aug 19 11:06:54 2019', queued=0ms, exec=85ms
* prmOracle_start_0 on rh76-oracle2 'not installed' (5): call=10, status=complete, exitreason='sqlplus: required binary not installed',
    last-rc-change='Mon Aug 19 11:06:54 2019', queued=0ms, exec=87ms
```

This PR is modified to output a user-friendly message when the sid parameter is invalid.

In addition, in the added check, if the sid parameter is invalid, it is changed so that unnecessary FO operation does not occur as an OCF_ERR_CONFIGURED error.

As a result of this modification, the check for OCF_RESKEY_home in ora_common_validate_all is no longer necessary and has been removed.

Please consider merging this PR in consideration of user setting mistakes.

Best Regards,
Hideo Yamauchi.