### PR TITLE
podman: add podman parameter error judgment

### DIFF
--- a/heartbeat/podman
+++ b/heartbeat/podman
@@ -376,6 +376,11 @@ run_new_container()
 		# with the same name, even though podman itself thinks there
 		# is no such container. If so, purge the storage layer to try
 		# to clean the corruption and try again.
+                if [ -n $(echo "$out" | grep -q "unknown*flag") ]; then
+                        ocf_exit_reason "$out"
+                        return $rc
+                fi
+
 		ocf_log warn "Internal podman error while creating new container $CONTAINER. Retrying."
 		ocf_run podman rm --storage $CONTAINER
 		ocf_run podman run $opts $image $cmd
@@ -438,6 +443,10 @@ podman_start()
 		# we already know at this point it wouldn't be running
 		remove_container
 		run_new_container "$run_opts" $OCF_RESKEY_image "$OCF_RESKEY_run_cmd"
+                if [ $? -eq 125 ]; then
+                        return $OCF_ERR_GENERIC
+                fi
+
 	fi
 	rc=$?
 

--- a/heartbeat/podman
+++ b/heartbeat/podman
@@ -376,7 +376,7 @@ run_new_container()
 		# with the same name, even though podman itself thinks there
 		# is no such container. If so, purge the storage layer to try
 		# to clean the corruption and try again.
-                if [ -n $(echo "$out" | grep -q "unknown*flag") ]; then
+                if echo "$out" | grep -q "unknown.*flag"; then
                         ocf_exit_reason "$out"
                         return $rc
                 fi

--- a/heartbeat/podman
+++ b/heartbeat/podman
@@ -376,10 +376,10 @@ run_new_container()
 		# with the same name, even though podman itself thinks there
 		# is no such container. If so, purge the storage layer to try
 		# to clean the corruption and try again.
-                if echo "$out" | grep -q "unknown.*flag"; then
-                        ocf_exit_reason "$out"
-                        return $rc
-                fi
+		if echo "$out" | grep -q "unknown.*flag"; then
+			ocf_exit_reason "$out"
+			return $rc
+		fi
 
 		ocf_log warn "Internal podman error while creating new container $CONTAINER. Retrying."
 		ocf_run podman rm --storage $CONTAINER
@@ -443,9 +443,9 @@ podman_start()
 		# we already know at this point it wouldn't be running
 		remove_container
 		run_new_container "$run_opts" $OCF_RESKEY_image "$OCF_RESKEY_run_cmd"
-                if [ $? -eq 125 ]; then
-                        return $OCF_ERR_GENERIC
-                fi
+		if [ $? -eq 125 ]; then
+			return $OCF_ERR_GENERIC
+		fi
 
 	fi
 	rc=$?


### PR DESCRIPTION
hi, I found a problem when using podman. If the parameters are incorrectly filled when creating a podman resource, podman will not return the corresponding error message as exit_reason, so some modifications have been made in podman to add podman parameter error judgment.