### PR TITLE
azure-events: handle exceptions in urlopen

### DIFF
--- a/heartbeat/azure-events.in
+++ b/heartbeat/azure-events.in
@@ -86,10 +86,10 @@ class azHelper:
 			resp = urllib2.urlopen(req)
 		except URLError as e:
 			if hasattr(e, 'reason'):
-				print('We failed to reach a server. Reason: '), e.reason
+				ocf.logger.warning("Failed to reach the server: %s" % e.reason)
 				clusterHelper.setAttr(attr_globalPullState, "IDLE")
 			elif hasattr(e, 'code'):
-				print('The server couldn\'t fulfill the request. Error code: '), e.code
+				ocf.logger.warning("The server couldn\'t fulfill the request. Error code: %s" % e.code)
 				clusterHelper.setAttr(attr_globalPullState, "IDLE")
 		else:
 			data = resp.read()

--- a/heartbeat/azure-events.in
+++ b/heartbeat/azure-events.in
@@ -82,9 +82,19 @@ class azHelper:
 		req = urllib2.Request(url, postData)
 		req.add_header("Metadata", "true")
 		req.add_header("User-Agent", USER_AGENT)
-		resp = urllib2.urlopen(req)
-		data = resp.read()
-		ocf.logger.debug("_sendMetadataRequest: response = %s" % data)
+		try:
+			resp = urllib2.urlopen(req)
+		except URLError as e:
+			if hasattr(e, 'reason'):
+				print('We failed to reach a server. Reason: '), e.reason
+				clusterHelper.setAttr(attr_globalPullState, "IDLE")
+			elif hasattr(e, 'code'):
+				print('The server couldn\'t fulfill the request. Error code: '), e.code
+				clusterHelper.setAttr(attr_globalPullState, "IDLE")
+		else:
+			data = resp.read()
+			ocf.logger.debug("_sendMetadataRequest: response = %s" % data)
+
 		if data:
 			data = json.loads(data)
 


### PR DESCRIPTION
The locking in azure-events does not correctly handle some
failures.

If the metadata server is not recheable or has an error
handling the request, attr_globalPullState will never go
back to IDLE unless the administrator manually changes it.

> azure-events: ERROR: [Errno 104] Connection reset by peer
> lrmd[2734]: notice: rsc_azure-events_monitor_10000:113088:stderr [ ocf-exit-reason:[Errno 104] Connection reset by peer ]