### PR TITLE
LVM-activate: to avoid auto activation race condition when the active node restart

### DIFF
--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -595,8 +595,10 @@ lvm_validate() {
 }
 
 # To activate LV(s) with different "activation mode" parameters
+# Note: the LV "ACTIVATION_SKIP" flag is practical useful in the cluster
+# to avoid the auto-activation race condition.
 do_activate() {
-	do_activate_opt=$1
+	do_activate_opt="--ignoreactivationskip $1"
 
 	if ocf_is_true "$OCF_RESKEY_partial_activation" ; then
 		do_activate_opt="${do_activate_opt} --partial"

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -606,11 +606,25 @@ do_activate() {
 
 	# Only activate the specific LV if it's given
 	if [ -n "$LV" ]; then
+		lv_attr_10=$(lvs --foreign --noheadings -olv_attr $VG/$LV|awk '{print $1}'|cut -c10)
+		if ! [ "$lv_attr_10" = "k" ]; then
+			ocf_log info "set ACTIVATION_SKIP flag to /dev/$VG/$LV"
+			ocf_run lvchange -ky $VG/$LV || return $OCF_ERR_GENERIC
+		fi
+
 		ocf_run lvchange $do_activate_opt ${VG}/${LV}
 		if [ $? -ne $OCF_SUCCESS ]; then
 			return $OCF_ERR_GENERIC
 		fi
 	else
+		lv_attr_10=$(lvs --foreign --noheadings -olv_attr $VG 2>/dev/null|awk '{print $1}'|cut -c10)
+		count_k=$(echo $lv_attr_10|sed 's/[^k]//g' | awk '{ print length }')
+		lv_count=$(vgs --foreign -o lv_count --noheadings ${VG} 2>/dev/null|awk '{print $1}')
+		if ! [ "$count_k" = "$lv_count" ]; then
+			ocf_log info "set ACTIVATION_SKIP flag to all LV(s) under /dev/$VG/"
+			ocf_run lvchange -ky $VG || return $OCF_ERR_GENERIC
+		fi
+
 		ocf_run lvchange $do_activate_opt ${VG}
 		if [ $? -ne $OCF_SUCCESS ]; then
 			return $OCF_ERR_GENERIC


### PR DESCRIPTION
Happy New Year of 2021, everyone! 

In this PR, the first commit is a MUST have to support ACTIVATION_SKIP flag of LV.

The second commit is highly suggested for the better user experience. It 
enforces ACTIVATION_SKIP flag to LV whenever RA LVM-activate
starts or stops.

The reason behind that is, for HA_LVM, auto-activation must be disabled
to avoid the race condition among multiple nodes. In the practice, often
this get forgotten and brings the unexpected trouble shooting effort. To
avoid that, the lv_attr 10th bit(ACTIVATION SKIP flag) is very handy to
simplify the user experience than to manage the out-of-band
auto_activation_volume_list option in lvm.conf. [1]

This involves two lvchange options:
-k,--setactivationskip y|n
-K,--ignoreactivationskip

ACTIVATION_SKIP flag of lv metadata is added since v2_02_99 and is
safe for the metadata compatibility.

[1] https://www.redhat.com/archives/linux-lvm/2020-November/msg00005.html
