### PR TITLE
galera: fix check user configuration with clustercheck

### DIFF
--- a/heartbeat/galera
+++ b/heartbeat/galera
@@ -85,7 +85,7 @@ fi
 
 OCF_RESKEY_wsrep_cluster_address_default=""
 OCF_RESKEY_cluster_host_map_default=""
-OCF_RESKEY_check_user_default="root"
+OCF_RESKEY_check_user_default=""
 OCF_RESKEY_check_passwd_default=""
 
 : ${OCF_RESKEY_wsrep_cluster_address=${OCF_RESKEY_wsrep_cluster_address_default}}


### PR DESCRIPTION
The new way of setting parameter defaults for the galera
resource agent has a side effect that broke the automatic
set up of OCF_RESKEY_check_user with clustercheck.

Revert to the original semantics of not not setting
default user to root early, as it prevents clustercheck
credentials to be used. Only set user to root as a fallback
if no other options configured it.