### PR TITLE
Low: MailTo: fix variable expansion

### DIFF
--- a/heartbeat/MailTo
+++ b/heartbeat/MailTo
@@ -67,7 +67,7 @@ a takeover occurs.
 The email address of sysadmin.
 </longdesc>
 <shortdesc lang="en">Email address</shortdesc>
-<content type="string" default="$[OCF_RESKEY_email_default]" />
+<content type="string" default="${OCF_RESKEY_email_default}" />
 </parameter>
 
 <parameter name="subject" unique="0">


### PR DESCRIPTION
Wrong kind of braces used (expand to 0 or fail
to expand with dash as shell).