### PR TITLE
sybaseASE: Run verify_all() for start operation only

### DIFF
--- a/heartbeat/sybaseASE.in
+++ b/heartbeat/sybaseASE.in
@@ -864,12 +864,10 @@ case $__OCF_ACTION in
 		exit $?
 		;;
 	stop)
-		verify_all || exit $OCF_ERR_GENERIC
 		ase_stop
 		exit $?
 		;;
 	status | monitor)
-		verify_all || exit $OCF_ERR_GENERIC
 		ase_status $OCF_CHECK_LEVEL
 		exit $?
 		;;


### PR DESCRIPTION
The `sybaseASE` resource agent runs the `verify_all()` function at the
beginning of start, stop, and monitor operations.

When `verify_all()` is run for a probe (monitor) operation and
`sybase_home` resides on a cluster-managed filesystem, the probe often
fails with `$OCF_ERR_GENERIC` because the filesystem isn't mounted yet.
This prevents the resource from starting on that node.

For the stop operation, there's simply no reason to run `verify_all()`.

This patch removes `verify_all()` for the stop and monitor operations.
It is now only run for the start operation.

Resolves: RHBZ#1848673
Resolves: RHBZ#1848025