### PR TITLE
nfsserver/nfsnotify: fix SELinux issue due to newer ls versions giving additional output.

### DIFF
--- a/heartbeat/nfsnotify.in
+++ b/heartbeat/nfsnotify.in
@@ -305,7 +305,7 @@ esac
 which restorecon > /dev/null 2>&1 && selinuxenabled
 SELINUX_ENABLED=$?
 if [ $SELINUX_ENABLED -eq 0 ]; then
-	export SELINUX_LABEL="$(ls -ldZ $STATD_PATH | cut -f4 -d' ')"
+	export SELINUX_LABEL="$(ls -dZ $STATD_PATH | grep -o '\S\+:\S\+:\S\+')"
 fi
 
 case $__OCF_ACTION in

--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -192,7 +192,7 @@ fi
 which restorecon > /dev/null 2>&1 && selinuxenabled
 SELINUX_ENABLED=$?
 if [ $SELINUX_ENABLED -eq 0 ]; then
-	export SELINUX_LABEL="$(ls -ldZ $STATD_PATH | cut -f4 -d' ')"
+	export SELINUX_LABEL="$(ls -dZ $STATD_PATH | grep -o '\S\+:\S\+:\S\+')"
 fi
 
 ##


### PR DESCRIPTION
This patch has been tested on RHEL6, 7 and 8.