### PR TITLE
iSCSILogicalUnit: do not use lio_iblock with lio-t

### DIFF
--- a/heartbeat/iSCSILogicalUnit.in
+++ b/heartbeat/iSCSILogicalUnit.in
@@ -428,7 +428,7 @@ iSCSILogicalUnit_start() {
 	lio-t)
 		ocf_take_lock $TARGETLOCKFILE
 		ocf_release_lock_on_exit $TARGETLOCKFILE
-		iblock_attrib_path="/sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/attrib"
+		iblock_attrib_path="/sys/kernel/config/target/core/iblock_*/${OCF_RESOURCE_INSTANCE}/attrib"
 		# For lio, we first have to create a target device, then
 		# add it to the Target Portal Group as an LU.
 		# Handle differently 'block', 'fileio' and 'pscsi'
@@ -445,10 +445,10 @@ iSCSILogicalUnit_start() {
 			ocf_run targetcli /backstores/${OCF_RESKEY_liot_bstype} create ${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_path} || exit $OCF_ERR_GENERIC
 		fi
 		if [ -n "${OCF_RESKEY_scsi_sn}" ]; then
-			echo ${OCF_RESKEY_scsi_sn} > /sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/wwn/vpd_unit_serial
+			echo ${OCF_RESKEY_scsi_sn} > /sys/kernel/config/target/core/iblock_*/${OCF_RESOURCE_INSTANCE}/wwn/vpd_unit_serial
 		fi
 		if [ -n "${OCF_RESKEY_product_id}" ]; then
-			echo "${OCF_RESKEY_product_id}" > /sys/kernel/config/target/core/iblock_${OCF_RESKEY_lio_iblock}/${OCF_RESOURCE_INSTANCE}/wwn/product_id
+			echo "${OCF_RESKEY_product_id}" > /sys/kernel/config/target/core/iblock_*/${OCF_RESOURCE_INSTANCE}/wwn/product_id
 		fi
 
 		ocf_run targetcli /iscsi/${OCF_RESKEY_target_iqn}/tpg1/luns create /backstores/${OCF_RESKEY_liot_bstype}/${OCF_RESOURCE_INSTANCE} ${OCF_RESKEY_lun} || exit $OCF_ERR_GENERIC


### PR DESCRIPTION
For lio-t, we cannot use the lio_iblock parameter, as targetcli just
ignores the index we give it and generates its own.

A logical consequence is that we cannot use the contents of the
lio_iblock parameter to access the iblock_* directories in the configfs,
since we do not know the values of the indices generated by targetcli.

This leads to an effect where systems with only one target work just
fine: targetcli always picks "0" as the first index, and the default
value of lio_iblock is "0". But when multiple targets are involved, one
of them will get the index "1" whereas we are still trying to access
"iblock_0", leading to errors of the form:

/sys/kernel/config/target/core/iblock_0/lu1_target1/wwn/product_id: No such file or directory

Since we only ever want to access the target directory inside the
iblock_* directory, we can just use a glob to sufficiently describe the
path -- there should always only be one match.