### PR TITLE
[tools] fix build on opensuse 15.3

### DIFF
--- a/tools/tickle_tcp.c
+++ b/tools/tickle_tcp.c
@@ -41,7 +41,6 @@ typedef union {
 	struct sockaddr_in6 ip6;
 } sock_addr;
 
-uint32_t uint16_checksum(uint16_t *data, size_t n);
 void set_nonblocking(int fd);
 void set_close_on_exec(int fd);
 static int parse_ipv4(const char *s, unsigned port, struct sockaddr_in *sin);
@@ -53,7 +52,7 @@ int send_tickle_ack(const sock_addr *dst,
 		    uint32_t seq, uint32_t ack, int rst);
 static void usage(void);
 
-uint32_t uint16_checksum(uint16_t *data, size_t n)
+static uint32_t uint16_checksum(uint16_t *data, size_t n)
 {
 	uint32_t sum=0;
 	while (n >= 2) {
@@ -91,6 +90,8 @@ static uint16_t tcp_checksum6(uint16_t *data, size_t n, struct ip6_hdr *ip6)
 	uint32_t phdr[2];
 	uint32_t sum = 0;
 	uint16_t sum2;
+
+	memset(phdr, 0, sizeof(phdr));
 
 	sum += uint16_checksum((uint16_t *)(void *)&ip6->ip6_src, 16);
 	sum += uint16_checksum((uint16_t *)(void *)&ip6->ip6_dst, 16);


### PR DESCRIPTION
tickle_tcp.c: In function ‘send_tickle_ack’:
tickle_tcp.c:60:26: error: ‘phdr’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   sum += (uint32_t)ntohs(*data);
                          ^
tickle_tcp.c:60:26: error: ‘*((void *)&phdr+2)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
tickle_tcp.c:60:26: error: ‘*((void *)&phdr+4)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
tickle_tcp.c:60:26: error: ‘*((void *)&phdr+6)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
cc1: all warnings being treated as errors
gmake[3]: *** [Makefile:697: tickle_tcp.o] Error 1

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>