### PR TITLE
openstack-info: Use OSInfo_validate in start action and remove superfluous final exit.

### DIFF
--- a/heartbeat/openstack-info
+++ b/heartbeat/openstack-info
@@ -246,7 +246,8 @@ case $__OCF_ACTION in
 meta-data)	meta_data
 		exit $OCF_SUCCESS
 		;;
-start)		OSInfo_start
+start)		OSInfo_validate
+		OSInfo_start
 		;;
 stop)		OSInfo_stop
 		;;
@@ -261,5 +262,3 @@ usage|help)	OSInfo_usage
 		exit $OCF_ERR_UNIMPLEMENTED
 		;;
 esac
-
-exit $?


### PR DESCRIPTION
- Use OSInfo_validate in start action and remove superfluous final exit.