### PR TITLE
openstack-info: Use OSInfo_validate in start action.

### DIFF
--- a/heartbeat/openstack-info.in
+++ b/heartbeat/openstack-info.in
@@ -278,7 +278,6 @@ stop)		OSInfo_stop
 monitor)	OSInfo_monitor
 		;;
 validate-all)	OSInfo_validate
-		exit $?
 		;;
 usage|help)	OSInfo_usage
 		exit $OCF_SUCCESS
@@ -287,3 +286,5 @@ usage|help)	OSInfo_usage
 		exit $OCF_ERR_UNIMPLEMENTED
 		;;
 esac
+
+exit $?

--- a/heartbeat/openstack-info.in
+++ b/heartbeat/openstack-info.in
@@ -270,7 +270,7 @@ case $__OCF_ACTION in
 meta-data)	meta_data
 		exit $OCF_SUCCESS
 		;;
-start)		OSInfo_validate
+start)		OSInfo_validate || exit $?
 		OSInfo_start
 		;;
 stop)		OSInfo_stop
@@ -278,6 +278,7 @@ stop)		OSInfo_stop
 monitor)	OSInfo_monitor
 		;;
 validate-all)	OSInfo_validate
+		exit $?
 		;;
 usage|help)	OSInfo_usage
 		exit $OCF_SUCCESS

--- a/heartbeat/openstack-info.in
+++ b/heartbeat/openstack-info.in
@@ -270,7 +270,8 @@ case $__OCF_ACTION in
 meta-data)	meta_data
 		exit $OCF_SUCCESS
 		;;
-start)		OSInfo_start
+start)		OSInfo_validate
+		OSInfo_start
 		;;
 stop)		OSInfo_stop
 		;;
@@ -285,5 +286,3 @@ usage|help)	OSInfo_usage
 		exit $OCF_ERR_UNIMPLEMENTED
 		;;
 esac
-
-exit $?


### PR DESCRIPTION
- Use OSInfo_validate in start action and remove superfluous final exit.