### PR TITLE
ocf-distro: Improve robustness and specificity

### DIFF
--- a/heartbeat/apache
+++ b/heartbeat/apache
@@ -167,16 +167,13 @@ silent_status() {
 
 # May be useful to add other distros in future
 validate_default_config() {
-	case "$( get_release_id )" in
-                *SUSE)
-                        validate_default_suse_config
-                        ;;
-                Debian)
-                        validate_default_debian_config
-                        ;;
-                *)
-                        return 0
-        esac
+	if is_suse_based; then
+		validate_default_suse_config
+	elif is_debian_based; then
+		validate_default_debian_config
+	else
+		return 0
+	fi
 }
 
 # When using the default /etc/apache2/httpd.conf on SUSE, the file

--- a/heartbeat/azure-lb
+++ b/heartbeat/azure-lb
@@ -17,12 +17,12 @@
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
 
 # Defaults
-OCF_RESKEY_nc_default="/usr/bin/nc"
-case "$( get_release_id )" in
-	*SUSE)
-		OCF_RESKEY_nc_default="/usr/bin/socat"
-	;;
-esac
+if is_suse_based; then
+	OCF_RESKEY_nc_default="/usr/bin/socat"
+else
+	OCF_RESKEY_nc_default="/usr/bin/nc"
+fi
+
 OCF_RESKEY_port_default="61000"
 
 : ${OCF_RESKEY_nc=${OCF_RESKEY_nc_default}}

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -3,6 +3,8 @@
 # 
 # Currently needed for the nfsserver RA which has some already
 # released RH specific stuff (/etc/sysconfig/nfs editing)
+#
+# These functions are intended to be POSIX-compliant for portability.
 # 
 
 # systemd-based systems should all have an os-release file.
@@ -19,18 +21,79 @@ _REDHAT_BASED_DISTROS_RE="red *hat|rhel|fedora|centos|scientific"
 _SUSE_BASED_DISTROS_RE="sles|suse"
 
 
+# Converts OS release ID to a standard form regardless of source.
+_process_os_release_id() {
+	_os="$1"
+
+	# Convert to lowercase, isolate distro name, remove whitespace
+	_os=$(echo "$_os" \
+		| tr "[:upper:]" "[:lower:]" \
+		| sed -e "s|\(gnu/\)*linux||" -e "s/server//" \
+			-e "s/release.*//" -e "s/[[:digit:]].*//" \
+			-e "s/[[:blank:]]//")
+
+	# Normalize known distros to os-release names
+	case "$_os" in
+	*centos*)
+		_os="centos"
+		;;
+	*debian*)
+		_os="debian"
+		;;
+	*fedora*)
+		_os="fedora"
+		;;
+	*redhat*|*rhel*|*scientific*)
+		_os="rhel"
+		;;
+	*opensuse*)
+		_os="opensuse"
+		;;
+	*suseenterprise*)
+		_os="sles"
+		;;
+	*ubuntu*)
+		_os="ubuntu"
+		;;
+	esac
+
+	echo "$_os"
+}
+
+# Converts OS version ID to a form that ocf_version_cmp() can handle.
+# Strips any garbage.
+_process_os_version_id() {
+	_ver="$1"
+
+	# Discard everything except the version.
+	# Use ocf_version_cmp() format if present, or bare integer
+	# otherwise.
+	# Append ".0" for integers so that ocf_version_cmp() doesn't
+	# fail.
+	_ver_cmp_fmt="[[:digit:]][[:digit:].-]*[[:digit:]]"
+	_ver=$(echo "$_ver" \
+		| sed -n -e "s/[^[:digit:]]*\(${_ver_cmp_fmt}\).*/\1/p" \
+			-e "s/[^[:digit:]]*\([[:digit:]]*\).*/\1.0/p" \
+		| head -n 1)
+
+	echo "$_ver"
+}
+
 # Gets OS release ID (i.e., distro) or version ID from os-release file.
 # $_ETC_OS_RELEASE_FILE takes precedence over $_USR_OS_RELEASE_FILE.
 _get_val_from_os_release_file() {
 	_key=""
 	_value=""
+	_func=""
 
 	case "$1" in
 	id)
 		_key="ID"
