### PR TITLE
findif: popen requires pclose and not fclose

### DIFF
--- a/tools/findif.c
+++ b/tools/findif.c
@@ -292,7 +292,7 @@ SearchUsingRouteCmd (char *address, struct in_addr *in
 			}
 		}
 	}
-	fclose(routefd);
+	pclose(routefd);
 
 	/*
 	 * Check to see if mask isn't available.  It may not be


### PR DESCRIPTION
Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>