### PR TITLE
Low: mysql-common: fix startup check

### DIFF
--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -239,8 +239,8 @@ mysql_common_start()
     --datadir=$OCF_RESKEY_datadir \
     --log-error=$OCF_RESKEY_log \
     $OCF_RESKEY_additional_parameters \
-    $mysql_extra_params >/dev/null 2>&1 &
-    pid=$!"
+    $mysql_extra_params >/dev/null 2>&1" &
+    pid=$!
 
     # Spin waiting for the server to come up.
     # Let the CRM/LRM time us out if required.


### PR DESCRIPTION
PID value is not captured correctly so the startup
fails with the wrong exit code.

Starting 'mysql' case 8 'check lib file':
Setting agent environment:    export OCF_RESKEY_CRM_meta_timeout=15000
Setting system environment:   chmod u-w /var/lib/mysql
Running agent:                ./mysql start
ERROR: The agent was hanging, killed it, maybe you damaged the agent or system's environment, see details below:
Oct 23 18:46:06 INFO: MySQL is not running
runuser: warning: cannot change directory to /nonexistent: No such file or directory
runuser: warning: cannot change directory to /nonexistent: No such file or directory
runuser: warning: cannot change directory to /nonexistent: No such file or directory
Oct 23 18:46:06 INFO: MySQL is not running
Oct 23 18:46:08 INFO: MySQL is not running
Oct 23 18:46:10 INFO: MySQL is not running
Oct 23 18:46:12 INFO: MySQL is not running
Oct 23 18:46:14 INFO: MySQL is not running
Oct 23 18:46:16 INFO: MySQL is not running
Oct 23 18:46:18 INFO: MySQL is not running
Oct 23 18:46:20 INFO: MySQL is not running
Oct 23 18:46:22 INFO: MySQL is not running
Oct 23 18:46:24 INFO: MySQL is not running