### PR TITLE
LVM-activate: Improve return codes and handling of missing PVs

### DIFF
--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -123,7 +123,7 @@ Option: OCF_CHECK_LEVEL
 The standard monitor operation of depth 0 checks if the VG or LV is valid.
 If you want deeper tests, set OCF_CHECK_LEVEL to 10:
 
-  10: read first 4096 bytes of the underlying device (raw read)
+  10: read first 4096 bytes of one random managed LV (raw read)
 
 If there are many underlying devs in VG, it will only read one of the devs.
 This is not perfect solution for detecting underlying devices livable.
@@ -771,6 +771,18 @@ get_dm_dependencies() {
 		| tr " " "\n"
 }
 
+# Gets a random file from a directory in a POSIX-compliant manner.
+# Techniques like shuf and $RANDOM are not portable.
+# Caller should ensure that the directory exists.
+# Assumes that filenames do not contain whitespace (a reasonable
+# assumption for this agent).
+get_random_file() {
+	find "$1" -maxdepth 1 -mindepth 1 \
+		| awk 'BEGIN { srand() } \
+			{ files[NR-1] = $0 } \
+			END { print files[int(rand() * NR)] }'
+}
+
 # Checks whether there is still a device-mapper mapping for the managed
 # volume and whether all required PVs are present.
 #
@@ -856,16 +868,16 @@ lvm_status() {
 			;;
 		10)
 			if [ -n "$LV" ]; then
-				dm_name="/dev/$VG/$LV"
+				dev="/dev/$VG/$LV"
 			else
-				# If there are many LVs in the VG dir,
-				# pick the first one.
-				dm_name="/dev/$VG/$(ls -1 /dev/$VG | head -n 1)"
+				# Check a random LV
+				dev=$(get_random_file "/dev/$VG")
 			fi
 
 			# Read from the device to check whether it's alive.
 			if ! dd if="$1" of=/dev/null bs=4096 count=1 \
 					iflag=direct >/dev/null 2>&1; then
+				ocf_log err "$VOL: Read failed."
 				return $OCF_ERR_GENERIC
 			fi
 			;;

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -120,7 +120,7 @@ Option: OCF_CHECK_LEVEL
 The standard monitor operation of depth 0 checks if the VG or LV is valid.
 If you want deeper tests, set OCF_CHECK_LEVEL to 10:
 
-  10: read first 1 byte of the underlying device (raw read)
+  10: read first 4096 bytes of the underlying device (raw read)
 
 If there are many underlying devs in VG, it will only read one of the devs.
 This is not perfect solution for detecting underlying devices livable.
