### PR TITLE
Fix audit issue with secure tmp file

### DIFF
--- a/rgmanager/src/resources/oradg.sh.in
+++ b/rgmanager/src/resources/oradg.sh.in
@@ -195,7 +195,7 @@ stop_db() {
 	fi
 
 	# If we see 'ORA-' or 'failure' in stdout, we're done.
-	if [[ "$startup_stdout" =~ "ORA-" ]] || [[ "$startup_stdout" =~ "failure" ]]; then
+	if [[ "$stop_stdout" =~ "ORA-" ]] || [[ "$stop_stdout" =~ "failure" ]]; then
 		ocf_log error "Stopping Oracle DB $ORACLE_SID failed, errors in stdout"
 		return 1
 	fi

--- a/tools/ocft/drbd.linbit
+++ b/tools/ocft/drbd.linbit
@@ -7,7 +7,7 @@ CONFIG
         HangTimeout 20
 
 VARIABLE
-	DRBDCONF=/tmp/ocft_drbd_tmp.conf
+	DRBDCONF=${HA_RSCTMP}/ocft_drbd_tmp.conf
 
         # should be this machine's hostname/ip, please modify it by yourself.
 	NAME_1=HOSTNAME1


### PR DESCRIPTION
* Change the drbd.linbit tmp file location to a more secure place. (https://github.com/ClusterLabs/resource-agents/issues/1049)
* Correct the stdout parameter from start to stop. 