### PR TITLE
VirtualDomain: drop prefix xenmigr from migrate uri

### DIFF
--- a/heartbeat/VirtualDomain
+++ b/heartbeat/VirtualDomain
@@ -854,7 +854,7 @@ mk_migrateuri() {
 				echo "tcp:${migrate_target}:${OCF_RESKEY_migrateport}"
 				;;
 			xen)
-				echo "xenmigr://${migrate_target}"
+				echo "${migrate_target}"
 				;;
 			*)
 				ocf_log warn "$DOMAIN_NAME: Migration via dedicated network currently not supported for ${hypervisor}."


### PR DESCRIPTION
Since 'xenmigr' scheme was no longer supported by libvirt, we
should remove the prefix 'xenmigr' from migrate uri.
Otherwise, there will be an error when migrate VM.