### PR TITLE
azure-events: update api_version

### DIFF
--- a/heartbeat/azure-events.in
+++ b/heartbeat/azure-events.in
@@ -70,7 +70,7 @@ class azHelper:
 	metadata_host = "http://169.254.169.254/metadata"
 	instance_api  = "instance"
 	events_api    = "scheduledevents"
-	api_version   = "2017-08-01"
+	api_version   = "2019-08-01"
 
 	@staticmethod
 	def _sendMetadataRequest(endpoint, postData=None):


### PR DESCRIPTION
According to Microsoft's document, current version of API is "2019-08-01"
https://docs.microsoft.com/en-us/azure/virtual-machines/linux/scheduled-events