### PR TITLE
galera: set bootstrap attribute before promote

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -587,8 +587,8 @@ detect_first_master()
     fi
 
     ocf_log info "Promoting $best_node to be our bootstrap node"
-    set_master_score $best_node
     set_bootstrap_node $best_node
+    set_master_score $best_node
 }
 
 detect_safe_to_bootstrap()


### PR DESCRIPTION
When the master detection takes place, the node chosen for
becoming the master is given two attributes in the CIB:
a master score and a bootstrap flag. The master score makes
pacemaker schedule a promote operation, and the bootstrap flag
drives how the galera server is started.

The order in which we set the attributes is racy; it may happen
that a promote operation is started before the current master
detection function has set the bootstrap flag, in which case
the promotion will fail.

Reverse the order in which we set the attributes on a bootstrap
node to close the race.