### PR TITLE
rabbitmq-server-ha: Revert "OCF RA: Do not start rabbitmq if notification of start is not…

### DIFF
--- a/heartbeat/rabbitmq-server-ha
+++ b/heartbeat/rabbitmq-server-ha
@@ -2220,6 +2220,7 @@ action_notify() {
                 ;;
             start)
                 ocf_log info "${LH} post-start begin."
+                local nodes_list="${OCF_RESKEY_CRM_meta_notify_start_uname} ${OCF_RESKEY_CRM_meta_notify_active_uname}"
                 # Do nothing, if the list of nodes being started or running reported empty
                 # Delegate recovery, if needed, to the "running out of the cluster" monitor's logic
                 if [ -z "${OCF_RESKEY_CRM_meta_notify_start_uname}" ] && [ -z "${OCF_RESKEY_CRM_meta_notify_active_uname}" ] ; then
@@ -2228,7 +2229,7 @@ action_notify() {
                   return $OCF_SUCCESS
                 fi
                 # check did this event from this host
-                my_host "${OCF_RESKEY_CRM_meta_notify_start_uname}"
+                my_host "${nodes_list}"
                 rc=$?
                 # Do nothing, if there is no master reported
                 # Delegate recovery, if needed, to the "running out of the cluster" monitor's logic


### PR DESCRIPTION
This reverts https://github.com/rabbitmq/rabbitmq-server-release/commit/2f284bf595dbbe1938a1ce3028b0299b1a75a6cc#diff-b8a3b79102e79858316f3690ea5a5f20L2185

Every time we get a start notification, all nodes should ensure
the rabbitmq app is started (even if nodes that are already active).
This is needed to mitigate a corner case described in

https://bugs.launchpad.net/fuel/+bug/1455761

This has the side effect of updating the start time for
each of these nodes, but that is fine. That could result in the master
moving to another node. That is totally fine as well, since the master
role only means the target for other nodes to join the cluster, and
has no other meanings, neither does that affect running nodes and its
state.

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>