### PR TITLE
LVM-activate:change lvm_status return value from ocf_not_running to ocf_err_generic

### DIFF
--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -790,7 +790,11 @@ lvm_status() {
 	fi
 
 	if [ $dm_count -eq 0 ]; then
-		return $OCF_ERR_GENERIC
+		if ocf_is_probe ;then
+			return $OCF_NOT_RUNNING
+		else
+			return $OCF_ERR_GENERIC
+		fi
 	fi
 
 	case "$OCF_CHECK_LEVEL" in

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -791,9 +791,9 @@ lvm_status() {
 
 	if [ $dm_count -eq 0 ]; then
 		if ocf_is_probe ;then
-			return $OCF_NOT_RUNNING
-		else
 			return $OCF_ERR_GENERIC
+		else
+			return $OCF_NOT_RUNNING
 		fi
 	fi
 

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -790,7 +790,7 @@ lvm_status() {
 	fi
 
 	if [ $dm_count -eq 0 ]; then
-		return $OCF_NOT_RUNNING
+		return $OCF_ERR_GENERIC
 	fi
 
 	case "$OCF_CHECK_LEVEL" in

--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -791,9 +791,9 @@ lvm_status() {
 
 	if [ $dm_count -eq 0 ]; then
 		if ocf_is_probe ;then
-			return $OCF_ERR_GENERIC
-		else
 			return $OCF_NOT_RUNNING
+		else
+			return $OCF_ERR_GENERIC
 		fi
 	fi
 


### PR DESCRIPTION
hi  ，I found a problem when building a cluster  , When the cluster uses LVM-activate and the on-fail=fence parameter is set, if  the vg is lost, the return value of the monitor function is ocf_not_running  that the cluster cannot trigger the fence action