### PR TITLE
galera: Fix value used for connecting with the empty password.

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -989,7 +989,7 @@ fi
 MYSQL_OPTIONS_CHECK="-nNE --user=${OCF_RESKEY_check_user}"
 
 if ocf_is_true "${OCF_RESKEY_check_passwd_use_empty}"; then
-    MYSQL_OPTIONS_CHECK="$MYSQL_OPTIONS_CHECK --password=''"
+    MYSQL_OPTIONS_CHECK="$MYSQL_OPTIONS_CHECK --password="
 elif [ -n "${OCF_RESKEY_check_passwd}" ]; then
     MYSQL_OPTIONS_CHECK="$MYSQL_OPTIONS_CHECK --password=${OCF_RESKEY_check_passwd}"
 fi


### PR DESCRIPTION
When check_passwd_use_empty option was introduced, it added a possibility
to connect to mysql explicitly using empty password, thus bypassing defaults
set in ~/.my.cnf.
However the the empty password set for MYSQL_OPTIONS_CHECK variable was wrong,
adding too many levels of escaping and ultimately failing when passed to mysql client.

This commit changes the password value in MYSQL_OPTIONS_CHECK so that it really
ends in passing the empty string.

Original PR here: https://github.com/ClusterLabs/resource-agents/pull/1330