### PR TITLE
galera/redis: use --output-as for crm_mon w/newer Pacemaker, and prepare for Promoted role

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -445,6 +445,13 @@ master_exists()
     res=$?
     if [ -z "$OCF_RESKEY_crm_feature_set" ] || [ $res -eq 2 ]; then
         XMLOPT="--output-as=xml"
+        ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.2.0"
+        if [ $? -eq 1 ]; then
+            crm_mon -1 $XMLOPT >/dev/null 2>&1
+            if [ $? -ne 0 ]; then
+                XMLOPT="--as-xml"
+            fi
+        fi
     else
         XMLOPT="--as-xml"
     fi

--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -441,7 +441,14 @@ master_exists()
         return 1
     fi
     # determine if a master instance is already up and is healthy
-    ${HA_SBIN_DIR}/crm_mon --as-xml | grep "resource.*id=\"${INSTANCE_ATTR_NAME}\".*role=\"Master\".*active=\"true\".*orphaned=\"false\".*failed=\"false\"" > /dev/null 2>&1
+    ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.1.0"
+    res=$?
+    if [ -z "$OCF_RESKEY_crm_feature_set" ] || [ $res -eq 2 ]; then
+        XMLOPT="--output-as=xml"
+    else
+        XMLOPT="--as-xml"
+    fi
+    ${HA_SBIN_DIR}/crm_mon -1 $XMLOPT | grep -q -i -E "resource.*id=\"${INSTANCE_ATTR_NAME}\".*role=\"(Promoted|Master)\".*active=\"true\".*orphaned=\"false\".*failed=\"false\""
     return $?
 }
 

--- a/heartbeat/redis.in
+++ b/heartbeat/redis.in
@@ -276,6 +276,13 @@ master_is_active()
 		res=$?
 		if [ -z "$OCF_RESKEY_crm_feature_set" ] || [ $res -eq 2 ]; then
 			XMLOPT="--output-as=xml"
+			ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.2.0"
+			if [ $? -eq 1 ]; then
+				crm_mon -1 $XMLOPT >/dev/null 2>&1
+				if [ $? -ne 0 ]; then
+					XMLOPT="--as-xml"
+				fi
+			fi
 		else
 			XMLOPT="--as-xml"
 		fi

--- a/heartbeat/redis.in
+++ b/heartbeat/redis.in
@@ -272,7 +272,14 @@ master_is_active()
 {
 	if [ -z "$MASTER_ACTIVE_CACHED" ]; then
 		# determine if a master instance is already up and is healthy
-		crm_mon --as-xml | grep "resource.*id=\"${OCF_RESOURCE_INSTANCE}\".* role=\"Master\".* active=\"true\".* orphaned=\"false\".* failed=\"false\"" > /dev/null 2>&1
+		ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.1.0"
+		res=$?
+		if [ -z "$OCF_RESKEY_crm_feature_set" ] || [ $res -eq 2 ]; then
+			XMLOPT="--output-as=xml"
+		else
+			XMLOPT="--as-xml"
+		fi
+		crm_mon -1 $XMLOPT | grep -q -i -E "resource.*id=\"${OCF_RESOURCE_INSTANCE}\".* role=\"(Promoted|Master)\".* active=\"true\".* orphaned=\"false\".* failed=\"false\""
 		MASTER_ACTIVE=$?
 		MASTER_ACTIVE_CACHED="true"
 	fi


### PR DESCRIPTION
Additional fixes based on https://github.com/ClusterLabs/resource-agents/pull/1518.