### PR TITLE
pgsql: support RHEL 8.1 pacemaker

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -2122,6 +2122,13 @@ print_crm_mon() {
         res=$?
         if [ -z "$OCF_RESKEY_crm_feature_set" ] || [ $res -eq 2 ]; then
             XMLOPT="--output-as=xml"
+            ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.2.0"
+            if [ $? -eq 1 ]; then
+                crm_mon -1 $XMLOPT >/dev/null 2>&1
+                if [ $? -ne 0 ]; then
+                    XMLOPT="--as-xml"
+                fi
+            fi
         else
             XMLOPT="--as-xml"
         fi


### PR DESCRIPTION
CRM_FEATURE_SET of pacemaker bundled with RHEL 8.1 is 3.2.0,
but crm_mon --output-as=xml is not implemented.

Fixes: https://github.com/ClusterLabs/resource-agents/issues/1527