### PR TITLE
exportfs: doc clarification for clientspec format

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -47,6 +47,12 @@ Manages NFS exports
 <longdesc lang="en">
 The client specification allowing remote machines to mount the directory
 (or directories) over NFS.
+
+Note: it follows the format defined in "man exportfs". For example, in
+the use case to export the directory(-ies) for multiple subnets, please
+do config a dedicated primitive for each subnet CIDR ip address, 
+and do not attempt to use multiple CIDR ip addresses in a space
+seperated list, like in /etc/exports.
 </longdesc>
 <shortdesc lang="en">
 Client ACL.


### PR DESCRIPTION
Point out the standard of the format is aligned with `man exportfs`, and also point out the correct way to deal with the use case to export the same directory(-ies) to multiple subnets.