+		_func="_process_os_release_id"
 		;;
 	version_id)
 		_key="VERSION_ID"
+		_func="_process_os_version_id"
 		;;
 	esac
 
@@ -46,9 +109,11 @@ _get_val_from_os_release_file() {
 		fi
 	fi
 
+	# Ensure the value is in the correct format
+	[ -n "$_func" ] && _value=$("$_func" "$_value")
+
 	echo "$_value"
 }
-
 
 # Gets OS release ID from lsb_release command or legacy *-release files
 _get_os_from_legacy_source() {
@@ -70,37 +135,7 @@ _get_os_from_legacy_source() {
 		_os=$(uname -s)
 	fi
 
-	# Convert to lowercase, isolate distro name, remove whitespace
-	_os=$(echo "$_os" \
-		| tr "[:upper:]" "[:lower:]" \
-		| sed -e "s|\(gnu/\)*linux||" -e "s/server//" \
-			-e "s/release.*//" -e "s/[[:digit:]].*//" \
-			-e "s/[[:blank:]]//")
-
-	# Normalize known distros to os-release names
-	case "$_os" in
-	*centos*)
-		_os="centos"
-		;;
-	*debian*)
-		_os="debian"
-		;;
-	*fedora*)
-		_os="fedora"
-		;;
-	*redhat*|*scientific*)
-		_os="rhel"
-		;;
-	*opensuse*)
-		_os="opensuse"
-		;;
-	*suseenterprise*)
-		_os="sles"
-		;;
-	*ubuntu*)
-		_os="ubuntu"
-		;;
-	esac
+	_process_os_release_id "$_os"
 }
 
 # Gets OS version from lsb_release command or legacy *-release files
@@ -127,7 +162,7 @@ _get_version_from_legacy_source() {
 		_ver=$(uname -r)
 	fi
 
-	echo "$_ver"
+	_process_os_version_id "$_ver"
 }
 
 # Prints OS release ID (i.e., distro name)