@@ -788,10 +788,9 @@ lvm_status() {
 			# if there are many lv in vg dir, pick the first name
 			dm_name="/dev/${VG}/$(ls -1 /dev/${VG} | head -n 1)"
 
-			# read 1 byte to check the dev is alive
-			dd if=${dm_name} of=/dev/null bs=1 count=1 >/dev/null \
-				2>&1
-			if [ $? -ne 0 ]; then
+			# Read from the device to check whether it's alive.
+			if ! dd if="$1" of=/dev/null bs=4096 count=1 \
+					iflag=direct >/dev/null 2>&1; then
 				return $OCF_ERR_GENERIC
 			fi
 			return $OCF_SUCCESS

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -286,7 +286,7 @@ check_tags()
 
 strip_tags()
 {
-	for tag in $(vgs --noheadings -o tags $OCF_RESKEY_volgrpname | sed s/","/" "/g); do
+	for tag in $(vgs --noheadings -o tags "$VG" | sed s/","/" "/g); do
 		ocf_log info "Stripping tag, $tag"
 
 		# LVM version 2.02.98 allows changing tags if PARTIAL

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -63,6 +63,9 @@ OCF_RESKEY_partial_activation_default="false"
 VG=${OCF_RESKEY_vgname}
 LV=${OCF_RESKEY_lvname}
 
+# Alias for convenient use in log messages
+[ -n "$LV" ] && VOL="$VG/$LV" || VOL="$VG"
+
 # How LVM controls access to the VG:
 #
 # 0: place-holder for any incorrect cases; To be safe, we enforce the VG
@@ -768,7 +771,8 @@ get_dm_dependencies() {
 		| tr " " "\n"
 }
 
-# Checks status of managed LV or VG.
+# Checks whether there is still a device-mapper mapping for the managed
+# volume and whether all required PVs are present.
 #
 # The conversation below explains the original rationale for taking a
 # roundabout approach.
@@ -801,8 +805,6 @@ get_dm_dependencies() {
 #
 # This is AllBad but there isn't a better way that I'm aware of yet.
 lvm_status() {
-	[ -n "$LV" ] && status_vol="$VG/$LV" || status_vol="$VG"
-
 	# First ensure that there are dm mappings for the managed
 	# VG or LV.
 	dev_list=$(get_dm_devs "$VG" "$LV")
@@ -843,9 +845,7 @@ lvm_status() {
 		for dev in $dev_list; do
 			if get_dm_dependencies "$dev" \
 					| grep "," >/dev/null 2>&1; then
-				msg="One or more PVs missing for $status_vol"
-				ocf_log err "$msg"
-
+				ocf_log err "One or more PVs missing for $VOL"
 				return $OCF_ERR_GENERIC
 			fi
 		done
@@ -903,14 +903,12 @@ lvm_start() {
 		fi
 	fi
 
-	[ -z ${LV} ] && vol=${VG} || vol=${VG}/${LV}
-
 	if lvm_status ; then
-		ocf_log info "${vol}: is already active."
+		ocf_log info "$VOL: is already active."
 		return $OCF_SUCCESS
 	fi
 
-	ocf_log info "Activating ${vol}"
+	ocf_log info "Activating $VOL"
 
 	case ${VG_access_mode_num} in
 	1)
@@ -933,30 +931,28 @@ lvm_start() {
 
 	rc=$?
 	if lvm_status ; then
-		ocf_log info "${vol}: activated successfully."
+		ocf_log info "$VOL: activated successfully."
 		return $OCF_SUCCESS
 	else
-		ocf_exit_reason "${vol}: failed to activate."
+		ocf_exit_reason "$VOL: failed to activate."
 		return $rc
 	fi
 }
 
 # Deactivate LVM volume(s)
 lvm_stop() {
-	[ -z ${LV} ] && vol=${VG} || vol=${VG}/${LV}
-
 	lvm_status
 
 	case "$?" in
 	"$OCF_NOT_RUNNING")
-		ocf_log info "$vol: has already been deactivated."
+		ocf_log info "$VOL: has already been deactivated."
 		return $OCF_SUCCESS
 		;;
 	"$OCF_SUCCESS")
-		ocf_log info "Deactivating $vol."
+		ocf_log info "Deactivating $VOL."
 		;;
 	*)
-		msg="$vol: Unexpected error. Deactivating any remaining volumes"
+		msg="$VOL: Unexpected error. Deactivating any remaining volumes"
 		msg="$msg and removing device-mapper entries."
 		ocf_log warn "$msg"
 		;;
@@ -985,7 +981,7 @@ lvm_stop() {
 
 	case "$?" in
 	"$OCF_NOT_RUNNING")
-		ocf_log info "$vol: deactivated successfully"
+		ocf_log info "$VOL: deactivated successfully"
 		return $OCF_SUCCESS
 		;;
 	"$OCF_ERR_GENERIC")
@@ -996,10 +992,10 @@ lvm_stop() {
 		done
 
 		if [ -z $(get_dm_devs "$VG" "$LV") ]; then
-			ocf_log info "$vol: Removed dm entries successfully."
+			ocf_log info "$VOL: Removed dm entries successfully."
 			return $OCF_SUCCESS
 		else
-			ocf_log err "$vol: Failed to remove dm entries."
+			ocf_log err "$VOL: Failed to remove dm entries."
 			return $OCF_ERR_GENERIC
 		fi
 		;;

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -855,9 +855,13 @@ lvm_status() {
 		0)
 			;;
 		10)
-			# if there are many lv in vg dir, pick the first name
-			# TODO: Use the LV if it's configured.
-			dm_name="/dev/${VG}/$(ls -1 /dev/${VG} | head -n 1)"
+			if [ -n "$LV" ]; then
+				dm_name="/dev/$VG/$LV"
+			else
+				# If there are many LVs in the VG dir,
+				# pick the first one.
+				dm_name="/dev/$VG/$(ls -1 /dev/$VG | head -n 1)"
+			fi
 
 			# Read from the device to check whether it's alive.
 			if ! dd if="$1" of=/dev/null bs=4096 count=1 \
@@ -872,6 +876,7 @@ lvm_status() {
 			;;
 		esac
 	fi
+
 	return $OCF_SUCCESS
 }
 

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -330,8 +330,7 @@ config_verify()
 	real=$(lvmconfig "$name" | cut -d'=' -f2)
 	if [ "$real" != "$expect" ]; then
 		ocf_exit_reason "config item $name: expect=$expect but real=$real"
-		exit $OCF_ERR_CONFIGURED
-
+		exit $OCF_ERR_ARGS
 	fi
 
 	return $OCF_SUCCESS
@@ -363,12 +362,12 @@ lvmlockd_check()
 		fi
 
 		ocf_exit_reason "lvmlockd daemon is not running!"
-		exit $OCF_ERR_CONFIGURED
+		exit $OCF_ERR_ARGS
 	fi
 
 	if pgrep clvmd >/dev/null 2>&1 ; then
 		ocf_exit_reason "clvmd daemon is running unexpectedly."
-		exit $OCF_ERR_CONFIGURED
+		exit $OCF_ERR_ARGS
 	fi
 
 	return $OCF_SUCCESS
@@ -399,17 +398,17 @@ clvmd_check()
 	# Good: clvmd is running, and lvmlockd is not running
 	if ! pgrep clvmd >/dev/null 2>&1 ; then
 		ocf_exit_reason "clvmd daemon is not running!"
-		exit $OCF_ERR_CONFIGURED
+		exit $OCF_ERR_ARGS
 	fi
 
 	if pgrep lvmetad >/dev/null 2>&1 ; then
 		ocf_exit_reason "Please stop lvmetad daemon when clvmd is running."
-		exit $OCF_ERR_CONFIGURED
+		exit $OCF_ERR_ARGS
 	fi
 
 	if pgrep lvmlockd >/dev/null 2>&1 ; then
 		ocf_exit_reason "lvmlockd daemon is running unexpectedly."
-		exit $OCF_ERR_CONFIGURED
+		exit $OCF_ERR_ARGS
 	fi
 
 	return $OCF_SUCCESS
@@ -421,12 +420,12 @@ systemid_check()
 	source=$(lvmconfig 'global/system_id_source' 2>/dev/null | cut -d"=" -f2)
 	if [ "$source" = "" ] || [ "$source" = "none" ]; then
 		ocf_exit_reason "system_id_source in lvm.conf is not set correctly!"
-		exit $OCF_ERR_CONFIGURED
+		exit $OCF_ERR_ARGS
 	fi
 
 	if [ -z ${SYSTEM_ID} ]; then
 		ocf_exit_reason "local/system_id is not set!"
-		exit $OCF_ERR_CONFIGURED
+		exit $OCF_ERR_ARGS
 	fi
 
 	return $OCF_SUCCESS
@@ -438,18 +437,18 @@ tagging_check()
 	# The volume_list must be initialized to something in order to
 	# guarantee our tag will be filtered on startup
 	if ! lvm dumpconfig activation/volume_list; then
-		ocf_log err  "LVM: Improper setup detected"
+		ocf_log err "LVM: Improper setup detected"
 		ocf_exit_reason "The volume_list filter must be initialized in lvm.conf for exclusive activation without clvmd"
-		exit $OCF_ERR_CONFIGURED
+		exit $OCF_ERR_ARGS
 	fi
 
 	# Our tag must _NOT_ be in the volume_list.  This agent
 	# overrides the volume_list during activation using the
 	# special tag reserved for cluster activation
 	if lvm dumpconfig activation/volume_list | grep -e "\"@${OUR_TAG}\"" -e "\"${VG}\"";  then
-		ocf_log err "LVM:  Improper setup detected"
+		ocf_log err "LVM: Improper setup detected"
 		ocf_exit_reason "The volume_list in lvm.conf must not contain the cluster tag, \"${OUR_TAG}\", or volume group, ${VG}"
-		exit $OCF_ERR_CONFIGURED
+		exit $OCF_ERR_ARGS
 	fi
 
 	return $OCF_SUCCESS
@@ -460,13 +459,13 @@ read_parameters()
 	if [ -z "$VG" ]
 	then
 		ocf_exit_reason "You must identify the volume group name!"
-		exit $OCF_ERR_ARGS
+		exit $OCF_ERR_CONFIGURED
 	fi
 
 	if [ "$LV_activation_mode" != "shared" ] && [ "$LV_activation_mode" != "exclusive" ]
 	then
 		ocf_exit_reason "Invalid value for activation_mode: $LV_activation_mode"
-		exit $OCF_ERR_ARGS
+		exit $OCF_ERR_CONFIGURED
 	fi
 
 	# Convert VG_access_mode from string to index
@@ -516,8 +515,10 @@ lvm_validate() {
 			exit $OCF_NOT_RUNNING
 		fi
 
+		# Could be a transient error (e.g., iSCSI connection
+		# issue) so use OCF_ERR_GENERIC
 		ocf_exit_reason "Volume group[${VG}] doesn't exist, or not visible on this node!"
-		exit $OCF_ERR_CONFIGURED
+		exit $OCF_ERR_GENERIC
 	fi
 
 	# Inconsistency might be due to missing physical volumes, which doesn't
@@ -546,23 +547,23 @@ lvm_validate() {
 	mode=$?
 	if [ $VG_access_mode_num -ne 4 ] && [ $mode -ne $VG_access_mode_num ]; then
 		ocf_exit_reason "The specified vg_access_mode doesn't match the lock_type on VG metadata!"
-		exit $OCF_ERR_ARGS
+		exit $OCF_ERR_CONFIGURED
 	fi
 
-	# Nothing to do if the VG has no logical volume
+	# Nothing to do if the VG has no logical volume.
 	lv_count=$(vgs --foreign -o lv_count --noheadings ${VG} 2>/dev/null)
 	if [ $lv_count -lt 1 ]; then
 		ocf_exit_reason "Volume group [$VG] doesn't contain any logical volume!"
 		exit $OCF_ERR_CONFIGURED
 	fi
 
-	# Check if the given $LV is in the $VG
+	# Check if the given LV is in the VG.
 	if [ -n "$LV" ]; then
-		OUT=$(lvs --foreign --noheadings ${VG}/${LV} 2>&1)
+		output=$(lvs --foreign --noheadings ${VG}/${LV} 2>&1)
 		if [ $? -ne 0 ]; then
-			ocf_log err "lvs: ${OUT}"
+			ocf_log err "lvs: ${output}"
 			ocf_exit_reason "LV ($LV) is not in the given VG ($VG)."
-			exit $OCF_ERR_ARGS
+			exit $OCF_ERR_CONFIGURED
 		fi
 	fi
 
@@ -577,7 +578,6 @@ lvm_validate() {
 	3)
 		systemid_check
 		;;
-
 	4)
 		tagging_check
 		;;
@@ -792,10 +792,9 @@ lvm_status() {
 			dd if=${dm_name} of=/dev/null bs=1 count=1 >/dev/null \
 				2>&1
 			if [ $? -ne 0 ]; then
-				return $OCF_NOT_RUNNING
-			else
-				return $OCF_SUCCESS
+				return $OCF_ERR_GENERIC
 			fi
+			return $OCF_SUCCESS
 			;;
 		*)
 			ocf_exit_reason "unsupported monitor level $OCF_CHECK_LEVEL"

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -505,6 +505,9 @@ lvm_validate() {
 
 	if ! vgs --foreign ${VG} >/dev/null 2>&1 ; then
 		# stop action exits successfully if the VG cannot be accessed...
+		#
+		# TODO: Consider removing. validate() is not called for
+		# stop and probe operations.
 		if [ $__OCF_ACTION = "stop" ]; then
 			ocf_log warn "VG [${VG}] cannot be accessed, stop action exits successfully."
 			exit $OCF_SUCCESS
@@ -526,6 +529,8 @@ lvm_validate() {
 	# we should let start try to handle it, or if no PVs are listed as
 	# "unknown device" then another node may have marked a device missing
 	# where we have access to all of them and can start without issue.
+	#
+	# TODO: Consider not checking entire VG when an LV is specified.
 	case $(vgs -o attr --noheadings $VG | tr -d ' ') in
 	???p??*)
 		if ! ocf_is_true "$OCF_RESKEY_partial_activation" ; then
@@ -738,8 +743,35 @@ tagging_deactivate() {
 	return $OCF_SUCCESS
 }
 
-# TODO:
-# How can we accurately check if LVs in the given VG are all active?
+# Gets a list of device-mapper devices corresponding to $VG/$LV or to
+# $VG.
+get_dm_devs() {
+	vg_arg="$1"
+	lv_arg="$2"
+
+	if [ -n "$lv_arg" ]; then
+		select="vg_name=$vg_arg && lv_name=$lv_arg"
+	else
+		select="vg_name=$vg_arg"
+	fi
+
+	dmsetup info --noheadings --noflush -c -S "$select" \
+		| grep -v "^No devices found" \
+		| cut -d":" -f1
+}
+
+# Gets a list of device-mapper dependencies corresponding to the
+# specified device.
+get_dm_dependencies() {
+	dmsetup deps -o blkdevname "$1" \
+		| sed -e "s/.*:[[:blank:]]*\(.*\)/\1/" -e "s/, /,/g" \
+		| tr " " "\n"
+}
+
+# Checks status of managed LV or VG.
+#
+# The conversation below explains the original rationale for taking a
+# roundabout approach.
 #
 # David:
 # If we wanted to check that all LVs in the VG are active, then we would
@@ -769,23 +801,62 @@ tagging_deactivate() {
 #
 # This is AllBad but there isn't a better way that I'm aware of yet.
 lvm_status() {
-	if [ -n "${LV}" ]; then
-		# dmsetup ls? It cannot accept device name. It's
-		# too heavy to list all DM devices.
-		dm_count=$(dmsetup info --noheadings --noflush -c -S "vg_name=${VG} && lv_name=${LV}" | grep -c -v '^No devices found')
-	else
-		dm_count=$(dmsetup info --noheadings --noflush -c -S "vg_name=${VG}" | grep -c -v '^No devices found')
-	fi
+	[ -n "$LV" ] && status_vol="$VG/$LV" || status_vol="$VG"
 
-	if [ $dm_count -eq 0 ]; then
-		return $OCF_NOT_RUNNING
-	fi
+	# First ensure that there are dm mappings for the managed
+	# VG or LV.
+	dev_list=$(get_dm_devs "$VG" "$LV")
+	[ -z "$dev_list" ] && return $OCF_NOT_RUNNING
 
-	case "$OCF_CHECK_LEVEL" in
+	# Make sure the PVs are still present. If a PV is (or was)
+	# missing, `dmsetup deps -o blkdevname` lists it as
+	# ($major, $minor) instead of using a "real" device name like
+	# "sdd". So we check for commas.
+	# We still have to recover the resource even if the PV has
+	# returned, since I/O to it continues to fail.
+	#
+	# The start operation validates PVs before lvm_status() is
+	# called and thus should not need special handling.
+	#
+	# A probe should return success or hit the OCF_NOT_RUNNING above
+	# unless there's a more serious issue.
+	#
+	# TODO: Decide how this should behave when
+	# partial_activation=true, since missing PVs are allowed. What
+	# PVs do we need to check, if any? What are the criteria for
+	# success or failure? This is tricky because we can end up in a
+	# state where the VG is totally missing in `vgs` output but the
+	# monitor passes, or a state where the monitor fails due to
+	# missing dm deps even though the VG exists in `vgs` output.
+	#
+	if ! ocf_is_true "$OCF_RESKEY_partial_activation"; then
+		# All PVs must be present for $VG/$LV if lvname is set,
+		# or for $VG otherwise.
+		#
+		# TODO: Should we require all PVs to be present for the
+		# entire VG, even if lvname is set? That would better
+		# match the current partial_activation (PA) logic: if PA
+		# is unset, then all PVs in the VG must be present at
+		# resource start/validation time. On the other hand,
+		# there's no clear reason to require PVs that the LV
+		# doesn't need. PA logic may need adjustment.
+		for dev in $dev_list; do
+			if get_dm_dependencies "$dev" \
+					| grep "," >/dev/null 2>&1; then
+				msg="One or more PVs missing for $status_vol"
+				ocf_log err "$msg"
+
+				return $OCF_ERR_GENERIC
+			fi
+		done
+
+		# Found all PVs. Test I/O if appropriate.
+		case "$OCF_CHECK_LEVEL" in
 		0)
 			;;
 		10)
 			# if there are many lv in vg dir, pick the first name
+			# TODO: Use the LV if it's configured.
 			dm_name="/dev/${VG}/$(ls -1 /dev/${VG} | head -n 1)"
 
 			# Read from the device to check whether it's alive.
@@ -793,18 +864,20 @@ lvm_status() {
 					iflag=direct >/dev/null 2>&1; then
 				return $OCF_ERR_GENERIC
 			fi
-			return $OCF_SUCCESS
 			;;
 		*)
-			ocf_exit_reason "unsupported monitor level $OCF_CHECK_LEVEL"
+			msg="unsupported monitor level $OCF_CHECK_LEVEL"
+			ocf_exit_reason "$msg"
 			return $OCF_ERR_CONFIGURED
 			;;
-	esac
+		esac
+	fi
+	return $OCF_SUCCESS
 }
 
 lvm_start() {
-        if systemd_is_running ; then
-        	# Create drop-in to deactivate VG before stopping
+	if systemd_is_running ; then
+		# Create drop-in to deactivate VG before stopping
 		# storage services during shutdown/reboot.
 		after=$(systemctl show resource-agents-deps.target.d \
 			--property=After | cut -d'=' -f2)
@@ -823,14 +896,15 @@ lvm_start() {
 		if ! systemctl is-active blk-availability.service ; then
 			systemctl start blk-availability.service
 		fi
-        fi
+	fi
+
+	[ -z ${LV} ] && vol=${VG} || vol=${VG}/${LV}
 
 	if lvm_status ; then
 		ocf_log info "${vol}: is already active."
 		return $OCF_SUCCESS
 	fi
 
-	[ -z ${LV} ] && vol=${VG} || vol=${VG}/${LV}
 	ocf_log info "Activating ${vol}"
 
 	case ${VG_access_mode_num} in
@@ -866,12 +940,22 @@ lvm_start() {
 lvm_stop() {
 	[ -z ${LV} ] && vol=${VG} || vol=${VG}/${LV}
 
-	if ! lvm_status ; then
-		ocf_log info "${vol}: has already been deactivated."
-		return $OCF_SUCCESS
-	fi
+	lvm_status
 
-	ocf_log info "Deactivating ${vol}"
+	case "$?" in
+	"$OCF_NOT_RUNNING")
+		ocf_log info "$vol: has already been deactivated."
+		return $OCF_SUCCESS
+		;;
+	"$OCF_SUCCESS")
+		ocf_log info "Deactivating $vol."
+		;;
+	*)
+		msg="$vol: Unexpected error. Deactivating any remaining volumes"
+		msg="$msg and removing device-mapper entries."
+		ocf_log warn "$msg"
+		;;
+	esac
 
 	case ${VG_access_mode_num} in
 	1)
@@ -892,13 +976,36 @@ lvm_stop() {
 		;;
 	esac
 
-	if ! lvm_status ; then
-		ocf_log info "${vol}: deactivated successfully."
+	lvm_status
+
+	case "$?" in
+	"$OCF_NOT_RUNNING")
+		ocf_log info "$vol: deactivated successfully"
 		return $OCF_SUCCESS
-	else
-		ocf_exit_reason "${vol}: failed to deactivate."
+		;;
+	"$OCF_ERR_GENERIC")
+		# PVs are missing.
+		# There may still be device mappings present.
+		for i in $(get_dm_devs "$VG" "$LV"); do
+			dmsetup remove $i
+		done
+
+		if [ -z $(get_dm_devs "$VG" "$LV") ]; then
+			ocf_log info "$vol: Removed dm entries successfully."
+			return $OCF_SUCCESS
+		else
+			ocf_log err "$vol: Failed to remove dm entries."
+			return $OCF_ERR_GENERIC
+		fi
+		;;
+	"$OCF_SUCCESS")
+		ocf_exit_reason "$vol: failed to deactivate."
 		return $OCF_ERR_GENERIC
-	fi
+		;;
+	esac
+
+	ocf_exit_reason "Unexpected error in lvm_stop function."
+	return $OCF_ERR_GENERIC
 }
 
 #

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -120,14 +120,19 @@ because some DLM lockspaces might be in use and cannot be closed automatically.
 
 Option: OCF_CHECK_LEVEL
 
