### PR TITLE
heartbeat/Route: Return OCF_NOT_RUNNING status if iface doesn't exist.

### DIFF
--- a/heartbeat/Route
+++ b/heartbeat/Route
@@ -227,6 +227,15 @@ route_stop() {
 }
 
 route_status() {
+    if [ -n "${OCF_RESKEY_device}" ]; then
+	# Must check if device exists or is gone.
+	# If device is gone, route is also unconfigured.
+	ip link show dev ${OCF_RESKEY_device} >/dev/null 2>&1
+	if [ $? -ne 0 ]; then
+	    # Assume device does not exist, and short-circuit here.
+	    return $OCF_NOT_RUNNING
+	fi
+    fi
     show_output="$(ip $addr_family route show $(create_route_spec) 2>/dev/null)"
     if [ $? -eq 0 ]; then
 	if [ -n "$show_output" ]; then


### PR DESCRIPTION
In combinations with other agents such as heartbeat/iface-vlan,
interfaces on which routes are managed might not exist
if that resource is stopped.
In this case, the status check can safely assume that the route
is not present when the interface does not exist.

fixes #1588