### PR TITLE
Added code to set the host_memory value for Utilization in the VirtualDomain RA

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -25,6 +25,7 @@ OCF_RESKEY_migration_network_suffix_default=""
 OCF_RESKEY_force_stop_default=0
 OCF_RESKEY_monitor_scripts_default=""
 OCF_RESKEY_autoset_utilization_cpu_default="true"
+OCF_RESKEY_autoset_utilization_host_memory_default="true"
 OCF_RESKEY_autoset_utilization_hv_memory_default="true"
 OCF_RESKEY_migrateport_default=$(( 49152 + $(ocf_maybe_random) % 64 ))
 OCF_RESKEY_CRM_meta_timeout_default=90000
@@ -45,6 +46,7 @@ OCF_RESKEY_start_resources_default="false"
 : ${OCF_RESKEY_force_stop=${OCF_RESKEY_force_stop_default}}
 : ${OCF_RESKEY_monitor_scripts=${OCF_RESKEY_monitor_scripts_default}}
 : ${OCF_RESKEY_autoset_utilization_cpu=${OCF_RESKEY_autoset_utilization_cpu_default}}
+: ${OCF_RESKEY_autoset_utilization_host_memory=${OCF_RESKEY_autoset_utilization_host_memory_default}}
 : ${OCF_RESKEY_autoset_utilization_hv_memory=${OCF_RESKEY_autoset_utilization_hv_memory_default}}
 : ${OCF_RESKEY_migrateport=${OCF_RESKEY_migrateport_default}}
 : ${OCF_RESKEY_CRM_meta_timeout=${OCF_RESKEY_CRM_meta_timeout_default}}
@@ -226,6 +228,15 @@ into the CPU utilization of the resource when the monitor is executed.
 <content type="boolean" default="${OCF_RESKEY_autoset_utilization_cpu_default}" />
 </parameter>
 
+<parameter name="autoset_utilization_host_memory" unique="0" required="0">
+<longdesc lang="en">
+If set true, the agent will detect the number of *Max memory* from virsh, and put it
+into the host_memory utilization of the resource when the monitor is executed.
+</longdesc>
+<shortdesc lang="en">Enable auto-setting the host_memory utilization of the resource</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_autoset_utilization_host_memory_default}" />
+</parameter>
+
 <parameter name="autoset_utilization_hv_memory" unique="0" required="0">
 <longdesc lang="en">
 If set true, the agent will detect the number of *Max memory* from virsh, and put it
@@ -259,7 +270,7 @@ migration.
 
 <parameter name="save_config_on_stop" unique="0" required="0">
 <longdesc lang="en">
-Changes to a running VM's config are normally lost on stop. 
+Changes to a running VM's config are normally lost on stop.
 This parameter instructs the RA to save the configuration back to the xml file provided in the "config" parameter.
 </longdesc>
 <shortdesc lang="en">Save running VM's config back to its config file</shortdesc>
@@ -385,6 +396,10 @@ update_utilization() {
 	   dom_cpu=$(LANG=C virsh $VIRSH_OPTIONS dominfo ${DOMAIN_NAME} 2>/dev/null | awk '/CPU\(s\)/{print $2}')
 	   test -n "$dom_cpu" && set_util_attr cpu $dom_cpu
 	fi
+	if ocf_is_true "$OCF_RESKEY_autoset_utilization_host_memory"; then
+	   dom_mem=$(LANG=C virsh $VIRSH_OPTIONS dominfo ${DOMAIN_NAME} 2>/dev/null | awk '/Max memory/{printf("%d", $3/1024)}')
+	   test -n "$dom_mem" && set_util_attr host_memory "$dom_mem"
+	fi
 	if ocf_is_true "$OCF_RESKEY_autoset_utilization_hv_memory"; then
 	   dom_mem=$(LANG=C virsh $VIRSH_OPTIONS dominfo ${DOMAIN_NAME} 2>/dev/null | awk '/Max memory/{printf("%d", $3/1024)}')
 	   test -n "$dom_mem" && set_util_attr hv_memory "$dom_mem"
@@ -461,7 +476,7 @@ pid_status()
 				if [ $? -eq 0 ]; then
 					rc=$OCF_SUCCESS
 				fi
-			else 
+			else
 				ocf_log $loglevel "Unable to determine emulator for $DOMAIN_NAME"
 			fi
 			;;

--- a/tools/ocft/VirtualDomain
+++ b/tools/ocft/VirtualDomain
@@ -1,5 +1,5 @@
 # VirtualDomain
-# by dejan@suse.de on 
+# by dejan@suse.de on
 # Tue Jul  8 12:48:03 CEST 2014
 
 CONFIG
@@ -16,6 +16,7 @@ CASE-BLOCK required_args
 	Env OCF_RESKEY_config=$OCFT_config
 
 CASE-BLOCK unset_utilization
+	Env OCF_RESKEY_autoset_utilization_host_memory=false
 	Env OCF_RESKEY_autoset_utilization_hv_memory=false
 	Env OCF_RESKEY_autoset_utilization_cpu=false
 


### PR DESCRIPTION
This is required to make it compatible with the values set by the NodeUtilization resource agent when running on a kvm based Hypervisor (RHEL, CentOS)

On CentOS, 
NodeUtilization can set available host_memory and cpu for the node but sets hv_memory to 0
VirtualDomain only sets cpu and hv_memory usage which means these two RAs cannot be used together.