### PR TITLE
Low: IPaddr2: fix to work properly with unsanitized IPv6 addresses

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -477,6 +477,12 @@ ip_init() {
 		fi
 	else
 		FAMILY=inet6
+		# address sanitization defined in RFC5952
+		SANITIZED_IP=$($IP2UTIL route get $OCF_RESKEY_ip | awk '$1~/:/ {print $1}  $2~/:/ {print $2}')
+                if [ -n "$SANITIZED_IP" ]; then
+                    OCF_RESKEY_ip="$SANITIZED_IP"
+                fi
+
 		if ocf_is_true $OCF_RESKEY_lvs_support ;then
 			ocf_exit_reason "The IPv6 does not support lvs_support"
 			exit $OCF_ERR_CONFIGURED


### PR DESCRIPTION
Fix for #1109 and #1357.

I have tested it locally with the OCFT test cases below:
* https://gist.github.com/kskmori/65a715627be207c3353cd31bad485a8c

### Limitations:
It can not be sanitized if the address is unreachable and on the recent distributions
such as RHEL8. (probably depending on the iproute package version)
* CentOS 7: can be sanitized 
```
[root@centos73-1 ~]# /sbin/ip route get 2001:db8:201::0001
unreachable 2001:db8:201::1 dev lo  table unspec  proto kernel  src 2001:db8:101:0:XXXX:XXXX:XXXX:XXXX  metric 429496
```
* RHEL 8: can **NOT** be sanitized
```
[root@rhel80-1 ~]# /sbin/ip route get 200:db8:201::0001
RTNETLINK answers: Network is unreachable
```

I believe that it's not the case of the typical network configurations and only affects to very limited use cases.
Even in such use case, it eventually works successfully (test case 8 of the OCFT scenario above), although a bit tricky thing is happening inside - the first start action is processed with an unsanitized address, and once it is assigned, the succeeding monitor/stop actions are processed with the sanitized address.
Finally if still there's a problem, there is a workaround - ask users to specify the address exactly same as how `ip` shows in such particular use cases.

Please review it if it's acceptable, or if there is a better idea, feedbacks are welcome.
Thanks,