### PR TITLE
Remove lio_iblock usage in lio-t implementation of iSCSILogicalUnit

### DIFF
--- a/heartbeat/iSCSILogicalUnit.in
+++ b/heartbeat/iSCSILogicalUnit.in
@@ -273,6 +273,8 @@ Using distinct values here avoids a warning in LIO "LEGACY: SHARED HBA";
 and it is necessary when using multiple LUNs started at the same time
 (eg. on node failover) to prevent a race condition in tcm_core on mkdir()
 in /sys/kernel/config/target/core/.
+
+This parameter is only used by LIO. LIO-T ignores it.
 </longdesc>
 <shortdesc lang="en">LIO iblock device number</shortdesc>
 <content type="integer" default="${OCF_RESKEY_lio_iblock_default}"/>
@@ -426,7 +428,8 @@ iSCSILogicalUnit_start() {
 	lio-t)
 		ocf_take_lock $TARGETLOCKFILE
 		ocf_release_lock_on_exit $TARGETLOCKFILE
-		iblock_attrib_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/attrib"
+		iblock_path="/sys/kernel/config/target/core/*_*/${OCF_RESOURCE_INSTANCE}"
+		iblock_attrib_path="${iblock_path}/attrib"
 		# For lio, we first have to create a target device, then
 		# add it to the Target Portal Group as an LU.
 		# Handle differently 'block' and 'fileio'
@@ -438,7 +441,7 @@ iSCSILogicalUnit_start() {
 			ocf_run targetcli /backstores/${OCF_RESKEY_liot_bstype} create ${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_path} $(test -n "$OCF_RESKEY_scsi_sn" && echo "wwn=${OCF_RESKEY_scsi_sn}") || exit $OCF_ERR_GENERIC
 		fi
 		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
-			echo ${OCF_RESKEY_scsi_sn} > /sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/wwn/vpd_unit_serial
+			echo ${OCF_RESKEY_scsi_sn} > ${iblock_path}/wwn/vpd_unit_serial
 		fi
 		ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns create /backstores/${OCF_RESKEY_liot_bstype}/${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
 


### PR DESCRIPTION
lio_iblock parameter is used in iSCSILogicalUnit_start(), although it is unsupported in lio-t implementation (see iSCSILogicalUnit_validate()).

This PR removes the use of lio_iblock and instead tries to autodetect the backstore index (for lio-t only).

Indexes are assigned sequentially and their value depends on the order in which the backstores are created by targetcli (i.e. on the order in which resources are started).

In current implementation, only 1 LUN resource based on lio-t works (tested in CentOS 8). The second one fails to start as it has a higher index than 0.

I believe this PR should resolve #1256.