### PR TITLE
azure-lb Set socat to default on SUSE distributions.

### DIFF
--- a/heartbeat/azure-lb
+++ b/heartbeat/azure-lb
@@ -18,6 +18,11 @@
 
 # Defaults
 OCF_RESKEY_nc_default="/usr/bin/nc"
+case "$( get_release_id )" in
+	*SUSE)
+		OCF_RESKEY_nc_default="/usr/bin/socat"
+	;;
+esac
 OCF_RESKEY_port_default="61000"
 
 : ${OCF_RESKEY_nc=${OCF_RESKEY_nc_default}}
@@ -54,8 +59,7 @@ Resource agent to answer Azure Load Balancer health probe requests
 <parameter name="nc">
 <longdesc lang="en">
 The full path of the used binary. This can be nc or socat path.
-The default is /usr/bin/nc.
-If you need /usr/bin/socat this parameter should be set.
+The default is /usr/bin/nc and /usr/bin/socat for SUSE distributions.
 </longdesc>
 <shortdesc lang="en">Full path of the used binary (nc or socat are allowed)</shortdesc>
 <content type="string" default="${OCF_RESKEY_nc_default}"/>


### PR DESCRIPTION
Socat was tested on SUSE and it works fine. To avoid the need to change the configuration we set socat to default on SUSE distributions.