### PR TITLE
fix master_is_active() erroneously reporting there is master when there is no

### DIFF
--- a/heartbeat/redis.in
+++ b/heartbeat/redis.in
@@ -242,7 +242,7 @@ master_is_active()
 {
 	if [ -z "$MASTER_ACTIVE_CACHED" ]; then
 		# determine if a master instance is already up and is healthy
-		crm_mon --as-xml | grep "resource.*id=\"${OCF_RESOURCE_INSTANCE}\".*role=\"Master\".*active=\"true\".*orphaned=\"false\".*failed=\"false\"" > /dev/null 2>&1
+		crm_mon --as-xml | grep "resource.*id=\"${OCF_RESOURCE_INSTANCE}\".* role=\"Master\".* active=\"true\".* orphaned=\"false\".* failed=\"false\"" > /dev/null 2>&1
 		MASTER_ACTIVE=$?
 		MASTER_ACTIVE_CACHED="true"
 	fi


### PR DESCRIPTION
New commit with expanded reasoning in the commit message instead of
https://github.com/pokotilenko/resource-agents/commit/28207caf5e028ac99bb9df9053d4f815933114c9
