### PR TITLE
ocf-shellfuncs: Parametrise the log destinarion by OCF_RESKEY_trace_dir

### DIFF
--- a/heartbeat/README
+++ b/heartbeat/README
@@ -24,7 +24,9 @@ language, use the appropriate extension.
 RA tracing
 
 RA tracing may be turned on by setting OCF_TRACE_RA. The trace
-output will be saved to OCF_TRACE_FILE, if set, or by default to
+output will be saved to OCF_TRACE_FILE, if set. If not,
+then the trace would be saved to the OCF_RESKEY_trace_dir.
+If it's also not defined, the log will be saved by default to
 
   $HA_VARLIB/trace_ra/<type>/<id>.<action>.<timestamp>
 

--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -962,7 +962,7 @@ ocf_default_trace_dest() {
 	if [ -n "$OCF_RESOURCE_TYPE" -a \
 			-n "$OCF_RESOURCE_INSTANCE" -a -n "$__OCF_ACTION" ]; then
 		local ts=`date +%F.%T`
-		__OCF_TRC_DEST=$HA_VARLIB/trace_ra/${OCF_RESOURCE_TYPE}/${OCF_RESOURCE_INSTANCE}.${__OCF_ACTION}.$ts
+		__OCF_TRC_DEST=${OCF_RESKEY_trace_dir}/${OCF_RESOURCE_TYPE}/${OCF_RESOURCE_INSTANCE}.${__OCF_ACTION}.$ts
 		__OCF_TRC_MANAGE="1"
 	fi
 }
@@ -1039,6 +1039,7 @@ ocf_attribute_target() {
 __ocf_set_defaults "$@"
 
 : ${OCF_TRACE_RA:=$OCF_RESKEY_trace_ra}
+: ${OCF_RESKEY_trace_dir:="$HA_VARLIB/trace_ra"}
 ocf_is_true "$OCF_TRACE_RA" && ocf_start_trace
 
 # pacemaker sets HA_use_logd, some others use HA_LOGD :/


### PR DESCRIPTION
The `OCF_TRACE_FILE` takes the precedence. If it's not defined,
the `OCF_RESKEY_trace_dir` is used. Otherwise the log is stored by default
in `$HA_VARLIB/trace_ra/<type>/`

This PR comes together with https://github.com/ClusterLabs/crmsh/pull/935 .  The crmsh stores the log-dir in the cib.xml. This PR uses the stored log-dir.

@gao-yan @liangxin1300 could you please have a look?