### PR TITLE
Fix ocf.py usage for py2 when self param is involved

### DIFF
--- a/heartbeat/ocf.py
+++ b/heartbeat/ocf.py
@@ -398,6 +398,7 @@ def run(agent, handlers=None):
 			params = inspect.signature(func).parameters.keys()
 		else:
 			params = inspect.getargspec(func).args
+			if 'self' in params: params.remove('self')
 		def value_for_parameter(param):
 			val = get_parameter(param)
 			if val is not None:


### PR DESCRIPTION
I have noticed that the `ocf.py` usage fails for python2, when the methods used in the handlers are coming from an object instance.
The `inspect.getargspec(func).args` piece of code returns `self` attribute, that we don't really want to use it.
This is the raised error:
```
ocf-exit-reason:validate() takes exactly 1 argument (2 given)
ocf.py(None)[22377]:	Sep 17 09:18:10 ERROR: validate() takes exactly 1 argument (2 given)
```

Removing `self` from the parameters list fixes the issue.
This doesn't affect to python3 as it goes for the other branch of the `if` statement