### PR TITLE
fix problem with unset OCF_RESKEY_CRM_meta_interval by cluster framework

### DIFF
--- a/heartbeat/ocf.py
+++ b/heartbeat/ocf.py
@@ -195,7 +195,8 @@ def is_probe():
 	not running resource.
 	"""
 	return (OCF_ACTION == "monitor" and
-			env.get("OCF_RESKEY_CRM_meta_interval", "") == "0")
+			( env.get("OCF_RESKEY_CRM_meta_interval", "") == "0" or
+			  env.get("OCF_RESKEY_CRM_meta_interval", "") == "" ))
 
 
 def get_parameter(name, default=None):


### PR DESCRIPTION
In my LAB I have seen  that ocf.py is_probe fails on unset OCF_RESKEY_CRM_meta_interval
See also Issue #1579 