### PR TITLE
Eliminated logging.basicConfig()

### DIFF
--- a/heartbeat/ocf.py
+++ b/heartbeat/ocf.py
@@ -98,7 +98,6 @@ HA_LOGFACILITY = env.get("HA_LOGFACILITY")
 HA_LOGFILE = env.get("HA_LOGFILE")
 HA_DEBUGLOG = env.get("HA_DEBUGLOG")
 
-logging.basicConfig()
 log = logging.getLogger(os.path.basename(argv[0]))
 log.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
That method installed a root logger to be used with logging methods.
The root logger is a stream logger which sends output to stderr,
so every log data ended up in stderr as well