### PR TITLE
crypt: initial pass on supporting clevis-unlocked volumes

### DIFF
--- a/heartbeat/crypt
+++ b/heartbeat/crypt
@@ -227,6 +227,19 @@ crypt_validate_all() {
 	return $OCF_SUCCESS
 }
 
+
+detect_clevis() {
+	if ! have_binary clevis; then
+		use_clevis="false" #We can't use clevis, if we don't have it installed
+	elif ! ocf_is_true "$use_clevis"; then #if not already specified by user to use clevis
+		#Try to detect whether clevis is available
+		if clevis luks list -d $encrypted_dev | grep -q '^[[:digit:]]\+:'; then
+			use_clevis="true" #if grep finds output that matches, we have clevis, therefore use it
+		fi
+	fi
+}
+
+
 get_users_pids() {
 	ocf_log debug "running lsof to list \"$crypt_dev\" users..."
 	ocf_run -warn 'lsof $crypt_dev_path | tail -n +2 | awk "{print $2}" | sort -u'
@@ -266,7 +279,8 @@ crypt_stop_one() {
 #
 crypt_start() {
 	local rc
-
+	detect_clevis
+	
 	if ocf_is_true "$use_clevis"; then
 		clevis luks unlock -d $encrypted_dev -n $crypt_dev
 		rc=$?

--- a/heartbeat/crypt
+++ b/heartbeat/crypt
@@ -37,12 +37,14 @@ OCF_RESKEY_crypt_dev_default=""
 OCF_RESKEY_key_file_default=""
 OCF_RESKEY_crypt_type_default=""
 OCF_RESKEY_force_stop_default="false"
+OCF_RESKEY_use_clevis_default="false"
 
 : ${OCF_RESKEY_encrypted_dev=${OCF_RESKEY_encrypted_dev_default}}
 : ${OCF_RESKEY_crypt_dev=${OCF_RESKEY_crypt_dev_default}}
 : ${OCF_RESKEY_key_file=${OCF_RESKEY_key_file_default}}
 : ${OCF_RESKEY_crypt_type=${OCF_RESKEY_crypt_type_default}}
 : ${OCF_RESKEY_force_stop=${OCF_RESKEY_force_stop_default}}
+: ${OCF_RESKEY_use_clevis=${OCF_RESKEY_use_clevis_default}}
 
 #######################################################################
 
@@ -122,6 +124,16 @@ will fail and the node will be fenced.
 <content type="boolean" default="${OCF_RESKEY_force_stop_default}" />
 </parameter>
 
+<parameter name="use_clevis" unique="0" required="0">
+<longdesc lang="en">
+If LUKS volume is set up to unlock automatically using Tang/Clevis,
+then set this parameter to "true".  This has the side-effect of ignoring
+the "key_file", "disable_locks" and "crypt_type" parameters.
+</longdesc>
+<shortdesc lang="en">use clevis tools to unlock volume</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_use_clevis_default}" />
+</parameter>
+
 </parameters>
 
 <actions>
@@ -153,10 +165,15 @@ crypt_dev_path="/dev/mapper/$crypt_dev"
 key_file="${OCF_RESKEY_key_file}"
 crypt_type="${OCF_RESKEY_crypt_type}"
 force_stop="${OCF_RESKEY_force_stop}"
+use_clevis="${OCF_RESKEY_use_clevis}"
 
 crypt_validate_all() {
 	if ! have_binary cryptsetup; then
 		ocf_exit_reason "Please install cryptsetup(8)"
+		return $OCF_ERR_INSTALLED
+	fi
+	if ocf_is_true "$use_clevis" && ! have_binary clevis ; then
+		ocf_exit_reason "Please install clevis tools"
 		return $OCF_ERR_INSTALLED
 	fi
 	if [ -z "$encrypted_dev" ]; then
@@ -250,8 +267,13 @@ crypt_stop_one() {
 crypt_start() {
 	local rc
 
-	cryptsetup open $encrypted_dev $crypt_dev --type $crypt_type $disable_locks --key-file=$key_file
-	rc=$?
+	if ocf_is_true "$use_clevis"; then
+		clevis luks unlock -d $encrypted_dev -n $crypt_dev
+		rc=$?
+	else
+ 		cryptsetup open $encrypted_dev $crypt_dev --type $crypt_type $disable_locks --key-file=$key_file
+ 		rc=$?
+	fi
 	if [ $rc -eq 0 ];then
 		crypt_monitor
 		rc=$?


### PR DESCRIPTION
This is an initial pass at supporting LUKS volumes, that are being non-interactively unlocked by Clevis/Tang, also known as "Network Bound Disk Encryption" or "NBDE".  Initial testing seems to work as expected, but I'll certainly do more thorough testing over the next week or so, just to be sure.

I would prefer a better way to have it realize that it needs to use clevis, than the "use_clevis" flag, but I haven't figured that out yet.  If you've got suggestions, that would be great.  I'll keep working on that, as well.

If it would be helpful, I can outline the steps necessary to set up a Clevis-unlocked volume.  These are the steps I was using to add my crypted LUKSv2 volume to pacemaker:

    pcs resource create einstein-crypt ocf:heartbeat:crypt encrypted_dev="8e6ef2f2-b06b-46da-969e-3583aaa8360d" crypt_dev="crypteinstein" crypt_type="luks2" use_clevis="true" key_file=/dev/null --group einstein --after einstein-lvm


Here are a few references for Clevis/Tang, as well:

*[Introduction to Tang and Clevis by Fraser Tweedale](https://frasertweedale.github.io/blog-redhat/posts/2016-02-11-tang-tls.html)
*[Clevis and Tang: securing your secrets at rest - Fraser Tweedale (LCA 2020)](https://youtu.be/Dk6ZuydQt9I)
**[Slides](https://speakerdeck.com/frasertweedale/clevis-and-tang-securing-your-secrets-at-rest)
*[An easier way to manage disk decryption at boot with Red Hat Enterprise Linux 7.5 using NBDE](https://www.redhat.com/en/blog/easier-way-manage-disk-decryption-boot-red-hat-enterprise-linux-75-using-nbde)
*[How to set up Network-Bound Disk Encryption with multiple LUKS devices (Clevis+Tang unlocking)](https://access.redhat.com/articles/4500491)
*[Automatic data encryption and decryption with Clevis and Tang](https://www.admin-magazine.com/Archive/2018/43/Automatic-data-encryption-and-decryption-with-Clevis-and-Tang)
*[Tang software development](https://github.com/latchset/tang)
*[Clevis Software Development](https://github.com/latchset/clevis)