### PR TITLE
Low: galera: Fix handling of Galera nodes when they include a port number

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -491,7 +491,7 @@ greater_than_equal_long()
 
 galera_to_pcmk_name()
 {
-    local galera=$1
+    local galera=${1%:*}
     if [ -z "$OCF_RESKEY_cluster_host_map" ]; then
         echo $galera
     else


### PR DESCRIPTION
When Galera is configured to use a non-default base port, this port number needs to be specified also in `wsrep_cluster_address`. Example:

    wsrep_cluster_address="gcomm://bsc1170646-node1:6666,bsc1170646-node2:6666"

This causes a problem for the Galera resource agent because it splits nodes in `wsrep_cluster_address` on character ',' and then expects to map obtained Galera node names to Pacemaker node names. The mapping is done either directly or indirectly via the `cluster_host_map` but fails in both cases as `cluster_host_map` is also not expected to include any port numbers. A result of the wrong mapping is that the agent invokes `crm_attribute -N <node>` with a non-existent node name and is therefore not able to obtain correct attribute values.

Example of a wrong command invoked by the agent:

    # /usr/sbin/crm_attribute -N bsc1170646-node1:6666 -l reboot --name "rsc_galera-last-committed" --quiet
    Could not map name=bsc1170646-node1:6666 to a UUID

Correct command:

    # /usr/sbin/crm_attribute -N bsc1170646-node1 -l reboot --name "rsc_galera-last-committed" --quiet
    7

A proposed patch addresses the problem by stripping any port number from a Galera node in function `galera_to_pcmk_name()`.

Note: As an alternative approach, handling of `cluster_host_map` could be improved/fixed to accept also port numbers:

    cluster_host_map=bsc1170646-node1:bsc1170646-node1:6666,bsc1170646-node2:bsc1170646-node2:6666

This provides more complete and explicit control. I am not sure if this would be potentially a more preferred approach.