### PR TITLE
podman: simplify the code for checking if an image exists

### DIFF
--- a/heartbeat/podman
+++ b/heartbeat/podman
@@ -441,31 +441,7 @@ podman_stop()
 
 image_exists()
 {
-	# if no tag was specified, use default "latest"
-	local COLON_FOUND=0
-	local SLASH_FOUND=0
-	local SERVER_NAME=""
-	local IMAGE_NAME="${OCF_RESKEY_image}"
-	local IMAGE_TAG="latest"
-
-	SLASH_FOUND="$(echo "${OCF_RESKEY_image}" | grep -o '/' | grep -c .)"
-
-	if [ ${SLASH_FOUND} -ge 1 ]; then
-		SERVER_NAME="$(echo ${IMAGE_NAME} | cut -d / -f 1-${SLASH_FOUND})"
-		IMAGE_NAME="$(echo ${IMAGE_NAME} | awk -F'/' '{print $NF}')"
-	fi
-
-	COLON_FOUND="$(echo "${IMAGE_NAME}" | grep -o ':' | grep -c .)"
-	if [ ${COLON_FOUND} -ge 1 ]; then
-		IMAGE_TAG="$(echo ${IMAGE_NAME} | awk -F':' '{print $NF}')"
-		IMAGE_NAME="$(echo ${IMAGE_NAME} | cut -d : -f 1-${COLON_FOUND})"
-	fi
-
-	# IMAGE_NAME might be following formats:
-	# - image
-	# - repository:port/image
-	# - docker.io/image (some distro will display "docker.io/" as prefix)
-	podman images | awk '{print $1 ":" $2}' | egrep -q -s "^(docker.io\/|${SERVER_NAME}\/)?${IMAGE_NAME}:${IMAGE_TAG}\$"
+	podman image exists "${OCF_RESKEY_image}"
 	if [ $? -eq 0 ]; then
 		# image found
 		return 0


### PR DESCRIPTION
Let's switch to the existing 'podman image exists' to determine if
an image is local to the machine or if it needs pulling.

Let's change this for a number of reasons:
- It simplifies the code greatly
- It makes everything work even when the image is prefixed with 'localhost/'
  names which are not detected as local images
- It makes the code faster as we do not need to list all the images as
  that is more expensive

Tested by running a couple of full containerized OpenStack deployments,
one with images tagged as 'localhost/foo/mysql:pcmklatest' and one
with a normal registry host prefix.

Co-Authored-By: Damien Ciabrini <dciabrin@redhat.com>