### PR TITLE
ocf-shellfuncs: quote pid in ocf_pidfile_status

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -453,19 +453,19 @@ ocf_run() {
 }
 
 ocf_pidfile_status() {
-    local pid pidfile=$1
-    if [ ! -e $pidfile ]; then
-	# Not exists
-	return 2
-    fi
-    pid=`cat $pidfile`
-    kill -0 $pid > /dev/null 2>&1
-    if [ $? = 0 ]; then
-	return 0
-    fi
+	local pid pidfile="$1"
+	if [ ! -e "$pidfile" ]; then
+		# Not exists
+		return 2
+	fi
+	pid=$(cat "$pidfile")
+	kill -0 "$pid" > /dev/null 2>&1
+	if [ $? = 0 ]; then
+		return 0
+	fi
 
-    # Stale
-    return 1
+	# Stale
+	return 1
 }
 
 # mkdir(1) based locking


### PR DESCRIPTION
Usage of pidfile variable was not quoted so it was not possible to call
ocf_pidfile_status with path containing space. Solution is to add quotes
to -e test and cat command. Also use $() syntax for cat command and
unify indentation.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>