### PR TITLE
mdraid: bugs fix & code enhancement

### DIFF
--- a/heartbeat/mdraid
+++ b/heartbeat/mdraid
@@ -67,6 +67,14 @@ It uses mdadm(8) to start, stop, and monitor the MD devices.
 Supported clustered (i.e., clonable active-active) arrays are linear,
 raid0, and clustered raid1/raid10 (i.e. mdadm(8) created with
 --bitmap=clustered).
+
+Option: OCF_CHECK_LEVEL
+
+The standard monitor operation of depth 0 checks if the cluster array
+is valid. If you want more action, set OCF_CHECK_LEVEL greate than 0:
+
+  >0: Attempting recovery sequence to re-add devices on MD RAID array
+
 </longdesc>
 <shortdesc lang="en">Manages Linux software RAID (MD) devices on shared
 storage</shortdesc>
@@ -273,7 +281,7 @@ array_is_clustered_raid() {
 	do
 		for s in $strs
 		do
-			$MDADM -E $d 2>&1 | grep -i "$s" >/dev/null 2>&1
+			$MDADM -E $d 2>&1 | $EGREP -i "$s" >/dev/null 2>&1
 			if [ $? -eq 0 ]; then
 				c=$((c+1))
 				break
@@ -286,7 +294,7 @@ array_is_clustered_raid() {
 
 # Check for all clustered types (linear, raid0, and clustered raid1/raid10).
 is_clustered_raid() {
-	array_is_clustered_raid || array_is_linear_or_raid0
+	array_is_clustered_raid || ! array_is_linear_or_raid0
 }
 
 md_assemble() {


### PR DESCRIPTION
1> add option description for OCF_CHECK_LEVEL

2> is_clustered_raid() logic is wrong

shell function return 0 means success, non 0 means fail.
but in non-function code, 0 means false, 1 means true.

let's see function is_clustered_raid()

```
is_clustered_raid() {
    array_is_clustered_raid || array_is_linear_or_raid0
}
```

assumption there is a clustered array /dev/md0, in is_clustered_raid(),
array_is_clustered_raid() will return 0, because this array is clustered.
array_is_linear_or_raid0() will return 1, because this array is not linear or raid0.
so the code logic become: "0 || 1", the result of the '||' is true.
the is_clustered_raid() will return true, it means this function return fail.
at this time, the result is wrong: clustered array becomes non-clustered.

3>  use 'egrep' in array_is_clustered_raid()

"mdadm -E <dev>" will show "Cluster name : ".
The "cluster.name" is a regex string, so egrep is correct tool.

Signed-off-by: Heming Zhao <heming.zhao@suse.com>