### PR TITLE
gcp-vpc-move-route, gcp-vpc-move-vip: Parameterize project ID

### DIFF
--- a/heartbeat/gcp-vpc-move-route.in
+++ b/heartbeat/gcp-vpc-move-route.in
@@ -106,6 +106,16 @@ Name of the VPC network
 <content type="string" default="default" />
 </parameter>
 
+<parameter name="project">
+<longdesc lang="en">
+Project ID of the instance. It can be useful to set this attribute if
+the instance is in a shared service project. Otherwise, the agent should
+be able to determine the project ID automatically.
+</longdesc>
+<shortdesc lang="en">Project ID</shortdesc>
+<content type="string" default="default" />
+</parameter>
+
 <parameter name="interface">
 <longdesc lang="en">
 Name of the network interface
@@ -215,7 +225,8 @@ def validate(ctx):
   try:
     ctx.instance = get_metadata('instance/name')
     ctx.zone = get_metadata('instance/zone').split('/')[-1]
-    ctx.project = get_metadata('project/project-id')
+    ctx.project = os.environ.get(
+        'OCF_RESKEY_project', get_metadata('project/project-id'))
   except Exception as e:
     logger.error(
         'Instance information not found. Is this a GCE instance ?: %s', str(e))

--- a/heartbeat/gcp-vpc-move-vip.in
+++ b/heartbeat/gcp-vpc-move-vip.in
@@ -75,6 +75,16 @@ METADATA = \
       <shortdesc lang="en">Host list</shortdesc>
       <content type="string" default="" />
     </parameter>
+    <parameter name="project" unique="0" required="0">
+      <longdesc lang="en">
+        Project ID of the instance. It can be useful to set this
+        attribute if the instance is in a shared service project.
+        Otherwise, the agent should be able to determine the project ID
+        automatically.
+      </longdesc>
+      <shortdesc lang="en">Project ID</shortdesc>
+      <content type="string" default="default" />
+    </parameter>
     <parameter name="stackdriver_logging" unique="0" required="0">
       <longdesc lang="en">If enabled (set to true), IP failover logs will be posted to stackdriver logging</longdesc>
       <shortdesc lang="en">Stackdriver-logging support</shortdesc>
@@ -267,7 +277,8 @@ def get_instances_list(project, exclude):
 def gcp_alias_start(alias):
   my_aliases = get_localhost_aliases()
   my_zone = get_metadata('instance/zone').split('/')[-1]
-  project = get_metadata('project/project-id')
+  project = os.environ.get(
+        'OCF_RESKEY_project', get_metadata('project/project-id'))
 
   if alias in my_aliases:
     # TODO: Do we need to check alias_range_name?
@@ -315,7 +326,8 @@ def gcp_alias_start(alias):
 def gcp_alias_stop(alias):
   my_aliases = get_localhost_aliases()
   my_zone = get_metadata('instance/zone').split('/')[-1]
-  project = get_metadata('project/project-id')
+  project = os.environ.get(
+        'OCF_RESKEY_project', get_metadata('project/project-id'))
 
   if alias in my_aliases:
     logger.info('Removing %s from %s' % (alias, THIS_VM))


### PR DESCRIPTION
The current route and vip resources fail if the instance is in a shared service project.

Resolves: RHBZ#1913932
Resolves: RHBZ#1913936

Signed-off-by: Reid Wahl <nrwahl@protonmail.com>