-The standard monitor operation of depth 0 checks if the VG or LV is valid.
-If you want deeper tests, set OCF_CHECK_LEVEL to 10:
+The standard monitor operation (OCF_CHECK_LEVEL=0) checks if the VG or
+LV has a device-mapper mapping. For deeper tests, set OCF_CHECK_LEVEL as
+follows for the monitor operation:
 
   10: read first 4096 bytes of one random managed LV (raw read)
+  20: read first 4096 bytes of all managed LVs (raw read)
 
-If there are many underlying devs in VG, it will only read one of the devs.
-This is not perfect solution for detecting underlying devices livable.
-e.g. iscsi SAN IO timeout will return EIO, and it makes monitor failed.
+It is obviously not safe to perform a write test.
+
+These tests can provide additional confirmation that the underlying
+devices are live/accessible. This is not a perfect solution. For
+example, if an LV is spread across multiple PVs, the test may only read
+from one PV.
 
 </longdesc>
 <shortdesc lang="en">This agent activates/deactivates logical volumes.</shortdesc>
@@ -863,10 +868,14 @@ lvm_status() {
 		done
 
 		# Found all PVs. Test I/O if appropriate.
+		# TODO: Consider reading directly from PVs as determined
+		# by `dmsetup deps -o blkdevname`, instead of from
+		# dev/$VG/$LV files.
 		case "$OCF_CHECK_LEVEL" in
 		0)
 			;;
 		10)
