### PR TITLE
Filesystem: Default fast_stop to no for RHEL 9+ and for other distros

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -68,7 +68,19 @@ OCF_RESKEY_fstype_default=""
 OCF_RESKEY_options_default=""
 OCF_RESKEY_statusfile_prefix_default="${DFLT_STATUSDIR}"
 OCF_RESKEY_run_fsck_default="auto"
-OCF_RESKEY_fast_stop_default="yes"
+
+OCF_RESKEY_fast_stop_default="no"
+
+# yes for RHEL/CentOS versions less than 9, otherwise no
+if is_redhat_based; then
+	get_os_ver
+	ocf_version_cmp "$VER" "9.0" 2>/dev/null
+
+	if [ "$?" -eq 0 ]; then
+		OCF_RESKEY_fast_stop_default="yes"
+	fi
+fi
+
 OCF_RESKEY_force_clones_default="false"
 OCF_RESKEY_force_unmount_default="true"
 


### PR DESCRIPTION
Set OCF_RESKEY_fast_stop_default="no" for RHEL and CentOS major releases
9 and above, and for all other distros.

In the past, this attribute has defaulted to "yes", which has caused a
lot of confusion for users. fast_stop preempts the resource's stop
timeout, causing the agent to give up on unmounting the filesystem after
six seconds and declare a stop failure. (The resource operation does not
time out.)

The existence of a stop operation timeout renders fast_stop unnecessary,
and users typically expect that the agent will keep trying to unmount
the filesystem until the full stop operation timeout expires.

Resolves: RHBZ#1843577