### PR TITLE
gcp-pd-move: add parameter stackdriver_logging

### DIFF
--- a/heartbeat/gcp-pd-move.in
+++ b/heartbeat/gcp-pd-move.in
@@ -105,7 +105,7 @@ correctly.
 <parameter name="stackdriver_logging" unique="1" required="0">
 <longdesc lang="en">Use stackdriver_logging output to global resource (yes, true, enabled)</longdesc>
 <shortdesc lang="en">Use stackdriver_logging</shortdesc>
-<content type="string" default="yes" />
+<content type="string" default="no" />
 </parameter>
 </parameters>
 <actions>

--- a/heartbeat/gcp-pd-move.in
+++ b/heartbeat/gcp-pd-move.in
@@ -102,6 +102,11 @@ correctly.
 <shortdesc lang="en">Optional device name</shortdesc>
 <content type="boolean" default="" />
 </parameter>
+<parameter name="stackdriver_logging" unique="1" required="0">
+<longdesc lang="en">Use stackdriver_logging output to global resource (yes, true, enabled)</longdesc>
+<shortdesc lang="en">Use stackdriver_logging</shortdesc>
+<content type="string" default="yes" />
+</parameter>
 </parameters>
 <actions>
 <action name="start" timeout="300s" />


### PR DESCRIPTION
gcp-pd-move use parameter 'OCF_RESKEY_stackdriver_logging', 
but  parameter 'stackdriver_logging' not exists in METADATA..
I will add parameter 'stackdriver_logging' !!
thank you.