### PR TITLE
aws-vpc-route53: Improvements and fixes

### DIFF
--- a/heartbeat/aws-vpc-route53.in
+++ b/heartbeat/aws-vpc-route53.in
@@ -214,7 +214,17 @@ r53_monitor() {
 		#
 		cmd="aws $AWS_PROFILE_OPT route53 list-resource-record-sets --hosted-zone-id $OCF_RESKEY_hostedzoneid --query ResourceRecordSets[?Name=='$OCF_RESKEY_fullname']"
 		ocf_log info "Route53 Agent Starting or probing - executing monitoring API call: $cmd"
-		ARECORD="$($cmd | grep RESOURCERECORDS | awk '{ print $2 }')"
+		CLIRES="$($cmd 2>&1)"
+		rc=$?
+		ocf_log debug "awscli returned code: $rc"
+		if [ $rc -ne 0 ]; then
+			CLIRES=$(echo $CLIRES | grep -v '^$')
+			ocf_log info "Route53 API returned an error: $CLIRES"
+			ocf_log info "Skipping cluster action due to API call error"
+			return $OCF_ERR_GENERIC
+		fi
+		ARECORD=$(echo $CLIRES | grep RESOURCERECORDS | awk '{ print $5 }')
+		#
 		if ocf_is_probe; then
 			#
 			# Prevent R53 record change during probe
@@ -305,7 +315,15 @@ _update_record() {
 	EOF
 	cmd="aws --profile $OCF_RESKEY_profile route53 change-resource-record-sets --hosted-zone-id $OCF_RESKEY_hostedzoneid --change-batch file://$ROUTE53RECORD "
 	ocf_log debug "Executing command: $cmd"
-	CHANGEID=$($cmd | grep CHANGEINFO | awk -F'\t' '{ print $3 }' )
+	CLIRES="$($cmd 2>&1)"
+	rc=$?
+	ocf_log debug "awscli returned code: $rc"
+	if [ $rc -ne 0 ]; then
+		ocf_log info "Route53 API returned an error: $CLIRES"
+		ocf_log info "Skipping cluster action due to API call error"
+		return $OCF_ERR_GENERIC
+	fi
+	CHANGEID=$(echo $CLIRES | awk '{ print $12 }')
 	ocf_log debug "Change id: $CHANGEID"
 	rmtempfile $ROUTE53RECORD
 	CHANGEID=$(echo $CHANGEID | cut -d'/' -f 3 | cut -d'"' -f 1 )
@@ -337,6 +355,10 @@ r53_start() {
 	ocf_log info "Starting Route53 DNS update...."
 	IPADDRESS="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
 	r53_monitor
+	if [ $? != $OCF_SUCCESS ]; then
+		ocf_log info "Could not start agent - check configurations"
+		return $OCF_ERR_GENERIC
+	fi
 	return $OCF_SUCCESS
 }
 

--- a/heartbeat/aws-vpc-route53.in
+++ b/heartbeat/aws-vpc-route53.in
@@ -219,8 +219,8 @@ r53_monitor() {
 		ocf_log debug "awscli returned code: $rc"
 		if [ $rc -ne 0 ]; then
 			CLIRES=$(echo $CLIRES | grep -v '^$')
-			ocf_log info "Route53 API returned an error: $CLIRES"
-			ocf_log info "Skipping cluster action due to API call error"
+			ocf_log warn "Route53 API returned an error: $CLIRES"
+			ocf_log warn "Skipping cluster action due to API call error"
 			return $OCF_ERR_GENERIC
 		fi
 		ARECORD=$(echo $CLIRES | grep RESOURCERECORDS | awk '{ print $5 }')
@@ -251,8 +251,8 @@ r53_monitor() {
 			ocf_log debug "awscli return code: $rc"
 			if [ $rc -ne 0 ]; then
 				CLIRES=$(echo $CLIRES | grep -v '^$')
-				ocf_log info "Route53 API returned an error: $CLIRES"
-				ocf_log info "Monitor skipping cluster action due to API call error"
+				ocf_log warn "Route53 API returned an error: $CLIRES"
+				ocf_log warn "Monitor skipping cluster action due to API call error"
 				return $OCF_SUCCESS
 			fi
 			ARECORD=$(echo $CLIRES | grep RESOURCERECORDS | awk '{ print $5 }')
@@ -321,8 +321,8 @@ _update_record() {
 	ocf_log debug "awscli returned code: $rc"
 	if [ $rc -ne 0 ]; then
 		CLIRES=$(echo $CLIRES | grep -v '^$')
-		ocf_log info "Route53 API returned an error: $CLIRES"
-		ocf_log info "Skipping cluster action due to API call error"
+		ocf_log warn "Route53 API returned an error: $CLIRES"
+		ocf_log warn "Skipping cluster action due to API call error"
 		return $OCF_ERR_GENERIC
 	fi
 	CHANGEID=$(echo $CLIRES | awk '{ print $12 }')

--- a/heartbeat/aws-vpc-route53.in
+++ b/heartbeat/aws-vpc-route53.in
@@ -250,6 +250,7 @@ r53_monitor() {
 			rc=$?
 			ocf_log debug "awscli return code: $rc"
 			if [ $rc -ne 0 ]; then
+				CLIRES=$(echo $CLIRES | grep -v '^$')
 				ocf_log info "Route53 API returned an error: $CLIRES"
 				ocf_log info "Monitor skipping cluster action due to API call error"
 				return $OCF_SUCCESS
@@ -319,6 +320,7 @@ _update_record() {
 	rc=$?
 	ocf_log debug "awscli returned code: $rc"
 	if [ $rc -ne 0 ]; then
+		CLIRES=$(echo $CLIRES | grep -v '^$')
 		ocf_log info "Route53 API returned an error: $CLIRES"
 		ocf_log info "Skipping cluster action due to API call error"
 		return $OCF_ERR_GENERIC

--- a/heartbeat/aws-vpc-route53.in
+++ b/heartbeat/aws-vpc-route53.in
@@ -213,7 +213,7 @@ r53_monitor() {
 	if [ "$__OCF_ACTION" = "start" ] || ocf_is_probe ; then
 		#
 		cmd="aws $AWS_PROFILE_OPT route53 list-resource-record-sets --hosted-zone-id $OCF_RESKEY_hostedzoneid --query ResourceRecordSets[?Name=='$OCF_RESKEY_fullname']"
-		ocf_log debug "Route53 Agent Starting or probing - executing monitoring API call: $cmd"
+		ocf_log info "Route53 Agent Starting or probing - executing monitoring API call: $cmd"
 		ARECORD="$($cmd | grep RESOURCERECORDS | awk '{ print $2 }')"
 		if ocf_is_probe; then
 			#
@@ -227,7 +227,7 @@ r53_monitor() {
 	else
 		#
 		cmd="dig +retries=3 +time=5 +short $OCF_RESKEY_fullname 2>/dev/null"
-		ocf_log debug "executing monitoring command : $cmd"
+		ocf_log info "executing monitoring command : $cmd"
 		ARECORD="$($cmd)"
 		rc=$?
 		ocf_log debug "dig return code: $rc"
@@ -248,10 +248,10 @@ r53_monitor() {
 		fi
 		#
 	fi
-	ocf_log debug "Route53 DNS record pointing $OCF_RESKEY_fullname to IP address $ARECORD"
+	ocf_log info "Route53 DNS record pointing $OCF_RESKEY_fullname to IP address $ARECORD"
 	#
 	if [ "$ARECORD" == "$IPADDRESS" ]; then
-		ocf_log debug "Route53 DNS record $ARECORD found"
+		ocf_log info "Route53 DNS record $ARECORD found"
 		return $OCF_SUCCESS
 	elif [[ $ARECORD =~ $IPREGEX ]] && [ "$ARECORD" != "$IPADDRESS" ]; then
 		ocf_log info "Route53 DNS record points to a different host, setting DNS record on Route53 to this host"

--- a/heartbeat/aws-vpc-route53.in
+++ b/heartbeat/aws-vpc-route53.in
@@ -215,6 +215,15 @@ r53_monitor() {
 		cmd="aws $AWS_PROFILE_OPT route53 list-resource-record-sets --hosted-zone-id $OCF_RESKEY_hostedzoneid --query ResourceRecordSets[?Name=='$OCF_RESKEY_fullname']"
 		ocf_log debug "Route53 Agent Starting or probing - executing monitoring API call: $cmd"
 		ARECORD="$($cmd | grep RESOURCERECORDS | awk '{ print $2 }')"
+		if ocf_is_probe; then
+			#
+			# Prevent R53 record change during probe
+			#
+			if [[ $ARECORD =~ $IPREGEX ]] && [ "$ARECORD" != "$IPADDRESS" ]; then
+				ocf_log debug "Route53 DNS record $ARECORD found at probing, disregarding"
+				return $OCF_NOT_RUNNING
+			fi
+		fi
 	else
 		#
 		cmd="dig +retries=3 +time=5 +short $OCF_RESKEY_fullname 2>/dev/null"
@@ -327,7 +336,7 @@ r53_start() {
 	#
 	ocf_log info "Starting Route53 DNS update...."
 	IPADDRESS="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
-	_update_record "UPSERT" "$IPADDRESS"
+	r53_monitor
 	return $OCF_SUCCESS
 }
 

--- a/heartbeat/aws-vpc-route53.in
+++ b/heartbeat/aws-vpc-route53.in
@@ -302,7 +302,7 @@ _update_record() {
 	CHANGEID=$(echo $CHANGEID | cut -d'/' -f 3 | cut -d'"' -f 1 )
 	ocf_log debug "Change id: $CHANGEID"
 	STATUS="PENDING"
-	MYSECONDS=8
+	MYSECONDS=20
 	while [ "$STATUS" = 'PENDING' ]; do
 		sleep $MYSECONDS
 		STATUS="$(aws --profile $OCF_RESKEY_profile route53 get-change --id $CHANGEID | grep CHANGEINFO | awk -F'\t' '{ print $4 }' |cut -d'"' -f 2 )"


### PR DESCRIPTION
This pull request is to add general improvements to different parts of the code.

## What is changing?

* **Increasing MYSECONDS time interval:** Changing from 8 seconds to 20 seconds to decrease the amount of ListResourceRecordSets API calls and decrease the change of Route53 API throttling from my observation and tests this will decrease the number of ListResourceRecordSets from 5-6 to 2-3 (50% reduction)

* **Changes in log level:** Making the agent a little more verbose - good for day-to-day troubleshooting

* **Improve API error handing on _update_record():** Previously I had included error handling on r53_monitor() function and now I'm adding the same handling to _update_record()

* **Strip empty line on AWSCLI output:** Cleanup from AWSCLI/API response to make the logging more readable

* **Fix potential race condition during agent probe:** During my tests I observed that while probing the agent could incorrectly trigger an incorrect API call, or try to start on both nodes at the same time, showing "Active on 2 nodes". I've included a condition to better deal with probing and avoid an early API call.

Let me know if you have questions about the changes.