### PR TITLE
MySQL: add Support for local SSL connection

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -239,6 +239,15 @@ The port on which the Master MySQL instance is listening.
 <content type="string" default="${OCF_RESKEY_replication_port_default}" />
 </parameter>
 
+<parameter name="replication_require_ssl" unique="0" required="0">
+<longdesc lang="en">
+Enables SSL connection to local MySQL service for replication user.
+i.e. if REQUIRE SSL for replication user in MySQL set, this should be set to "true".
+</longdesc>
+<shortdesc lang="en">MySQL replication require ssl</shortdesc>
+<content type="string" default="${OCF_RESKEY_replication_require_ssl_default}" />
+</parameter>
+
 <parameter name="replication_master_ssl_ca" unique="0" required="0">
 <longdesc lang="en">
 The SSL CA certificate to be used for replication over SSL.

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -96,8 +96,7 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 # Convenience variables
 
 MYSQL=$OCF_RESKEY_client_binary
-if [ "$OCF_RESKEY_replication_require_ssl" = "true" ]
-then
+if ocf_is_true "$OCF_RESKEY_replication_require_ssl"; then
   MYSQL_OPTIONS_LOCAL_SSL_OPTIONS="--ssl"
 fi
 MYSQL_OPTIONS_LOCAL="-S $OCF_RESKEY_socket"

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -98,6 +98,8 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 MYSQL=$OCF_RESKEY_client_binary
 if ocf_is_true "$OCF_RESKEY_replication_require_ssl"; then
   MYSQL_OPTIONS_LOCAL_SSL_OPTIONS="--ssl"
+else
+  MYSQL_OPTIONS_LOCAL_SSL_OPTIONS=""
 fi
 MYSQL_OPTIONS_LOCAL="-S $OCF_RESKEY_socket"
 MYSQL_OPTIONS_REPL="$MYSQL_OPTIONS_LOCAL_SSL_OPTIONS $MYSQL_OPTIONS_LOCAL --user=$OCF_RESKEY_replication_user --password=$OCF_RESKEY_replication_passwd"

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -225,7 +225,7 @@ mysql_common_prepare_dirs()
     # Regardless of whether we just created the directory or it
     # already existed, check whether it is writable by the configured
     # user
-    for dir in $pid_dir $socket_dir; do
+    for dir in $pid_dir $socket_dir $OCF_RESKEY_datadir; do
         if ! $SU -s /bin/sh - $OCF_RESKEY_user -c "test -w $dir"; then
             ocf_exit_reason "Directory $dir is not writable by $OCF_RESKEY_user"
             exit $OCF_ERR_PERM;
@@ -245,8 +245,8 @@ mysql_common_start()
     --datadir=$OCF_RESKEY_datadir \
     --log-error=$OCF_RESKEY_log \
     $OCF_RESKEY_additional_parameters \
-    $mysql_extra_params >/dev/null 2>&1 &
-    pid=$!"
+    $mysql_extra_params >/dev/null 2>&1" &
+    pid=$!
 
     # Spin waiting for the server to come up.
     # Let the CRM/LRM time us out if required.


### PR DESCRIPTION
Added support for local MySQL connection over SSL.

**Use Case:**

once a `REQUIRE  SSL` for MySQL user is set, the cluster will not be able to manage its MySQL resource any further.

A good practice is to require SSL for all MySQL external users. A replication user is one of those.  A replication by itself may _(and should)_ be configured over SSL, however the enforcement for replication user to use SSL may be occasionally not set.
This patch allows to configure MySQL resource to use SSL _(by default is set to `false` - so no running setups will be affected)_.

**_How To:_**
1. Enforce SSL for MySQL user _(MySQL v5.7+)_:
```
mysql> show variables like 'version';
+---------------+-----------------------------+
| Variable_name | Value                       |
+---------------+-----------------------------+
| version       | 5.7.35-0ubuntu0.18.04.1-log |
+---------------+-----------------------------+
1 row in set (0,00 sec)

mysql> SHOW CREATE USER 'repl'@'%';
+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| CREATE USER for repl@%                                                                                                                                           |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| CREATE USER 'repl'@'%' IDENTIFIED WITH 'mysql_native_password' AS 'XXXXXXXXXX' REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0,00 sec)

mysql> ALTER USER 'repl'@'%' REQUIRE SSL;
Query OK, 0 rows affected (0,02 sec)

mysql> FLUSH PRIVILEGES;
Query OK, 0 rows affected (0,02 sec)

mysql> SHOW CREATE USER 'repl'@'%';
+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| CREATE USER for repl@%                                                                                                                                           |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| CREATE USER 'repl'@'%' IDENTIFIED WITH 'mysql_native_password' AS 'XXXXXXXXXX' REQUIRE SSL PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0,00 sec)
```
2. Update clusters `mysql` resource to use SSL:
```
pcs resource update mysql replication_require_ssl="true"
```