### PR TITLE
AWS agents: dont partially match similar IPs during monitor-action and dont spam log files when getting token

### DIFF
--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -215,7 +215,7 @@ ec2ip_validate() {
 		return $OCF_ERR_CONFIGURED
 	fi
 
-	TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+	TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 	EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id -H "X-aws-ec2-metadata-token: $TOKEN")
 
 	if [ -z "${EC2_INSTANCE_ID}" ]; then

--- a/heartbeat/aws-vpc-route53.in
+++ b/heartbeat/aws-vpc-route53.in
@@ -347,7 +347,7 @@ r53_monitor() {
 _get_ip() {
 	case $OCF_RESKEY_ip in
 		local|public)
-			TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+			TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 			IPADDRESS=$(curl -s http://169.254.169.254/latest/meta-data/${OCF_RESKEY_ip}-ipv4 -H "X-aws-ec2-metadata-token: $TOKEN");;
 		*.*.*.*)
 			IPADDRESS="${OCF_RESKEY_ip}";;

--- a/heartbeat/awseip
+++ b/heartbeat/awseip
@@ -244,7 +244,7 @@ AWSCLI="${OCF_RESKEY_awscli}"
 ELASTIC_IP="${OCF_RESKEY_elastic_ip}"
 ALLOCATION_ID="${OCF_RESKEY_allocation_id}"
 PRIVATE_IP_ADDRESS="${OCF_RESKEY_private_ip_address}"
-TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id -H "X-aws-ec2-metadata-token: $TOKEN")
 
 case $__OCF_ACTION in

--- a/heartbeat/awsvip
+++ b/heartbeat/awsvip
@@ -172,7 +172,7 @@ awsvip_monitor() {
             --instance-id "${INSTANCE_ID}" \
             --query 'Reservations[].Instances[].NetworkInterfaces[].PrivateIpAddresses[].PrivateIpAddress[]' \
             --output text | \
-            grep -q "${SECONDARY_PRIVATE_IP}"
+            grep -qE "(^|\s)${SECONDARY_PRIVATE_IP}(\s|$)"
     RET=$?
 
     if [ $RET -ne 0 ]; then

--- a/heartbeat/awsvip
+++ b/heartbeat/awsvip
@@ -206,7 +206,7 @@ esac
 
 AWSCLI="${OCF_RESKEY_awscli}"
 SECONDARY_PRIVATE_IP="${OCF_RESKEY_secondary_private_ip}"
-TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id -H "X-aws-ec2-metadata-token: $TOKEN")
 MAC_ADDRESS=$(curl -s http://169.254.169.254/latest/meta-data/mac -H "X-aws-ec2-metadata-token: $TOKEN")
 NETWORK_ID=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC_ADDRESS}/interface-id -H "X-aws-ec2-metadata-token: $TOKEN")


### PR DESCRIPTION
Fixes https://github.com/ClusterLabs/resource-agents/issues/1624 and https://github.com/ClusterLabs/resource-agents/issues/1625.