### PR TITLE
Low: NodeUtilization: Fix checking for Xen commands

### DIFF
--- a/heartbeat/NodeUtilization
+++ b/heartbeat/NodeUtilization
@@ -135,10 +135,10 @@ Host_Total_Memory() {
 
     xentool=$(which xl 2> /dev/null || which xm 2> /dev/null)
 
-    if [ -x $xentool ]; then
-        $xentool info | awk '/total_memory/{printf("%d\n",$3);exit(0)}'
+    if [ -x "$xentool" ]; then
+        "$xentool" info | awk '/total_memory/{printf("%d\n",$3);exit(0)}'
     else
-        ocf_log warn "Can only set hv_memory for Xen hypervisor"
+        ocf_log debug "Can only set hv_memory for Xen hypervisor"
         echo "0"
     fi
 }


### PR DESCRIPTION
Fix shell quoting in function `Host_Total_Memory()`. Missing quotes caused that if no Xen command (`xl` or `xm`) was found the function made a non-sense call to the `info` utility. This could have resulted in unexpected messages appearing in pacemaker logs. Example:
```
lrmd[3476]:   notice: prm_node_util_monitor_300000:3915:stderr [ info: Writing node (dir)Top... ]
lrmd[3476]:   notice: prm_node_util_monitor_300000:3915:stderr [ info: Cannot find node `(dir)GNU Free Documentation License'. ]
lrmd[3476]:   notice: prm_node_util_monitor_300000:3915:stderr [ info: Done. ]
```

The proposed patch also removes a warning about no Xen command being available. With the fixed quoting, if a NodeUtilization resource was configured to use the default `utilization_hv_memory=true` parameter but the Xen tools were not available, the warning would be reported each time when the monitor operation is run. This change preserves the previous behaviour that reported no warning.