### PR TITLE
The anything RA getpid() function can fail to return the pid in the O…

### DIFF
--- a/heartbeat/anything
+++ b/heartbeat/anything
@@ -110,7 +110,7 @@ anything_start() {
 		fi
 		ocf_log debug "Starting $process: $cmd"
 		# Execute the command as created above
-		eval $cmd > $pidfile
+		eval $cmd | tail -n 1 > $pidfile
 		if anything_status
 		then
 			ocf_log debug "$process: $cmd started successfully, calling monitor"


### PR DESCRIPTION
…CF_RESKEY_pidfile if the root user has commands in .profile which prints numeric characters.

To demonstrate, /root/.profile contains:
echo -e '911 WARNING: YOU ARE SUPERUSER!'
Write only the pid into the pidfile.