@@ -150,17 +185,6 @@ get_os_version_id() {
 		# $_DEBIAN_VERSION_FILE has ${major}.${minor}.
 		_ver=$(_get_version_from_legacy_source)
 	fi
-
-	# Discard everything in _ver except the version.
-	# Use ocf_version_cmp() format if present, or bare integer
-	# otherwise.
-	# Append ".0" for integers so that ocf_version_cmp() doesn't
-	# fail.
-	_ver_cmp_fmt="[[:digit:]][[:digit:].-]*[[:digit:]]"
-	_ver=$(echo "$_ver" \
-		| sed -n -e "s/[^[:digit:]]*\(${_ver_cmp_fmt}\).*/\1/p" \
-			-e "s/[^[:digit:]]*\([[:digit:]]*\).*/\1.0/p" \
-		| head -n 1)
 
 	echo "$_ver"
 }

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -46,13 +46,45 @@ get_release_id() {
 		elif [ -e $_DEBIAN_VERSION_FILE ]; then
 			_os=debian
 		elif [ -e $_SUSE_RELEASE_FILE ]; then
-			_os=suse
+			_os=$(head -1 "$_SUSE_RELEASE_FILE")
 		elif [ -e $_REDHAT_RELEASE_FILE ]; then
-			_os=redhat
+			_os=$(head -1 "$_REDHAT_RELEASE_FILE")
 		else
 			_os=$(uname -s)
 		fi
 	fi
+
+	# Convert to lowercase, isolate distro name, remove whitespace
+	_os=$(echo "$_os" \
+		| tr "[:upper:]" "[:lower:]" \
+		| sed -e "s|\(gnu/\)*linux||" -e "s/server//" \
+			-e "s/release.*//" -e "s/[[:digit:]].*//" \
+			-e "s/[[:blank:]]//")
+
+	# Normalize known distros to os-release names
+	case "$_os" in
+	*centos*)
+		_os="centos"
+		;;
+	*debian*)
+		_os="debian"
+		;;
+	*fedora*)
+		_os="fedora"
+		;;
+	*redhat*|*scientific*)
+		_os="rhel"
+		;;
+	*opensuse*)
+		_os="opensuse"
+		;;
+	*suseenterprise*)
+		_os="sles"
+		;;
+	*ubuntu*)
+		_os="ubuntu"
+		;;
+	esac
 
 	echo "$_os"
 }

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -40,6 +40,13 @@ get_os_ver() {
 	elif [ -f $_REDHAT_RELEASE_FILE ]; then
 		OS=RedHat  # redhat or similar
 		VER=$(sed "s/.* release \([^ ]\+\).*/\1/" $_REDHAT_RELEASE_FILE)
+	elif [ -f $_SUSE_RELEASE_FILE ]; then
+		OS=SUSE
+		VER=$(awk '$1 == "VERSION" {print $3}' "$_SUSE_RELEASE_FILE")
+
+		_patchlevel=$(awk '$1 == "PATCHLEVEL" {print $3}' \
+				"$_SUSE_RELEASE_FILE")
+		[ -n "$_patchlevel" ] && VER="${VER}.${_patchlevel}"
 	else
 		OS=$(uname -s)
 		VER=$(uname -r)

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -9,7 +9,9 @@ _DEBIAN_VERSION_FILE="/etc/debian_version"
 _REDHAT_RELEASE_FILE="/etc/redhat-release"
 _SUSE_RELEASE_FILE="/etc/SuSE-release"
 _RELEASE_FILES="/etc/*-release"
-_REDHAT_BASED_DISTROS_RE='red *hat|fedora|centos|scientific linux'
+_DEBIAN_BASED_DISTROS_RE="debian|ubuntu"
+_REDHAT_BASED_DISTROS_RE="red *hat|fedora|centos|scientific linux"
+_SUSE_BASED_DISTROS_RE="sles|suse"
 
 get_release_id() {
 	if which lsb_release >/dev/null 2>&1; then
@@ -46,8 +48,19 @@ get_os_version_id() {
 	echo "$_ver"
 }
 
+# Returns true if the OS is Debian-based, otherwise false
+is_debian_based() {
+	get_release_id | grep -Eqi "$_DEBIAN_BASED_DISTROS_RE"
+}
+
+# Returns true if the OS is Red Hat-based, otherwise false
 is_redhat_based() {
-	get_release_id | egrep -qsi "$_REDHAT_BASED_DISTROS_RE"
+	get_release_id | grep -Eqi "$_REDHAT_BASED_DISTROS_RE"
+}
+
+# Returns true if the OS is SUSE-based, otherwise false
+is_suse_based() {
+	get_release_id | grep -Eqi "$_SUSE_BASED_DISTROS_RE"
 }
 
 # Sets global variables OS and VER.

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -103,6 +103,33 @@ _get_os_from_legacy_source() {
 	esac
 }
 
+# Gets OS version from lsb_release command or legacy *-release files
+_get_version_from_legacy_source() {
+	_ver=""
+
+	if which lsb_release >/dev/null 2>&1; then
+		_ver=$(lsb_release -sr)
+
+	elif [ -f "$_DEBIAN_VERSION_FILE" ]; then
+		_ver=$(cat "$_DEBIAN_VERSION_FILE")
+
+	elif [ -f "$_REDHAT_RELEASE_FILE" ]; then
+		_ver=$(head -1 "$_REDHAT_RELEASE_FILE")
+
+	elif [ -f "$_SUSE_RELEASE_FILE" ]; then
+		_ver=$(awk '$1 == "VERSION" {print $3}' "$_SUSE_RELEASE_FILE")
+		_patchlevel=$(awk '$1 == "PATCHLEVEL" {print $3}' \
+				"$_SUSE_RELEASE_FILE")
+
+		[ -n "$_patchlevel" ] && _ver="${_ver}.${_patchlevel}"
+
+	else
+		_ver=$(uname -r)
+	fi
+
+	echo "$_ver"
+}
+
 # Prints OS release ID (i.e., distro name)
 get_release_id() {
 	_os=$(_get_val_from_os_release_file id)
@@ -121,24 +148,7 @@ get_os_version_id() {
 	if [ -z "$_ver" ] || [ "$(get_release_id)" = "debian" ]; then
 		# Debian only includes major release in os-release.
 		# $_DEBIAN_VERSION_FILE has ${major}.${minor}.
-
-		if which lsb_release >/dev/null 2>&1; then
-			_ver=$(lsb_release -sr)
-		elif [ -f "$_DEBIAN_VERSION_FILE" ]; then
-			_ver=$(cat "$_DEBIAN_VERSION_FILE")
-		elif [ -f "$_REDHAT_RELEASE_FILE" ]; then
-			_ver=$(sed "s/.* release \([^ ]\+\).*/\1/" \
-				"$_REDHAT_RELEASE_FILE")
-		elif [ -f "$_SUSE_RELEASE_FILE" ]; then
-			_ver=$(awk '$1 == "VERSION" {print $3}' \
-				"$_SUSE_RELEASE_FILE")
-
-			_patchlevel=$(awk '$1 == "PATCHLEVEL" {print $3}' \
-					"$_SUSE_RELEASE_FILE")
-			[ -n "$_patchlevel" ] && _ver="${_ver}.${_patchlevel}"
-		else
-			_ver=$(uname -r)
-		fi
+		_ver=$(_get_version_from_legacy_source)
 	fi
 
 	# Discard everything in _ver except the version.

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -10,7 +10,7 @@ _REDHAT_RELEASE_FILE="/etc/redhat-release"
 _SUSE_RELEASE_FILE="/etc/SuSE-release"
 _RELEASE_FILES="/etc/*-release"
 _DEBIAN_BASED_DISTROS_RE="debian|ubuntu"
-_REDHAT_BASED_DISTROS_RE="red *hat|fedora|centos|scientific linux"
+_REDHAT_BASED_DISTROS_RE="red *hat|fedora|centos|scientific"
 _SUSE_BASED_DISTROS_RE="sles|suse"
 
 get_release_id() {

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -5,26 +5,57 @@
 # released RH specific stuff (/etc/sysconfig/nfs editing)
 # 
 
+# systemd-based systems should all have an os-release file.
+_ETC_OS_RELEASE_FILE="/etc/os-release"
+_USR_OS_RELEASE_FILE="/usr/lib/os-release"
+
+# Legacy distro-specific files
 _DEBIAN_VERSION_FILE="/etc/debian_version"
 _REDHAT_RELEASE_FILE="/etc/redhat-release"
 _SUSE_RELEASE_FILE="/etc/SuSE-release"
 _RELEASE_FILES="/etc/*-release"
+
 _DEBIAN_BASED_DISTROS_RE="debian|ubuntu"
-_REDHAT_BASED_DISTROS_RE="red *hat|fedora|centos|scientific"
+_REDHAT_BASED_DISTROS_RE="red *hat|rhel|fedora|centos|scientific"
 _SUSE_BASED_DISTROS_RE="sles|suse"
 
-get_release_id() {
-	if which lsb_release >/dev/null 2>&1; then
-		lsb_release -si
-	elif [ -e $_DEBIAN_VERSION_FILE ]; then
-		echo Debian
-	elif [ -e $_SUSE_RELEASE_FILE ]; then
-		echo SUSE
-	elif [ -e $_REDHAT_RELEASE_FILE ]; then
-		echo Redhat
-	else # FIXME not exactly the id here, but will do for our purpose
-		cat $_RELEASE_FILES 2>/dev/null
+
+# Gets OS release ID from os-release file.
+# $_ETC_OS_RELEASE_FILE takes precedence over $_USR_OS_RELEASE_FILE.
+_get_os_from_os_release_file() {
+	_os=""
+
+	if [ -f "$_ETC_OS_RELEASE_FILE" ]; then
+		_os=$(awk -F '=' '$1 == "ID" {print $2}' \
+			"$_ETC_OS_RELEASE_FILE" | tr -d \")
 	fi
+
+	if [ -z "$_os" ] && [ -f "$_USR_OS_RELEASE_FILE" ]; then
+		_os=$(awk -F '=' '$1 == "ID" {print $2}' \
+			"$_USR_OS_RELEASE_FILE" | tr -d \")
+	fi
+
+	echo "$_os"
+}
+
+get_release_id() {
+	_os=$(_get_os_from_os_release_file)
+
+	if [ -z "$_os" ]; then
+		if which lsb_release >/dev/null 2>&1; then
+			_os=$(lsb_release -si)
+		elif [ -e $_DEBIAN_VERSION_FILE ]; then
+			_os=debian
+		elif [ -e $_SUSE_RELEASE_FILE ]; then
+			_os=suse
+		elif [ -e $_REDHAT_RELEASE_FILE ]; then
+			_os=redhat
+		else # FIXME not exactly the id here, but will do for our purpose
+			_os=$(cat $_RELEASE_FILES 2>/dev/null)
+		fi
+	fi
+
+	echo "$_os"
 }
 
 get_os_version_id() {

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -25,30 +25,35 @@ get_release_id() {
 	fi
 }
 
+get_os_version_id() {
+	if which lsb_release >/dev/null 2>&1; then
+		_ver=$(lsb_release -sr)
+	elif [ -f "$_DEBIAN_VERSION_FILE" ]; then
+		_ver=$(cat "$_DEBIAN_VERSION_FILE")
+	elif [ -f "$_REDHAT_RELEASE_FILE" ]; then
+		_ver=$(sed "s/.* release \([^ ]\+\).*/\1/" \
+			"$_REDHAT_RELEASE_FILE")
+	elif [ -f "$_SUSE_RELEASE_FILE" ]; then
+		_ver=$(awk '$1 == "VERSION" {print $3}' "$_SUSE_RELEASE_FILE")
+
+		_patchlevel=$(awk '$1 == "PATCHLEVEL" {print $3}' \
+				"$_SUSE_RELEASE_FILE")
+		[ -n "$_patchlevel" ] && _ver="${_ver}.${_patchlevel}"
+	else
+		_ver=$(uname -r)
+	fi
+
+	echo "$_ver"
+}
+
 is_redhat_based() {
 	get_release_id | egrep -qsi "$_REDHAT_BASED_DISTROS_RE"
 }
 
-# get_os_ver() is currently unused
+# Sets global variables OS and VER.
+# get_os_ver() is currently unused upstream; maintained for backwards
+# compatibility.
 get_os_ver() {
-	if which lsb_release >/dev/null 2>&1; then
-		OS=`lsb_release -si`
-		VER=`lsb_release -sr`
-	elif [ -f $_DEBIAN_VERSION_FILE ]; then
-		OS=Debian
-		VER=$(cat $_DEBIAN_VERSION_FILE)
-	elif [ -f $_REDHAT_RELEASE_FILE ]; then
-		OS=RedHat  # redhat or similar
-		VER=$(sed "s/.* release \([^ ]\+\).*/\1/" $_REDHAT_RELEASE_FILE)
-	elif [ -f $_SUSE_RELEASE_FILE ]; then
-		OS=SUSE
-		VER=$(awk '$1 == "VERSION" {print $3}' "$_SUSE_RELEASE_FILE")
-
-		_patchlevel=$(awk '$1 == "PATCHLEVEL" {print $3}' \
-				"$_SUSE_RELEASE_FILE")
-		[ -n "$_patchlevel" ] && VER="${VER}.${_patchlevel}"
-	else
-		OS=$(uname -s)
-		VER=$(uname -r)
-	fi
+	OS=$(get_release_id)
+	VER=$(get_os_version_id)
 }

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -37,21 +37,24 @@ _get_os_from_os_release_file() {
 	echo "$_os"
 }
 
-get_release_id() {
-	_os=$(_get_os_from_os_release_file)
+# Gets OS release ID from lsb_release command or legacy *-release files
+_get_os_from_legacy_source() {
+	_os=""
 
-	if [ -z "$_os" ]; then
-		if which lsb_release >/dev/null 2>&1; then
-			_os=$(lsb_release -si)
-		elif [ -e $_DEBIAN_VERSION_FILE ]; then
-			_os=debian
-		elif [ -e $_SUSE_RELEASE_FILE ]; then
-			_os=$(head -1 "$_SUSE_RELEASE_FILE")
-		elif [ -e $_REDHAT_RELEASE_FILE ]; then
-			_os=$(head -1 "$_REDHAT_RELEASE_FILE")
-		else
-			_os=$(uname -s)
-		fi
+	if which lsb_release >/dev/null 2>&1; then
+		_os=$(lsb_release -si)
+
+	elif [ -f "$_DEBIAN_VERSION_FILE" ]; then
+		_os="debian"
+
+	elif [ -f "$_REDHAT_RELEASE_FILE" ]; then
+		_os=$(head -n 1 "$_REDHAT_RELEASE_FILE")
+
+	elif [ -f "$_SUSE_RELEASE_FILE" ]; then
+		_os=$(head -n 1 "$_SUSE_RELEASE_FILE")
+
+	else
+		_os=$(uname -s)
 	fi
 
 	# Convert to lowercase, isolate distro name, remove whitespace
@@ -85,6 +88,15 @@ get_release_id() {
 		_os="ubuntu"
 		;;
 	esac
+}
+
+# Prints OS release ID (i.e., distro name)
+get_release_id() {
+	_os=$(_get_os_from_os_release_file)
+
+	if [ -z "$_os" ]; then
+		_os=$(_get_os_from_legacy_source)
+	fi
 
 	echo "$_os"
 }

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -13,7 +13,6 @@ _USR_OS_RELEASE_FILE="/usr/lib/os-release"
 _DEBIAN_VERSION_FILE="/etc/debian_version"
 _REDHAT_RELEASE_FILE="/etc/redhat-release"
 _SUSE_RELEASE_FILE="/etc/SuSE-release"
-_RELEASE_FILES="/etc/*-release"
 
 _DEBIAN_BASED_DISTROS_RE="debian|ubuntu"
 _REDHAT_BASED_DISTROS_RE="red *hat|rhel|fedora|centos|scientific"
@@ -50,8 +49,8 @@ get_release_id() {
 			_os=suse
 		elif [ -e $_REDHAT_RELEASE_FILE ]; then
 			_os=redhat
-		else # FIXME not exactly the id here, but will do for our purpose
-			_os=$(cat $_RELEASE_FILES 2>/dev/null)
+		else
+			_os=$(uname -s)
 		fi
 	fi
 

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -45,6 +45,17 @@ get_os_version_id() {
 		_ver=$(uname -r)
 	fi
 
+	# Discard everything in _ver except the version.
+	# Use ocf_version_cmp() format if present, or bare integer
+	# otherwise.
+	# Append ".0" for integers so that ocf_version_cmp() doesn't
+	# fail.
+	_ver_cmp_fmt="[[:digit:]][[:digit:].-]*[[:digit:]]"
+	_ver=$(echo "$_ver" \
+		| sed -n -e "s/[^[:digit:]]*\(${_ver_cmp_fmt}\).*/\1/p" \
+			-e "s/[^[:digit:]]*\([[:digit:]]*\).*/\1.0/p" \
+		| head -n 1)
+
 	echo "$_ver"
 }
 

--- a/heartbeat/ocf-distro
+++ b/heartbeat/ocf-distro
@@ -19,23 +19,36 @@ _REDHAT_BASED_DISTROS_RE="red *hat|rhel|fedora|centos|scientific"
 _SUSE_BASED_DISTROS_RE="sles|suse"
 
 
-# Gets OS release ID from os-release file.
+# Gets OS release ID (i.e., distro) or version ID from os-release file.
 # $_ETC_OS_RELEASE_FILE takes precedence over $_USR_OS_RELEASE_FILE.
-_get_os_from_os_release_file() {
-	_os=""
+_get_val_from_os_release_file() {
+	_key=""
+	_value=""
 
-	if [ -f "$_ETC_OS_RELEASE_FILE" ]; then
-		_os=$(awk -F '=' '$1 == "ID" {print $2}' \
-			"$_ETC_OS_RELEASE_FILE" | tr -d \")
+	case "$1" in
+	id)
+		_key="ID"
+		;;
+	version_id)
+		_key="VERSION_ID"
+		;;
+	esac
+
+	if [ -n "$_key" ]; then
+		if [ -f "$_ETC_OS_RELEASE_FILE" ]; then
+			_value=$(awk -F "=" -v k="$_key" '$1 == k {print $2}' \
+					"$_ETC_OS_RELEASE_FILE" | tr -d \")
+		fi
+
+		if [ -z "$_value" ] && [ -f "$_USR_OS_RELEASE_FILE" ]; then
+			_value=$(awk -F "=" -v k="$_key" '$1 == k {print $2}' \
+					"$_USR_OS_RELEASE_FILE" | tr -d \")
+		fi
 	fi
 
-	if [ -z "$_os" ] && [ -f "$_USR_OS_RELEASE_FILE" ]; then
-		_os=$(awk -F '=' '$1 == "ID" {print $2}' \
-			"$_USR_OS_RELEASE_FILE" | tr -d \")
-	fi
-
-	echo "$_os"
+	echo "$_value"
 }
+
 
 # Gets OS release ID from lsb_release command or legacy *-release files
 _get_os_from_legacy_source() {
@@ -92,7 +105,7 @@ _get_os_from_legacy_source() {
 
 # Prints OS release ID (i.e., distro name)
 get_release_id() {
-	_os=$(_get_os_from_os_release_file)
+	_os=$(_get_val_from_os_release_file id)
 
 	if [ -z "$_os" ]; then
 		_os=$(_get_os_from_legacy_source)
@@ -101,22 +114,31 @@ get_release_id() {
 	echo "$_os"
 }
 
+# Prints OS version ID
 get_os_version_id() {
-	if which lsb_release >/dev/null 2>&1; then
-		_ver=$(lsb_release -sr)
-	elif [ -f "$_DEBIAN_VERSION_FILE" ]; then
-		_ver=$(cat "$_DEBIAN_VERSION_FILE")
-	elif [ -f "$_REDHAT_RELEASE_FILE" ]; then
-		_ver=$(sed "s/.* release \([^ ]\+\).*/\1/" \
-			"$_REDHAT_RELEASE_FILE")
-	elif [ -f "$_SUSE_RELEASE_FILE" ]; then
-		_ver=$(awk '$1 == "VERSION" {print $3}' "$_SUSE_RELEASE_FILE")
+	_ver=$(_get_val_from_os_release_file version_id)
 
-		_patchlevel=$(awk '$1 == "PATCHLEVEL" {print $3}' \
+	if [ -z "$_ver" ] || [ "$(get_release_id)" = "debian" ]; then
+		# Debian only includes major release in os-release.
+		# $_DEBIAN_VERSION_FILE has ${major}.${minor}.
+
+		if which lsb_release >/dev/null 2>&1; then
+			_ver=$(lsb_release -sr)
+		elif [ -f "$_DEBIAN_VERSION_FILE" ]; then
+			_ver=$(cat "$_DEBIAN_VERSION_FILE")
+		elif [ -f "$_REDHAT_RELEASE_FILE" ]; then
+			_ver=$(sed "s/.* release \([^ ]\+\).*/\1/" \
+				"$_REDHAT_RELEASE_FILE")
+		elif [ -f "$_SUSE_RELEASE_FILE" ]; then
+			_ver=$(awk '$1 == "VERSION" {print $3}' \
 				"$_SUSE_RELEASE_FILE")
-		[ -n "$_patchlevel" ] && _ver="${_ver}.${_patchlevel}"
-	else
-		_ver=$(uname -r)
+
+			_patchlevel=$(awk '$1 == "PATCHLEVEL" {print $3}' \
+					"$_SUSE_RELEASE_FILE")
+			[ -n "$_patchlevel" ] && _ver="${_ver}.${_patchlevel}"
+		else
+			_ver=$(uname -r)
+		fi
 	fi
 
 	# Discard everything in _ver except the version.


### PR DESCRIPTION
This PR seeks to address several issues in ocf-distro. Summary:
  - `get_os_ver()` is missing a check for SUSE OSes. This PR adds one.
  - `get_os_ver()` does two jobs. This PR creates a new `get_os_version_id()` function to get the OS version, to parallel the existing `get_release_id()` function that gets the OS release. `get_os_ver()` now calls each of these functions to reduce code duplication. We do keep `get_os_ver()` for backwards compatibility in case anyone uses it in a custom script. It's unused upstream.
  - We have `is_redhat_based()` already. This PR adds `is_debian_based()` and `is_suse_based()`, and then calls them instead of using `get_release_id()` and case statements in the `azure-lb` and `apache` agents.
  - The Red Hat distro regex fails for Scientific Linux when `lsb_release` retrieves the OS release ID. This PR fixes that.
  - The version string that `get_os_ver()` assigns to `VER` causes `ocf_version_cmp()` to fail when the version is a bare integer (e.g., `29` for Fedora 29). This PR fixes that by appending `.0` to bare integer version strings.
  - `ocf_version_cmp()` is picky about the formats it can accept. This PR adds a sanity check/cleanup to help ensure the version string is compatible with `ocf_version_cmp()`.
  - If the `lsb_release` command is not available on an OpenSUSE system, then we may not get a release ID at all. If it's not available on an Ubuntu system, then we incorrectly call the distro Debian. This PR fixes that by trying `/etc/os-release` and `/usr/lib/os-release` first. [The `os-release` file is supposed to be available on any systemd system and intends to be the new standard source of OS release/version info.](http://0pointer.de/blog/projects/os-release) This PR falls back to the old distro detection methods if we don't find what we need in `os-release`.
  - `get_release_id()` may not correctly determine that a system is FreeBSD (or other non-Linux system). This PR adds `uname -s` as the final fallback in `get_release_id()`.
  - The existing `get_release_id()` and `get_os_ver()` functions may return various names for the same OS. Depending on where the info comes from (`lsb_release` vs. `/etc/redhat-release`) and what function is getting the info (`get_release_id()` vs. `get_os_ver()`), RHEL could be returned as "RedHatEnterprise", "Redhat", or "RedHat". This PR attempts to normalize distro names to a standard format (the same format used in the `ID` field of `os-release`.
  - This PR checks `os-release` first for the OS version ID. This is necessary at least for OpenSUSE and for Ubuntu. In OpenSUSE, `/etc/SuSE-release` is deprecated. We need to query `os-release` to get the version info in case `lsb_release` is unavailable. [In Ubuntu, `/etc/debian_version` contains the wrong version info](https://gist.github.com/natefoo/814c5bf936922dad97ff#distro-specific-files), and it's not a compatible format for `ocf_version_cmp()`.