### PR TITLE
aws-vpc-move-ip: Don't warn for expected scenarios

### DIFF
--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -270,7 +270,13 @@ ec2ip_monitor() {
 	ocf_log debug "executing command: $cmd"
 	RESULT=$($cmd | grep "$OCF_RESKEY_ip")
 	if [ -z "$RESULT" ]; then
-		ocf_log warn "IP $OCF_RESKEY_ip not assigned to running interface"
+		if [ "$__OCF_ACTION" = "monitor" ] && ! ocf_is_probe; then
+			level="error"
+		else
+			level="info"
+		fi
+
+		ocf_log "$level" "IP $OCF_RESKEY_ip not assigned to running interface"
 		return $OCF_NOT_RUNNING
 	fi
 
@@ -282,11 +288,22 @@ ec2ip_monitor() {
 ec2ip_drop() {
 	cmd="ip addr delete ${OCF_RESKEY_ip}/32 dev $OCF_RESKEY_interface"
 	ocf_log debug "executing command: $cmd"
-	$cmd
+	output=$($cmd 2>&1)
 	rc=$?
+
 	if [ "$rc" -gt 0 ]; then
-		ocf_log warn "command failed, rc $rc"
+		if [ "$__OCF_ACTION" = "start" ]; then
+			# expected to fail during start
+			level="debug"
+		else
+			level="warn"
+		fi
+
+		ocf_log "$level" "command failed, rc $rc"
+		ocf_log "$level" "output/error: $output"
 		return $OCF_ERR_GENERIC
+	else
+		ocf_log debug "output/error: $output"
 	fi
 
 	# delete remaining route-entries if any


### PR DESCRIPTION
Make log levels more appropriate to the situation. Before this patch, a
normal start looked like this:
```
Operation start for aws-vip (ocf:heartbeat:aws-vpc-move-ip) returned: 'ok' (0)
 >  stderr: Nov 09 02:38:20 INFO: EC2: Moving IP address 10.0.1.65 to this host by adjusting routing table rtb-01b4ea1ae0ec0a4d9
 >  stderr: Nov 09 02:38:20 INFO: monitor: check routing table (API call) - rtb-01b4ea1ae0ec0a4d9
 >  stderr: Nov 09 02:38:22 WARNING: IP 10.0.1.65 not assigned to running interface
 >  stderr: Nov 09 02:38:22 INFO: EC2: Adjusting routing table and locally configuring IP address
 >  stderr: RTNETLINK answers: Cannot assign requested address
 >  stderr: Nov 09 02:38:24 WARNING: command failed, rc 2
 >  stderr: Nov 09 02:38:24 INFO: monitor: check routing table (API call) - rtb-01b4ea1ae0ec0a4d9
```

Now it looks like this:
```
Operation start for aws-vip (ocf:heartbeat:aws-vpc-move-ip) returned: 'ok' (0)
 >  stderr: Nov 09 02:40:43 INFO: EC2: Moving IP address 10.0.1.65 to this host by adjusting routing table rtb-01b4ea1ae0ec0a4d9
 >  stderr: Nov 09 02:40:43 INFO: monitor: check routing table (API call) - rtb-01b4ea1ae0ec0a4d9
 >  stderr: Nov 09 02:40:44 INFO: IP 10.0.1.65 not assigned to running interface
 >  stderr: Nov 09 02:40:44 INFO: EC2: Adjusting routing table and locally configuring IP address
 >  stderr: Nov 09 02:40:46 INFO: monitor: check routing table (API call) - rtb-01b4ea1ae0ec0a4d9
```

Under normal circumstances, the call to `ec2ip_drop()` within
`ec2ip_get_and_configure` should not be required at all. The drop
function deletes the address before the get_and_configure function
immediately re-adds the address. This call could probably be removed
altogether. Instead, I left the call and silenced its output just in
case of unexpected edge cases.

Resolves: RHBZ#1895811

Signed-off-by: Reid Wahl <nrwahl@protonmail.com>