### PR TITLE
nfsserver: Error-check unbind_tree

### DIFF
--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -465,9 +465,20 @@ unbind_tree ()
 		sleep 1
 		i=$((i + 1))
 	done
-	if is_bound /var/lib/nfs; then
-		umount /var/lib/nfs
+
+	if mount | grep -q " on $OCF_RESKEY_rpcpipefs_dir "; then
+		ocf_log err "Failed to unmount $OCF_RESKEY_rpcpipefs_dir"
+		return $OCF_ERR_GENERIC
 	fi
+
+	if is_bound /var/lib/nfs; then
+		if ! umount /var/lib/nfs; then
+			ocf_log err "Failed to unmount /var/lib/nfs"
+			return $OCF_ERR_GENERIC
+		fi
+	fi
+
+	return $OCF_SUCCESS
 }
 
 binary_status()
@@ -836,8 +847,14 @@ nfsserver_stop ()
 	esac
 
 	unbind_tree
-	ocf_log info "NFS server stopped"
-	return 0
+	rc=$?
+	if [ "$rc" -ne $OCF_SUCCESS ]; then
+		ocf_exit_reason "Failed to unmount a bind mount"
+	else
+		ocf_log info "NFS server stopped"
+	fi
+
+	return $rc
 }
 
 nfsserver_validate ()


### PR DESCRIPTION
Fail to stop if unmounting rpcpipefs_dir or /var/lib/nfs fails.

After:
```
# pcs resource debug-stop nfs-daemon
Operation stop for nfs-daemon (ocf:heartbeat:nfsserver) returned: 'error' (1)
Feb 02 17:58:58 INFO: Stopping NFS server ...
Feb 02 17:58:58 INFO: Stop: threads
Feb 02 17:58:58 INFO: Stop: rpc-statd
Feb 02 17:58:58 INFO: Stop: nfs-idmapd
Feb 02 17:58:58 INFO: Stop: nfs-mountd
Feb 02 17:58:58 INFO: Stop: nfsdcld
Feb 02 17:58:58 INFO: Stop: rpc-gssd
Feb 02 17:58:58 INFO: Stop: umount (1/10 attempts)
umount: /var/lib/nfs: target is busy.
Feb 02 17:58:59 ERROR: Failed to unmount /var/lib/nfs
ocf-exit-reason:Failed to unmount a bind mount
```

Resolves: RHBZ#1924363

Signed-off-by: Reid Wahl <nrwahl@protonmail.com>