### PR TITLE
Make secure tmp files

### DIFF
--- a/heartbeat/ClusterMon
+++ b/heartbeat/ClusterMon
@@ -45,8 +45,8 @@
 OCF_RESKEY_user_default="root"
 OCF_RESKEY_update_default="15000"
 OCF_RESKEY_extra_options_default=""
-OCF_RESKEY_pidfile_default="/tmp/ClusterMon_${OCF_RESOURCE_INSTANCE}.pid"
-OCF_RESKEY_htmlfile_default="/tmp/ClusterMon_${OCF_RESOURCE_INSTANCE}.html"
+OCF_RESKEY_pidfile_default="${HA_RSCTMP}/ClusterMon_${OCF_RESOURCE_INSTANCE}.pid"
+OCF_RESKEY_htmlfile_default="${HA_RSCTMP}/ClusterMon_${OCF_RESOURCE_INSTANCE}.html"
 
 : ${OCF_RESKEY_user=${OCF_RESKEY_user_default}}
 : ${OCF_RESKEY_update=${OCF_RESKEY_update_default}}

--- a/heartbeat/openstack-cinder-volume
+++ b/heartbeat/openstack-cinder-volume
@@ -35,7 +35,7 @@
 
 # Defaults
 OCF_RESKEY_openstackcli_default="/usr/bin/openstack"
-OCF_RESKEY_node_id_cache_file_default="/tmp/node_id"
+OCF_RESKEY_node_id_cache_file_default="${HA_RSCTMP}/node_id"
 OCF_RESKEY_volume_local_check_default="true"
 
 export attached_server_id=""

--- a/heartbeat/sapdb-nosha.sh
+++ b/heartbeat/sapdb-nosha.sh
@@ -740,5 +740,5 @@ sidadm="`echo $SID | tr '[:upper:]' '[:lower:]'`adm"
 }
 
 # Set a tempfile and make sure to clean it up again
-TEMPFILE="/tmp/SAPDatabase.$$.tmp"
+TEMPFILE="/var/run/SAPDatabase.$$.tmp"
 trap trap_handler INT TERM

--- a/heartbeat/sapdb-nosha.sh
+++ b/heartbeat/sapdb-nosha.sh
@@ -740,5 +740,5 @@ sidadm="`echo $SID | tr '[:upper:]' '[:lower:]'`adm"
 }
 
 # Set a tempfile and make sure to clean it up again
-TEMPFILE="/var/run/SAPDatabase.$$.tmp"
+TEMPFILE="${HA_RSCTMP}/SAPDatabase.$$.tmp"
 trap trap_handler INT TERM

--- a/rgmanager/src/resources/oradg.sh.in
+++ b/rgmanager/src/resources/oradg.sh.in
@@ -122,7 +122,7 @@ end;
 select database_role, open_mode from v\$database;
 set heading off;
 set serveroutput off;
-spool /tmp/dgstatus.${ORACLE_SID};
+spool ${HA_RSCTMP}/dgstatus.${ORACLE_SID};
 select open_mode from v\$database;
 spool off;
 EOF
@@ -463,9 +463,9 @@ start_oracle() {
 		fi
 	done
 
-	if [ -n "$ORACLE_HOSTNAME" -a -s /tmp/dgstatus.${ORACLE_SID} ]; then
+	if [ -n "$ORACLE_HOSTNAME" -a -s ${HA_RSCTMP}/dgstatus.${ORACLE_SID} ]; then
         	# Start DB Console if vhost defined and database_role is READ WRITE
-		if cat /tmp/dgstatus.${ORACLE_SID} 2>/dev/null | grep "READ WRITE"; then
+		if cat ${HA_RSCTMP}/dgstatus.${ORACLE_SID} 2>/dev/null | grep "READ WRITE"; then
 			ocf_log info "Starting Oracle EM DB Console for $ORACLE_SID"
 			emctl start dbconsole
 			if [ $? -ne 0 ]; then
@@ -478,7 +478,7 @@ start_oracle() {
 				ocf_log info "Oracle EM DB Console startup for $ORACLE_SID succeeded"
 			fi
 		fi
-                rm -f /tmp/dgstatus.${ORACLE_SID}
+                rm -f ${HA_RSCTMP}/dgstatus.${ORACLE_SID}
 	fi
 
 	if [ -n "$LOCKFILE" ]; then
@@ -619,7 +619,7 @@ status_oracle() {
 # Data Guard Modification 1 - Debug Logging
 case $1 in
 stop | start | status | restart | recover | monitor )
-[ $(id -u) = 0 ] && exec > "/tmp/oradg_${ORACLE_SID}_$1.log" 2>&1
+[ $(id -u) = 0 ] && exec > "${HA_RSCTMP}/oradg_${ORACLE_SID}_$1.log" 2>&1
 set -x
 date
 echo $@

--- a/tools/ocft/caselib.in
+++ b/tools/ocft/caselib.in
@@ -93,7 +93,7 @@ agent_run()
 
   aroot=${__OCFT__MYROOT:-$__OCFT__AGENT_ROOT}
 
-  setsid $aroot/$agent $cmd >/tmp/.ocft_runlog 2>&1 &
+  setsid $aroot/$agent $cmd >${HA_RSCTMP}/.ocft_runlog 2>&1 &
   pid=$!
 
   i=0
@@ -111,7 +111,7 @@ agent_run()
     kill -SIGKILL -$pid >/dev/null 2>&1
     echo -n "${__OCFT__showhost}ERROR: The agent was hanging, killed it, "
     echo "maybe you damaged the agent or system's environment, see details below:"
-    cat /tmp/.ocft_runlog
+    cat ${HA_RSCTMP}/.ocft_runlog
     echo
     quit 1
   fi
@@ -174,7 +174,7 @@ backbash_start()
   fi
 
   ssh root@$host '@BASH_SHELL@ 2>&1
-                  sed "s/00/001/g" /tmp/.backbash-log
+                  sed "s/00/001/g" ${HA_RSCTMP}/.backbash-log
                   echo 000
                   echo 1' >$__OCFT__CASES_DIR/${host}_r <$__OCFT__CASES_DIR/${host}_w &
 
@@ -203,8 +203,8 @@ EOF
   cat >&$wfd
   cat >&$wfd <<EOF
 
-} >&/tmp/.backbash-log
-sed 's/00/001/g' /tmp/.backbash-log
+} >&${HA_RSCTMP}/.backbash-log
+sed 's/00/001/g' ${HA_RSCTMP}/.backbash-log
 echo 000
 echo 0
 EOF


### PR DESCRIPTION
There are various problems with tmp-races. Some of them may be used for LPE.
This changes makes resource-agents safer.