### PR TITLE
gcp-vpc-move: Disable google api cache discovery

### DIFF
--- a/heartbeat/gcp-vpc-move-route.in
+++ b/heartbeat/gcp-vpc-move-route.in
@@ -202,7 +202,7 @@ def validate(ctx):
     sys.exit(OCF_ERR_PERM)
 
   try:
-    ctx.conn = googleapiclient.discovery.build('compute', 'v1')
+    ctx.conn = googleapiclient.discovery.build('compute', 'v1', cache_discovery=False)
   except Exception as e:
     logger.error('Couldn\'t connect with google api: ' + str(e))
     sys.exit(OCF_ERR_CONFIGURED)

--- a/heartbeat/gcp-vpc-move-vip.in
+++ b/heartbeat/gcp-vpc-move-vip.in
@@ -274,7 +274,7 @@ def validate():
 
   # Populate global vars
   try:
-    CONN = googleapiclient.discovery.build('compute', 'v1')
+    CONN = googleapiclient.discovery.build('compute', 'v1', cache_discovery=False)
   except Exception as e:
     logger.error('Couldn\'t connect with google api: ' + str(e))
     sys.exit(OCF_ERR_CONFIGURED)


### PR DESCRIPTION
The underlying google api code cache discovery process
uses deprecated code. In order to avoid the usage of that
code and the related warning messages the cache usage is
disabled