### PR TITLE
pgsql: make wal receiver check compatible with PostgreSQL >= 11

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -934,7 +934,7 @@ pgsql_wal_receiver_status() {
     local pgsql_real_monitor_status=$1
 
     PID=`head -n 1 $PIDFILE`
-    receiver_parent_pids=`ps -ef | tr -s " " | grep "[w]al receiver process" | cut -d " " -f 3`
+    receiver_parent_pids=`ps -ef | tr -s " " | grep "[w]al\s*receiver" | cut -d " " -f 3`
 
     if echo "$receiver_parent_pids" | grep -q -w "$PID" ; then
         attrd_updater -n "$PGSQL_WAL_RECEIVER_STATUS_ATTR" -v "normal" -q


### PR DESCRIPTION
In PostgreSQL 11 and later the wal receiver process is named
"walreceiver" instead of "wal receiver process". This change makes the
check for a running wal receiver process compatible with both variants.

Fixes #1551