### PR TITLE
Remove a bashism in ocf-shellfuncs.in

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -924,13 +924,11 @@ ocf_unique_rundir()
 # OCF_TRACE_FILE is set to a path.
 #
 ocf_bash_has_xtracefd() {
-	echo "$SHELL" | grep bash > /dev/null &&
-			[ ${BASH_VERSINFO[0]} -ge 4 ]
+	[ -n "$BASH_VERSION" ] && [ ${BASH_VERSINFO[0]} -ge 4 ]
 }
 # for backwards compatibility
 ocf_is_bash4() {
 	ocf_bash_has_xtracefd
-	return $?
 }
 ocf_trace_redirect_to_file() {
 	local dest=$1


### PR DESCRIPTION
The function `ocf_bash_has_xtracefd` and its alias `ocf_is_bash4` break non bash shells (in my case dash) because of how bash version is tested. Due to local environment idiosyncrasies it is perfectly possible to have dash running a script while the variable `SHELL` has a value of `/bin/bash`. It works fine for most of the code except the tracing functionality.

What I propose is to fix the version detection mechanism by first checking against the usually not exported variable `BASH_VERSION`.