### PR TITLE
storage_mon: Use the O_DIRECT flag in open() to eliminate cache effects

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -74,6 +74,7 @@ sfex_stat_LDADD		= $(GLIBLIB) -lplumb -lplumbgpl
 findif_SOURCES		= findif.c
 
 storage_mon_SOURCES	= storage_mon.c
+storage_mon_CFLAGS	= -D_GNU_SOURCE
 
 if BUILD_TICKLE
 halib_PROGRAMS		+= tickle_tcp

--- a/tools/storage_mon.c
+++ b/tools/storage_mon.c
@@ -38,7 +38,6 @@ static int open_device(const char *device, int verbose)
 	uint64_t devsize;
 	off_t seek_spot;
 
-#if defined(__linux__) || defined(__FreeBSD__)
 	device_fd = open(device, O_RDONLY|O_DIRECT);
 	if (device_fd >= 0) {
 		return device_fd;
@@ -46,7 +45,6 @@ static int open_device(const char *device, int verbose)
 		fprintf(stderr, "Failed to open %s: %s\n", device, strerror(errno));
 		return -1;
 	}
-#endif
 
 	device_fd = open(device, O_RDONLY);
 	if (device_fd < 0) {
@@ -100,7 +98,11 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
 		exit(-1);
 	}
 
+#ifdef __FreeBSD__
+	ioctl(device_fd, DIOCGSECTORSIZE, &sec_size);
+#else
 	ioctl(device_fd, BLKSSZGET, &sec_size);
+#endif
 	if (sec_size == 0) {
 		fprintf(stderr, "Failed to stat %s: %s\n", device, strerror(errno));
 		goto error;

--- a/tools/storage_mon.c
+++ b/tools/storage_mon.c
@@ -63,7 +63,7 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
 	res = ioctl(device_fd, BLKGETSIZE64, &devsize);
 #endif
 	if (res < 0) {
-		fprintf(stderr, "Failed to stat %s: %s\n", device, strerror(errno));
+		fprintf(stderr, "Failed to get device size for %s: %s\n", device, strerror(errno));
 		goto error;
 	}
 	if (verbose) {
@@ -93,7 +93,7 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
 		res = ioctl(device_fd, BLKSSZGET, &sec_size);
 #endif
 		if (res < 0) {
-			fprintf(stderr, "Failed to stat %s: %s\n", device, strerror(errno));
+			fprintf(stderr, "Failed to get block device sector size for %s: %s\n", device, strerror(errno));
 			goto error;
 		}
 


### PR DESCRIPTION
Use of O_DIRECT in open() eliminates the possibility of false negatives resulting from buffer cache reads.

please refer to https://lists.clusterlabs.org/pipermail/users/2022-August/030459.html for background.