### PR TITLE
asterisk: fix sipsak check during start-action

### DIFF
--- a/heartbeat/asterisk
+++ b/heartbeat/asterisk
@@ -307,22 +307,23 @@ asterisk_monitor() {
     #   This can also happen if sipsak is run too early after asterisk
     #   start.
    
-   #To avoid the case where the sipsak check runs before the sip starts at the start action
+    #To avoid the case where the sipsak check runs before the sip starts at the start action
+    SIPCHECK=`sipsak -s $OCF_RESKEY_monitor_sipuri`
     if [ -n "$OCF_RESKEY_monitor_sipuri" ]; then   
-        ocf_run sipsak -s "$OCF_RESKEY_monitor_sipuri"
+        ocf_run $SIPCHECK
         rc=$?
         if [ "$__OCF_ACTION" = "start" ]; then
           while [ $rc -ne 0 ]; do
             ocf_log info "Starting ast, waiting for SIP ok"
             sleep 1
-            ocf_run sipsak -s "$OCF_RESKEY_monitor_sipuri"
+            ocf_run $SIPCHECK
             rc=$?
           done
         else
-        case "$rc" in
-          1|2) return $OCF_ERR_GENERIC;;
-          3)   return $OCF_NOT_RUNNING;;
-        esac
+          case "$rc" in
+            1|2) return $OCF_ERR_GENERIC;;
+            3)   return $OCF_NOT_RUNNING;;
+          esac
         fi
     fi
 


### PR DESCRIPTION
To avoid the case where the sipsak check runs before the sip starts at the start action