### PR TITLE
docker-compose: Bugfix handle ymls correctly

### DIFF
--- a/heartbeat/docker-compose
+++ b/heartbeat/docker-compose
@@ -139,7 +139,7 @@ docker_compose_status()
 	# use docker-compose ps if YML found, otherwise try docker ps and kill containers
 	if [ -r "$DIR/$YML" ]; then
 
-		DKPS=$(cd $DIR; $COMMAND ps -q)
+		DKPS=$(cd $DIR; $COMMAND -f $YML ps -q)
 		STAT_MSG=$(docker ps --no-trunc | grep -E $(echo "$DKPS" | tr '\n' '|') | expand)
 		LNWTH=$(echo "$STAT_MSG" | head -n1 | wc -c)
 		STATEPOS=$(echo "$STAT_MSG" | head -n1 | egrep -o 'STATUS.*$' | wc -c)
@@ -190,7 +190,7 @@ docker_compose_start()
 	[ $retVal -eq $OCF_SUCCESS ] && exit $OCF_SUCCESS
 
 	cd $DIR
-	$COMMAND up -d || {
+	$COMMAND -f $YML up -d || {
 		ocf_log err "Error. docker-compose returned error $?."
 		exit $OCF_ERR_GENERIC
 	}
@@ -205,7 +205,7 @@ docker_compose_stop()
 	if [ -r "$DIR/$YML" ]; then
 		docker_compose_validate_all
 		cd $DIR
-		$COMMAND down || {
+		$COMMAND -f $YML down || {
 			ocf_log err "Error on shutting down docker service, try docker kill..."
 			RUN_KILL=true
 		}


### PR DESCRIPTION
The current docker-compose resource only handles docker-compose.yml file. It doesn't matter what you set when creating resource in pacemaker with **ymlfile** parameter.

Fixed missing **-f $YML** when doing start/stop/monitor actions.