### PR TITLE
Make storage_mon -h exit just after printing help messages.

### DIFF
--- a/tools/storage_mon.c
+++ b/tools/storage_mon.c
@@ -28,7 +28,7 @@ static void usage(char *name, FILE *f)
 	fprintf(f, "      --timeout <n>   max time to wait for a device test to come back. in seconds (default %d)\n", DEFAULT_TIMEOUT);
 	fprintf(f, "      --inject-errors-percent <n> Generate EIO errors <n>%% of the time (for testing only)\n");
 	fprintf(f, "      --verbose        emit extra output to stdout\n");
-	fprintf(f, "      --help           print this messages\n");
+	fprintf(f, "      --help           print this messages, then exit\n");
 }
 
 /* Check one device */
@@ -178,9 +178,11 @@ int main(int argc, char *argv[])
 				break;
 			case 'h':
 				usage(argv[0], stdout);
+				exit(0);
 				break;
 			default:
 				usage(argv[0], stderr);
+				exit(-1);
 				break;
 		}
 


### PR DESCRIPTION
Previously, when -h or an invalid option was specified, storage_mon
printed the help messages, proceeded processing and then could
throw an error. This was not the behavior that, e.g., users who want
to specify -h option to see the help messages are expecting. To fix
this issue, this commit changes storage_mon so that it exits just
after printing the help messages when -h or an invalid option is
specified.