### PR TITLE
LVM-activate: move pvscan --cache to validate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ dnl     checks for system services
 
 AC_INIT([resource-agents], 
 	m4_esyscmd([make/git-version-gen .tarball-version]),
-	[to_be_defined@foobar.org])
+	[developers@clusterlabs.org])
 
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -489,6 +489,11 @@ lvm_validate() {
 	check_binary lvm
 	check_binary dmsetup
 
+	# This is necessary when using system ID to update lvm hints,
+	# or in older versions of lvm, this is necessary to update the
+	# lvmetad cache.
+	pvscan --cache
+
 	if ! vgs --foreign ${VG} >/dev/null 2>&1 ; then
 		# stop action exits successfully if the VG cannot be accessed...
 		if [ $__OCF_ACTION = "stop" ]; then
@@ -627,7 +632,6 @@ clvmd_activate() {
 systemid_activate() {
 	local cur_systemid
 
-	pvscan --cache
 	cur_systemid=$(vgs --foreign --noheadings -o systemid ${VG} | tr -d '[:blank:]')
 
 	# Put our system ID on the VG


### PR DESCRIPTION
It needs to be called before validate attempts to look at the VG.