### PR TITLE
rabbitmq-cluster: also restore users/perms/policies when starting in single node mode

### DIFF
--- a/heartbeat/rabbitmq-cluster
+++ b/heartbeat/rabbitmq-cluster
@@ -114,6 +114,62 @@ rmq_wipe_data()
 	rm -rf $RMQ_DATA_DIR > /dev/null 2>&1 
 }
 
+rmq_restore_users_perms_policies()
+{
+	# Restore users, user permissions, and policies (if any)
+	BaseDataDir=`dirname $RMQ_DATA_DIR`
+	$RMQ_EVAL "
+		%% Run only if Mnesia is ready.
+		lists:any(fun({mnesia,_,_}) -> true; ({_,_,_}) -> false end, application:which_applications()) andalso
+		begin
+			Restore = fun(Table, PostprocessFun, Filename) ->
+				case file:consult(Filename) of
+					{error, _} ->
+						ok;
+					{ok, [Result]} ->
+						lists:foreach(fun(X) -> mnesia:dirty_write(Table, PostprocessFun(X)) end, Result),
+						file:delete(Filename)
+				end
+			end,
+
+			%% Restore users
+
+			Upgrade = fun
+				({internal_user, A, B, C}) -> {internal_user, A, B, C, rabbit_password_hashing_md5};
+				({internal_user, A, B, C, D}) -> {internal_user, A, B, C, D}
+			end,
+
+			Downgrade = fun
+				({internal_user, A, B, C}) -> {internal_user, A, B, C};
+				({internal_user, A, B, C, rabbit_password_hashing_md5}) -> {internal_user, A, B, C};
+				%% Incompatible scheme, so we will loose user's password ('B' value) during conversion.
+				%% Unfortunately, this case will require manual intervention - user have to run:
+				%%    rabbitmqctl change_password <A> <somenewpassword>
+				({internal_user, A, B, C, _}) -> {internal_user, A, B, C}
+			end,
+
+			%% Check db scheme first
+			[WildPattern] = ets:select(mnesia_gvar, [ { {{rabbit_user, wild_pattern}, '\\\$1'}, [], ['\\\$1'] } ]),
+			case WildPattern of
+				%% Version < 3.6.0
+				{internal_user,'_','_','_'} ->
+					Restore(rabbit_user, Downgrade, \"$BaseDataDir/users.erl\");
+				%% Version >= 3.6.0
+				{internal_user,'_','_','_','_'} ->
+					Restore(rabbit_user, Upgrade, \"$BaseDataDir/users.erl\")
+			end,
+
+			NoOp = fun(X) -> X end,
+
+			%% Restore user permissions
+			Restore(rabbit_user_permission, NoOp, \"$BaseDataDir/users_perms.erl\"),
+
+			%% Restore policies
+			Restore(rabbit_runtime_parameters, NoOp, \"$BaseDataDir/policies.erl\")
+		end.
+	"
+}
+
 rmq_local_node()
 {
 
@@ -411,6 +467,7 @@ rmq_try_start() {
 	if [ -z "$join_list" ]; then
 		rmq_start_first
 		rc=$?
+		rmq_restore_users_perms_policies
 		return $rc
 	fi
 
@@ -437,58 +494,8 @@ rmq_try_start() {
 		return $RMQ_TRY_RESTART_ERROR_CODE
 	fi
 
-	# Restore users, user permissions, and policies (if any)
-	BaseDataDir=`dirname $RMQ_DATA_DIR`
-	$RMQ_EVAL "
-		%% Run only if Mnesia is ready.
-		lists:any(fun({mnesia,_,_}) -> true; ({_,_,_}) -> false end, application:which_applications()) andalso
-		begin
-			Restore = fun(Table, PostprocessFun, Filename) ->
-				case file:consult(Filename) of
-					{error, _} ->
-						ok;
-					{ok, [Result]} ->
-						lists:foreach(fun(X) -> mnesia:dirty_write(Table, PostprocessFun(X)) end, Result),
-						file:delete(Filename)
-				end
-			end,
+	rmq_restore_users_perms_policies
 
-			%% Restore users
-
-			Upgrade = fun
-				({internal_user, A, B, C}) -> {internal_user, A, B, C, rabbit_password_hashing_md5};
-				({internal_user, A, B, C, D}) -> {internal_user, A, B, C, D}
-			end,
-
-			Downgrade = fun
-				({internal_user, A, B, C}) -> {internal_user, A, B, C};
-				({internal_user, A, B, C, rabbit_password_hashing_md5}) -> {internal_user, A, B, C};
-				%% Incompatible scheme, so we will loose user's password ('B' value) during conversion.
-				%% Unfortunately, this case will require manual intervention - user have to run:
-				%%    rabbitmqctl change_password <A> <somenewpassword>
-				({internal_user, A, B, C, _}) -> {internal_user, A, B, C}
-			end,
-
-			%% Check db scheme first
-			[WildPattern] = ets:select(mnesia_gvar, [ { {{rabbit_user, wild_pattern}, '\\\$1'}, [], ['\\\$1'] } ]),
-			case WildPattern of
-				%% Version < 3.6.0
-				{internal_user,'_','_','_'} ->
-					Restore(rabbit_user, Downgrade, \"$BaseDataDir/users.erl\");
-				%% Version >= 3.6.0
-				{internal_user,'_','_','_','_'} ->
-					Restore(rabbit_user, Upgrade, \"$BaseDataDir/users.erl\")
-			end,
-
-			NoOp = fun(X) -> X end,
-
-			%% Restore user permissions
-			Restore(rabbit_user_permission, NoOp, \"$BaseDataDir/users_perms.erl\"),
-
-			%% Restore policies
-			Restore(rabbit_runtime_parameters, NoOp, \"$BaseDataDir/policies.erl\")
-		end.
-	"
 	return $OCF_SUCCESS
 }
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/1744467#c1

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>