### PR TITLE
LVM-activate: verify vg or lv validity

### DIFF
--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -114,6 +114,18 @@ clvm+LVM-activate. However, it is not possible to use both at the same time!
 if using the cluster to manage at least one of them.  If you manage some manually,
 the stop action of the lvmlockd agent may fail and the node may get fenced,
 because some DLM lockspaces might be in use and cannot be closed automatically.
+
+Option: OCF_CHECK_LEVEL
+
+The standard monitor operation of depth 0 checks if the VG or LV is valid.
+If you want deeper tests, set OCF_CHECK_LEVEL to 10:
+
+  10: read first 1 byte of the underlying device (raw read)
+
+If there are many underlying devs in VG, it will only read one of the devs.
+This is not perfect solution for detecting underlying devices livable.
+e.g. iscsi SAN IO timeout will return EIO, and it makes monitor failed.
+
 </longdesc>
 <shortdesc lang="en">This agent activates/deactivates logical volumes.</shortdesc>
 
@@ -793,16 +805,25 @@ lvm_status() {
 		return $OCF_NOT_RUNNING
 	fi
 
-	# if there are many lv in vg dir, pick the first name
-	dm_name="/dev/${VG}/$(ls -1 /dev/${VG} | head -n 1)"
+	if [ $OCF_CHECK_LEVEL -gt 0 ]; then
+		case "$OCF_CHECK_LEVEL" in
+			10)
+				# if there are many lv in vg dir, pick the first name
+				dm_name="/dev/${VG}/$(ls -1 /dev/${VG} | head -n 1)"
 
-	# read 1 byte to check the dev is alive
-	dd if=${dm_name} of=/dev/null bs=1 count=1 >/dev/null 2>&1
-	if [ $? -ne 0 ]; then
-		return $OCF_NOT_RUNNING
+				# read 1 byte to check the dev is alive
+				dd if=${dm_name} of=/dev/null bs=1 count=1 >/dev/null 2>&1
+				if [ $? -ne 0 ]; then
+					return $OCF_NOT_RUNNING
+				fi
+				return $OCF_SUCCESS
+				;;
+			*)
+				ocf_exit_reason "unsupported monitor level $OCF_CHECK_LEVEL"
+				rc=$OCF_ERR_CONFIGURED
+				;;
+		esac
 	fi
-
-	return $OCF_SUCCESS
 }
 
 lvm_start() {

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -779,6 +779,7 @@ tagging_deactivate() {
 # This is AllBad but there isn't a better way that I'm aware of yet.
 lvm_status() {
 	local dm_count
+	local dm_name
 
 	if [ -n "${LV}" ]; then
 		# dmsetup ls? It cannot accept device name. It's
@@ -789,6 +790,15 @@ lvm_status() {
 	fi
 
 	if [ $dm_count -eq 0 ]; then
+		return $OCF_NOT_RUNNING
+	fi
+
+	# if there are many lv in vg dir, pick the first name
+	dm_name="/dev/${VG}/$(ls -1 /dev/${VG} | head -n 1)"
+
+	# read 1 byte to check the dev is alive
+	dd if=${dm_name} of=/dev/null bs=1 count=1 >/dev/null 2>&1
+	if [ $? -ne 0 ]; then
 		return $OCF_NOT_RUNNING
 	fi
 


### PR DESCRIPTION
When LVM underlying devs disappear, eg iSCSI SAN disks suffer network
disconnect, the pvs/vgs/lvs won't show related PVs/VGs/LVs, but dm
devs won't disappear. This makes the lvm_status() doesn't work as
expect.

This patch uses simple & stupid method "read 1 byte from underlaying
dev" to detect abnormal underlying devices.