+			# Attempts to read from one managed LV.
 			if [ -n "$LV" ]; then
 				dev="/dev/$VG/$LV"
 			else
@@ -880,6 +889,26 @@ lvm_status() {
 				ocf_log err "$VOL: Read failed."
 				return $OCF_ERR_GENERIC
 			fi
+			;;
+		20)
+			# Attempts to read from all managed LVs.
+			# When lvname is specified, this behaves the
+			# same as OCF_CHECK_LEVEL=10.
+			if [ -n "$LV" ]; then
+				dev_list="/dev/$VG/$LV"
+			else
+				dev_list=$(find "/dev/$VG" -maxdepth 1 \
+					-mindepth 1)
+			fi
+
+			for dev in $dev_list; do
+				if ! dd if="$1" of=/dev/null bs=4096 count=1 \
+						iflag=direct >/dev/null 2>&1;
+				then
+					ocf_log err "$VOL: Read failed."
+					return $OCF_ERR_GENERIC
+				fi
+			done
 			;;
 		*)
 			msg="unsupported monitor level $OCF_CHECK_LEVEL"


### PR DESCRIPTION
`OCF_ERR_ARGS` and `OCF_ERR_CONFIGURED` were used in inappropriate ways that
led to starts being disallowed in the wrong places. This pull attempts 
to correct that.

`lvm_status()` and `lvm_stop()` weren't designed to handle missing VGs or 
LVs appropriately, due to the decision not to use any LVM commands in 
the monitor operation. This pull attempts to address that by using 
`dmsetup deps` to indirectly check the status of the PVs behind a VG. 
It's unlikely to be a perfect solution, but neither is the current 
approach. This aims to be an improvement.

We could use some additional testing for the scenario where a VG contains
(or the cluster manages) more specialized types of logical volumes (e.g.,
thin pools and mirrors).


Finally, the `lvm_validate()` function performs a partial activation check 
for a VG, but there's no special handling in case the resource specifies 
an LV. This adds some logic to handle LV partial activation.


I strongly suggest that we have one or more LVM/device-mapper experts 
review this. My biggest concern is there may be edge cases in which my 
approach (running `dmsetup deps`, checking for devices with commas, and 
assuming that this means a missing PV because it's only a major/minor 
number) is not valid.


Resolves: RHBZ#1905820
Resolves: RHBZ#1902433
Resolves: RHBZ#1905825

Signed-off-by: Reid Wahl <nrwahl@protonmail.com>