### PR TITLE
gcp-vpc-move-vip: Fix sort for list of dicts in python3

### DIFF
--- a/heartbeat/gcp-vpc-move-vip.in
+++ b/heartbeat/gcp-vpc-move-vip.in
@@ -200,7 +200,8 @@ def add_rm_alias(mode, project, zone, instance, alias, alias_range_name=None):
     else:
       raise ValueError('Invalid value for mode: {}'.format(mode))
 
-  if (sorted(new_aliases) != sorted(old_aliases)):
+  if (sorted(new_aliases, key=lambda item: item.get('ipCidrRange'))
+      != sorted(old_aliases, key=lambda item: item.get('ipCidrRange'))):
     set_aliases(project, zone, instance, new_aliases, fingerprint)
     return True
   else:


### PR DESCRIPTION
python2 sorts a list of dicts of `{'ipCidrRange': <alias>}` correctly by
default. python3 fails with a TypeError:

`TypeError: '<' not supported between instances of 'dict' and 'dict'`

Fix this by using the key parameter of sorted(). python2 also supports
this.

Signed-off-by: Reid Wahl <nrwahl@protonmail.com>