### PR TITLE
iSCSILogicalUnit: lio-t: Add pscsi LIO-T backing store

### DIFF
--- a/heartbeat/iSCSILogicalUnit.in
+++ b/heartbeat/iSCSILogicalUnit.in
@@ -285,6 +285,8 @@ set this to 'block'. If you want to use async IO, set this to 'fileio'.
 Async I/O works also with block devices, however - you need to understand
 the consequences. See targetcli(8). If using file backend, you need to create this file in
 advance.
+If you want to use SCSI Passthrough, set this to 'pscsi'.
+Do not use PSCSI unless you know exactly how it will be used. 
 </longdesc>
 <shortdesc lang="en">LIO-T backing store type</shortdesc>
 <content type="string" default="${OCF_RESKEY_liot_bstype_default}"/>
@@ -429,13 +431,18 @@ iSCSILogicalUnit_start() {
 		iblock_attrib_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/attrib"
 		# For lio, we first have to create a target device, then
 		# add it to the Target Portal Group as an LU.
-		# Handle differently 'block' and 'fileio'
+		# Handle differently 'block', 'fileio' and 'pscsi'
 		if [ "${OCF_RESKEY_liot_bstype}" = "block" ]
 		then
 			ocf_run targetcli /backstores/${OCF_RESKEY_liot_bstype} create name=${OCF_RESOURCE_INSTANCE} dev=${OCF_RESKEY_path} $(test -n "$OCF_RESKEY_scsi_sn" && echo "wwn=${OCF_RESKEY_scsi_sn}") || exit $OCF_ERR_GENERIC
 		elif [ "${OCF_RESKEY_liot_bstype}" = "fileio" ]
 		then
 			ocf_run targetcli /backstores/${OCF_RESKEY_liot_bstype} create ${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_path} $(test -n "$OCF_RESKEY_scsi_sn" && echo "wwn=${OCF_RESKEY_scsi_sn}") || exit $OCF_ERR_GENERIC
+		elif [ "${OCF_RESKEY_liot_bstype}" = "pscsi" ]
+		then
+			# pscsi don't use custom wwn because it's SCSI passthrough so scsi_generic device will report it's own wwn
+			# so lets ignore provided serial in $OCF_RESKEY_scsi_sn
+			ocf_run targetcli /backstores/${OCF_RESKEY_liot_bstype} create ${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
 		fi
 		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
 			echo ${OCF_RESKEY_scsi_sn} > /sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/wwn/vpd_unit_serial


### PR DESCRIPTION
With minimal changes LIO-T 'pscsi' backing store can be implemented. As use case example this enables possibility to export tape library robot devices via SCSI passthrough to virtual machine in HA KVM setup where same multiple library robots are zoned to multiple corosync nodes in multiple datacenters via SAN to achieve HA. In such scenario corosync just switch iSCSILogicalUnit to online node. This solution can work with persistent device naming such as '/dev/tape/by-id/<wwn>' but firstly this patch has to be implemented https://github.com/open-iscsi/rtslib-fb/pull/165 into rtslib-fb because otherwise targetcli returns error when scsi_generic device is being exported via pscsi backend.