### PR TITLE
ethmonitor,ovsmonitor,mariadb: check for bc binary

### DIFF
--- a/heartbeat/ethmonitor
+++ b/heartbeat/ethmonitor
@@ -545,6 +545,7 @@ if_start()
 if_validate() {
 	check_binary $IP2UTIL
 	check_binary arping
+	check_binary bc
 	if_init
 }
 

--- a/heartbeat/mariadb.in
+++ b/heartbeat/mariadb.in
@@ -988,6 +988,10 @@ mysql_notify() {
     esac
 }
 
+mysql_validate() {
+    check_binary bc
+}
+
 #######################################################################
 
 
@@ -1049,7 +1053,7 @@ case "$1" in
   promote)  mysql_promote;;
   demote)   mysql_demote;;
   notify)   mysql_notify;;
-  validate-all) exit $OCF_SUCCESS;;
+  validate-all) mysql_validate;;
 
  *)     usage
         exit $OCF_ERR_UNIMPLEMENTED;;

--- a/heartbeat/ovsmonitor
+++ b/heartbeat/ovsmonitor
@@ -437,6 +437,7 @@ if_validate() {
 	check_binary ovs-vsctl
 	check_binary ovs-appctl
 	check_binary ovs-ofctl
+	check_binary bc
 	if_init
 }
 


### PR DESCRIPTION
bc might not be installed by default on a minimal Debian system.