### PR TITLE
nfsserver: prevent error messages when /etc/sysconfig/nfs does not exist

### DIFF
--- a/heartbeat/nfsserver-redhat.sh
+++ b/heartbeat/nfsserver-redhat.sh
@@ -150,10 +150,12 @@ set_env_args()
 
 	# override local nfs config. preserve previous local config though.
 	if [ -s $tmpconfig ]; then
-		cat $NFS_SYSCONFIG | grep -q -e "$NFS_SYSCONFIG_AUTOGEN_TAG" > /dev/null 2>&1 
-		if [ $? -ne 0 ]; then
-			# backup local nfs config if it doesn't have our HA autogen tag in it.
-			mv -f $NFS_SYSCONFIG $NFS_SYSCONFIG_LOCAL_BACKUP
+		if [ -f "$NFS_SYSCONFIG" ]; then
+			cat $NFS_SYSCONFIG | grep -q -e "$NFS_SYSCONFIG_AUTOGEN_TAG" > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+				# backup local nfs config if it doesn't have our HA autogen tag in it.
+				mv -f $NFS_SYSCONFIG $NFS_SYSCONFIG_LOCAL_BACKUP
+			fi
 		fi
 
 		cat $tmpconfig | grep -q -e "$NFS_SYSCONFIG_AUTOGEN_TAG" > /dev/null 2>&1 


### PR DESCRIPTION
On RHEL8, /etc/sysconfig/nfs is deprecated and has been replaced by /etc/nfs.conf [1],
the following error is output when nfserver is started.
Added a check to prevent users from getting confusing messages.

```
Jun 08 14:08:00 r81-1 pacemaker-execd     [4241] (operation_finished)   notice: nfs-daemon_start_0:6981:stderr [ cat: /etc/sysconfig/nfs: No such file or directory ]
Jun 08 14:08:00 r81-1 pacemaker-execd     [4241] (operation_finished)   notice: nfs-daemon_start_0:6981:stderr [ mv: cannot stat '/etc/sysconfig/nfs': No such file or directory ]
```

[1] https://access.redhat.com/solutions/3938381