### PR TITLE
Adapt azure-lb Resource Agent to support socat usage too

### DIFF
--- a/heartbeat/azure-lb
+++ b/heartbeat/azure-lb
@@ -17,8 +17,8 @@
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
 
 # Defaults
-OCF_RESKEY_nc_default="/usr/bin/nc"
 OCF_RESKEY_port_default="61000"
+OCF_RESKEY_nc_default="/usr/bin/nc"
 
 : ${OCF_RESKEY_nc=${OCF_RESKEY_nc_default}}
 : ${OCF_RESKEY_port=${OCF_RESKEY_port_default}}
@@ -53,9 +53,11 @@ Resource agent to answer Azure Load Balancer health probe requests
 
 <parameter name="nc">
 <longdesc lang="en">
-The full name of the nc binary.
+The full path of the used binary. This can be nc or socat path.
+The default is /usr/bin/nc.
+If you need /usr/bin/socat this parameter should be set.
 </longdesc>
-<shortdesc lang="en">Full path name of the nc binary</shortdesc>
+<shortdesc lang="en">Full path of the used binary (nc or socat are allowed)</shortdesc>
 <content type="string" default="${OCF_RESKEY_nc_default}"/>
 </parameter>
 
@@ -100,6 +102,10 @@ lb_monitor() {
 
 lb_start() {
 	cmd="$OCF_RESKEY_nc -l -k $OCF_RESKEY_port"
+	if [ $( basename $OCF_RESKEY_nc ) = 'socat' ]; then
+		#socat has different parameters
+		cmd="$OCF_RESKEY_nc -U TCP-LISTEN:$OCF_RESKEY_port,backlog=10,fork,reuseaddr /dev/null"
+	fi
 	if ! lb_monitor; then
 		ocf_log debug "Starting $process: $cmd"
 		# Execute the command as created above


### PR DESCRIPTION
Netcat doesn't handle multiple connections, breaking connectivity to the application in pacemaker cluster. Netcat doesn't allow to restrict which clients can initiate connections.