### PR TITLE
podman: make sure to remove containers with lingering exec sessions

### DIFF
--- a/heartbeat/podman
+++ b/heartbeat/podman
@@ -222,6 +222,9 @@ container_exists()
 
 remove_container()
 {
+	local rc
+	local execids
+
 	if ocf_is_true "$OCF_RESKEY_reuse"; then
 		# never remove the container if we have reuse enabled.
 		return 0
@@ -234,6 +237,19 @@ remove_container()
 	fi
 	ocf_log notice "Cleaning up inactive container, ${CONTAINER}."
 	ocf_run podman rm $CONTAINER
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		# due to a podman bug (rhbz#1841485), sometimes a stopped
+		# container can still be associated with Exec sessions, in
+		# which case the "podman rm" has to be forced
+		execids=$(podman inspect $CONTAINER --format '{{len .ExecIDs}}')
+		if [ "$execids" -ne "0" ]; then
+			ocf_log warn "Inactive container ${CONTAINER} has lingering exec sessions. Force-remove it."
+			ocf_run podman rm -f $CONTAINER
+			rc=$?
+		fi
+	fi
+	return $rc
 }
 
 podman_simple_status()


### PR DESCRIPTION
It may happen that some "podman exec" commands don't finish
cleanly and leave lingering "Exec sessions" in the container's
state. In that case, a "podman rm" command will always fail.

To overcome the podman bug, issue a "podman rm -f" command when
we detect a container is stopped but still has some lingering
"Exec sessions" associated with it.

Related-Bug: rhbz#1839721