### PR TITLE
heartbeat/iface-vlan: vlan_{interface,id} do not have to be unique.

### DIFF
--- a/heartbeat/iface-vlan
+++ b/heartbeat/iface-vlan
@@ -89,7 +89,7 @@ vlan_meta_data() {
   </shortdesc>
 
   <parameters>
-    <parameter name="vlan_interface" unique="1" required="1">
+    <parameter name="vlan_interface" unique="0" required="1">
       <longdesc lang="en">
         Define the interface where VLAN should be attached.
       </longdesc>
@@ -99,7 +99,7 @@ vlan_meta_data() {
       <content type="string"/>
     </parameter>
 
-    <parameter name="vlan_id" unique="1" required="1">
+    <parameter name="vlan_id" unique="0" required="1">
       <longdesc lang="en">
         Define the VLAN ID. It has to be a value between 0 and 4094.
       </longdesc>


### PR DESCRIPTION
Machines commonly have several vlan_id attached to one interface,
and may also have a vlan_id attached to several interfaces.

vlan_name will still be unique, usual names are:
- bond_in.83@bond_in
- bond_in.84@bond_in

fixes #1581