### PR TITLE
Filesystem: do not call partprobe for bind mounts

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -493,6 +493,9 @@ trigger_udev_rules_if_needed()
 		-L*|--label*)
 			tmp="/dev/disk/by-label/$tmp" 
 			;;
+		*)
+			# bind mount?
+			return ;;
 		esac
 		[ ! -b "$tmp" ] && refresh_flag="yes"
 	fi


### PR DESCRIPTION
Calling partprobe is a heavy fallback.

(And should not be used at all, IMO, as it masks somebody elses problem, really.
If you need it, you _actively_ created something on one cluster node that did
not exist before, so you actively added this to the cluster configurtion just
now as well, so you can actively call partprobe yourself after creating the
thing and before adding it to the cluster config, right?)

Anyways. Now partprobe is called for each and every bind mount since
a9fb8077 Filesystem: add trigger_udev_rules_if_need() for -U, -L, or /dev/xxx device

I suggest to only do it if we know it is supposed to be a block device.