### PR TITLE
iSCSILogicalUnit: lio-t: support setting product_id

### DIFF
--- a/heartbeat/iSCSILogicalUnit.in
+++ b/heartbeat/iSCSILogicalUnit.in
@@ -447,6 +447,10 @@ iSCSILogicalUnit_start() {
 		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
 			echo ${OCF_RESKEY_scsi_sn} > /sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/wwn/vpd_unit_serial
 		fi
+		if [ -n "${OCF_RESKEY_product_id}" ]; then
+			echo "${OCF_RESKEY_product_id}" > /sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/wwn/product_id
+		fi
+
 		ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns create /backstores/${OCF_RESKEY_liot_bstype}/${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC
 
 		if $(ip a | grep -q inet6); then
@@ -694,7 +698,7 @@ iSCSILogicalUnit_validate() {
 		unsupported_params="scsi_id vendor_id product_id tgt_bstype tgt_bsoflags tgt_bsopts tgt_device_type emulate_tpu emulate_3pc emulate_caw liot_bstype"
 		;;
 	lio-t)
-		unsupported_params="scsi_id vendor_id product_id tgt_bstype tgt_bsoflags tgt_bsopts tgt_device_type lio_iblock"
+		unsupported_params="scsi_id vendor_id tgt_bstype tgt_bsoflags tgt_bsopts tgt_device_type lio_iblock"
 		;;
 	esac
 


### PR DESCRIPTION
Since Linux kernel commit [0322913cab79](https://github.com/torvalds/linux/commit/0322913cab79e47282fa98910559cbf6f3660b52) ("scsi: target: Add device
product id and revision configfs attributes"), setting a SCSI product id
via the product_id configfs attribute is supported in the target
subsystem.

Thus, forward the value of the product_id resource agent parameter there
and remove it from the list of unsupported parameters for lio-t.

---

This is a relatively modern feature, only being present in mainline kernels >5.1. Though it seems like at least RedHat have backported this to their 4.18.0 series (RHEL8):

```
[root@test1 ~]# uname -r
4.18.0-305.7.1.el8_4.x86_64
[root@test1 ~]# cat /sys/kernel/config/target/core/iblock_0/lu1_target1/wwn/product_id
Custom Product
```