### PR TITLE
rabbitmq-server-ha: Avoid forget_cluster_node without node name

### DIFF
--- a/heartbeat/rabbitmq-cluster.in
+++ b/heartbeat/rabbitmq-cluster.in
@@ -488,7 +488,11 @@ rmq_try_start() {
 
 	rmq_stop
 	rmq_wipe_data
-	rmq_forget_cluster_node_remotely "$join_list" "$local_rmq_node"
+	if [ -z "$local_rmq_node" ]; then
+		ocf_log warn "Unable to forget the cluster node because local node name cannot be detected"
+	else
+		rmq_forget_cluster_node_remotely "$join_list" "$local_rmq_node"
+	fi
 	rmq_join_existing "$join_list"
 	rc=$?
 


### PR DESCRIPTION
Currently when a rabbitmq-server resource is started,
the forget_cluster_node command is executed to ensure the node being
started is not part of the existing cluster.

This command is dependent on the local node name defined as a node
attribute but there are some situations like the examples below where
the attribute is not yet defined when the resource is started.
 - When a cluster is freshly deployed and started for the first time
 - When a cluster node is broken and replaced by a new node

This change ensures the node attribute exists to run the command,
to avoid invalid usage of the command without the target node name.