### PR TITLE
storage-mon: daemonize storage_mon to deal with I/O hangs

### DIFF
--- a/heartbeat/storage-mon.in
+++ b/heartbeat/storage-mon.in
@@ -49,19 +49,20 @@
 
 #
 STORAGEMON=$HA_BIN/storage_mon
-ATTRDUP=/usr/sbin/attrd_updater
+PIDFILE=${HA_VARRUN}/storage-mon-${OCF_RESOURCE_INSTANCE}.pid
+ATTRNAME="#health-${OCF_RESOURCE_INSTANCE}"
 
 OCF_RESKEY_CRM_meta_interval_default="0"
 OCF_RESKEY_io_timeout_default="10"
+OCF_RESKEY_check_interval_default="30"
 OCF_RESKEY_inject_errors_default=""
-OCF_RESKEY_state_file_default="${HA_RSCTMP%%/}/storage-mon-${OCF_RESOURCE_INSTANCE}.state"
 
 # Explicitly list all environment variables used, to make static analysis happy
 : ${OCF_RESKEY_CRM_meta_interval:=${OCF_RESKEY_CRM_meta_interval_default}}
 : ${OCF_RESKEY_drives:=""}
 : ${OCF_RESKEY_io_timeout:=${OCF_RESKEY_io_timeout_default}}
+: ${OCF_RESKEY_check_interval:=${OCF_RESKEY_check_interval_default}}
 : ${OCF_RESKEY_inject_errors:=${OCF_RESKEY_inject_errors_default}}
-: ${OCF_RESKEY_state_file:=${OCF_RESKEY_state_file_default}}
 
 #######################################################################
 
@@ -82,14 +83,6 @@ devices per instance.
 
 <parameters>
 
-<parameter name="state_file" unique="1">
-<longdesc lang="en">
-Location to store the resource state in.
-</longdesc>
-<shortdesc lang="en">State file</shortdesc>
-<content type="string" default="${OCF_RESKEY_state_file_default}" />
-</parameter>
-
 <parameter name="drives" unique="1" required="1">
 <longdesc lang="en">
 The drive(s) to check as a SPACE separated list. Enter the full path to the device, e.g. "/dev/sda".
@@ -106,6 +99,14 @@ Specify disk I/O timeout in seconds. Minimum 1, recommended 10 (default).
 <content type="integer" default="${OCF_RESKEY_io_timeout_default}" />
 </parameter>
 
+<parameter name="check_interval" unique="0">
+<longdesc lang="en">
+Specify interval between I/O checks in seconds.
+</longdesc>
+<shortdesc lang="en">I/O check interval</shortdesc>
+<content type="integer" default="${OCF_RESKEY_check_interval_default}" />
+</parameter>
+
 <parameter name="inject_errors" unique="0">
 <longdesc lang="en">
 Used only for testing! Specify % of I/O errors to simulate drives failures.
@@ -119,7 +120,7 @@ Used only for testing! Specify % of I/O errors to simulate drives failures.
 <actions>
 <action name="start"        timeout="10s" />
 <action name="stop"         timeout="120s" />
-<action name="monitor"      timeout="120s" interval="30s" start-delay="0s" />
+<action name="monitor"      timeout="10s" interval="30s" start-delay="0s" />
 <action name="meta-data"    timeout="5s" />
 <action name="validate-all" timeout="10s" />
 </actions>
@@ -146,6 +147,11 @@ storage-mon_init() {
 		exit $OCF_ERR_INSTALLED
 	fi
 
+	if [ ! -x "${HA_SBIN_DIR}/attrd_updater" ] ; then
+		ocf_log err "${HA_SBIN_DIR}/attrd_updater not installed."
+		exit $OCF_ERR_INSTALLED
+	fi
+
 	i=0
 	for DRIVE in ${OCF_RESKEY_drives}; do
 		if [ ! -e "$DRIVE" ] ; then
@@ -161,7 +167,12 @@ storage-mon_init() {
 	fi
 
 	if [ "${OCF_RESKEY_io_timeout}" -lt "1" ]; then
-		ocf_log err "Minimum timeout is 1. Recommended 10 (default)."
+		ocf_log err "Minimum timeout is 1. Recommended ${OCF_RESKEY_io_timeout_default} (default)."
+		exit $OCF_ERR_CONFIGURED
+	fi
+
+	if [ "${OCF_RESKEY_check_interval}" -lt "1" ]; then
+		ocf_log err "Minimum interval to check is 1. default ${OCF_RESKEY_check_interval_default}."
 		exit $OCF_ERR_CONFIGURED
 	fi
 
@@ -173,79 +184,70 @@ storage-mon_init() {
 	fi
 }
 
-storage-mon_validate() {
+storage-mon_start() {
 	storage-mon_init
-
-	# Is the state directory writable?
-	state_dir=$(dirname "$OCF_RESKEY_state_file")
-	touch "$state_dir/$$"
-	if [ $? -ne 0 ]; then
-		return $OCF_ERR_CONFIGURED
-	fi
-	rm "$state_dir/$$"
-
-	return $OCF_SUCCESS
-}
-
-storage-mon_monitor() {
-	storage-mon_init
-
-	# Monitor _MUST!_ differentiate correctly between running
-	# (SUCCESS), failed (ERROR) or _cleanly_ stopped (NOT RUNNING).
-	# That is THREE states, not just yes/no.
-
-	if [ ! -f "${OCF_RESKEY_state_file}" ]; then
-		return $OCF_NOT_RUNNING
-	fi
 
 	# generate command line
 	cmdline=""
 	for DRIVE in ${OCF_RESKEY_drives}; do
 		cmdline="$cmdline --device $DRIVE --score 1"
 	done
-	cmdline="$cmdline --timeout ${OCF_RESKEY_io_timeout}"
+	cmdline="$cmdline --timeout ${OCF_RESKEY_io_timeout} --interval ${OCF_RESKEY_check_interval} --pidfile ${PIDFILE} --attrname ${ATTRNAME} --ha-sbin-dir ${HA_SBIN_DIR}"
 	if [ -n "${OCF_RESKEY_inject_errors}" ]; then
 		cmdline="$cmdline --inject-errors-percent ${OCF_RESKEY_inject_errors}"
 	fi
 	$STORAGEMON $cmdline
-	if [ $? -ne 0 ]; then
-		status="red"
-	else
-		status="green"
+	if [ "$?" -ne 0 ]; then
+		return $OCF_ERR_GENERIC
 	fi
-
-	"$ATTRDUP" -n "#health-${OCF_RESOURCE_INSTANCE}" -U "$status" -d "5s"
 	return $OCF_SUCCESS
 }
 
-storage-mon_start() {
-	storage-mon_monitor
-	if [ $? -eq $OCF_SUCCESS ]; then
-		return $OCF_SUCCESS
-	fi
-	touch "${OCF_RESKEY_state_file}"
+storage-mon_monitor() {
+	ocf_pidfile_status "${PIDFILE}" > /dev/null 2>&1
+	case "$?" in
+		0)	rc=$OCF_SUCCESS;;
+		1|2)	rc=$OCF_NOT_RUNNING;;
+		*)	rc=$OCF_ERR_GENERIC;;
+	esac
+
+	return "$rc"
 }
 
 storage-mon_stop() {
 	storage-mon_monitor
-	if [ $? -eq $OCF_SUCCESS ]; then
-		rm "${OCF_RESKEY_state_file}"
+	rc="$?"
+	case "$rc" in
+		$OCF_SUCCESS)
+			;;
+		$OCF_NOT_RUNNING)
+			return "$OCF_SUCCESS";;
+		*)
+			return "$rc";;
+	esac
+
+	kill -TERM $(cat "${PIDFILE}")
+	if [ "$?" -ne 0 ]; then
+		return $OCF_ERR_GENERIC
 	fi
-	return $OCF_SUCCESS
+	while true; do
+		storage-mon_monitor
+		rc="$?"
+		case "$rc" in
+			$OCF_SUCCESS)
+				;;
+			$OCF_NOT_RUNNING)
+				return "$OCF_SUCCESS";;
+			*)
+				return "$rc";;
+		esac
+		sleep 1
+	done
 }
 
 storage-mon_validate() {
 	storage-mon_init
-
-	# Is the state directory writable?
-	state_dir=$(dirname "${OCF_RESKEY_state_file}")
-	touch "$state_dir/$$"
-	if [ $? -ne 0 ]; then
-		return $OCF_ERR_CONFIGURED
-	fi
-	rm "$state_dir/$$"
-
-	return $OCF_SUCCESS
+	return "$OCF_SUCCESS"
 }
 
 case "$__OCF_ACTION" in

--- a/tools/storage_mon.c
+++ b/tools/storage_mon.c
@@ -16,23 +16,48 @@
 #ifdef __FreeBSD__
 #include <sys/disk.h>
 #endif
+#include <glib.h>
+#include <libgen.h>
 
 #define MAX_DEVICES 25
 #define DEFAULT_TIMEOUT 10
+#define DEFAULT_INTERVAL 30
+#define DEFAULT_PIDFILE "/tmp/storage_mon.pid"
+#define DEFAULT_ATTRNAME "#health-storage_mon"
+#define DEFAULT_HA_SBIN_DIR "/usr/sbin"
+
+char *devices[MAX_DEVICES];
+size_t device_count;
+int scores[MAX_DEVICES];
+int timeout = DEFAULT_TIMEOUT;
+const char *attrname = DEFAULT_ATTRNAME;
+const char *ha_sbin_dir = DEFAULT_HA_SBIN_DIR;
+int verbose;
+int inject_error_percent;
+
+GMainLoop *mainloop;
+guint timer;
+int shutting_down = FALSE;
+
+int write_pid_file(const char *pidfile);
 
 static void usage(char *name, FILE *f)
 {
-	fprintf(f, "usage: %s [-hv] [-d <device>]... [-s <score>]... [-t <secs>]\n", name);
-	fprintf(f, "      --device <dev>  device to test, up to %d instances\n", MAX_DEVICES);
-	fprintf(f, "      --score  <n>    score if device fails the test. Must match --device count\n");
-	fprintf(f, "      --timeout <n>   max time to wait for a device test to come back. in seconds (default %d)\n", DEFAULT_TIMEOUT);
-	fprintf(f, "      --inject-errors-percent <n> Generate EIO errors <n>%% of the time (for testing only)\n");
-	fprintf(f, "      --verbose        emit extra output to stdout\n");
-	fprintf(f, "      --help           print this message\n");
+	fprintf(f, "usage: %s [-hv] [-d <device>]... [-s <score>]... [-t <secs>] [-i <secs>] [-p <pidfile>] [-a <attrname>]\n", name);
+	fprintf(f, "      --device <dev>       device to test, up to %d instances\n", MAX_DEVICES);
+	fprintf(f, "      --score <n>          score if device fails the test. Must match --device count\n");
+	fprintf(f, "      --timeout <n>        max time to wait for a device test to come back. in seconds (default %d)\n", DEFAULT_TIMEOUT);
+	fprintf(f, "      --interval <n>       interval to test. in seconds (default %d)\n", DEFAULT_INTERVAL);
+	fprintf(f, "      --pidfile <path>     file path to record pid (default %s)\n", DEFAULT_PIDFILE);
+	fprintf(f, "      --attrname <attr>    attribute name to update test result (default %s)\n", DEFAULT_ATTRNAME);
+	fprintf(f, "      --ha-sbin-dir <dir>  directory where attrd_updater is located (default %s)\n", DEFAULT_HA_SBIN_DIR);
+	fprintf(f, "      --inject-errors-percent <n>  Generate EIO errors <n>%% of the time (for testing only)\n");
+	fprintf(f, "      --verbose            emit extra output to LOG_INFO\n");
+	fprintf(f, "      --help               print this message\n");
 }
 
 /* Check one device */
-static void *test_device(const char *device, int verbose, int inject_error_percent)
+static void *test_device(const char *device)
 {
 	uint64_t devsize;
 	int flags = O_RDONLY | O_DIRECT;
@@ -41,19 +66,19 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
 	off_t seek_spot;
 
 	if (verbose) {
-		printf("Testing device %s\n", device);
+		syslog(LOG_INFO, "Testing device %s", device);
 	}
 
 	device_fd = open(device, flags);
 	if (device_fd < 0) {
 		if (errno != EINVAL) {
-			fprintf(stderr, "Failed to open %s: %s\n", device, strerror(errno));
+			syslog(LOG_ERR, "Failed to open %s: %s", device, strerror(errno));
 			exit(-1);
 		}
 		flags &= ~O_DIRECT;
 		device_fd = open(device, flags);
 		if (device_fd < 0) {
-			fprintf(stderr, "Failed to open %s: %s\n", device, strerror(errno));
+			syslog(LOG_ERR, "Failed to open %s: %s", device, strerror(errno));
 			exit(-1);
 		}
 	}
@@ -63,11 +88,11 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
 	res = ioctl(device_fd, BLKGETSIZE64, &devsize);
 #endif
 	if (res < 0) {
-		fprintf(stderr, "Failed to get device size for %s: %s\n", device, strerror(errno));
+		syslog(LOG_ERR, "Failed to get device size for %s: %s", device, strerror(errno));
 		goto error;
 	}
 	if (verbose) {
-		printf("%s: opened %s O_DIRECT, size=%zu\n", device, (flags & O_DIRECT)?"with":"without", devsize);
+		syslog(LOG_INFO, "%s: opened %s O_DIRECT, size=%zu", device, (flags & O_DIRECT)?"with":"without", devsize);
 	}
 
 	/* Don't fret about real randomness */
@@ -76,11 +101,11 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
 	seek_spot = (rand() % (devsize-1024)) & 0xFFFFFFFFFFFFFE00;
 	res = lseek(device_fd, seek_spot, SEEK_SET);
 	if (res < 0) {
-		fprintf(stderr, "Failed to seek %s: %s\n", device, strerror(errno));
+		syslog(LOG_ERR, "Failed to seek %s: %s", device, strerror(errno));
 		goto error;
 	}
 	if (verbose) {
-		printf("%s: reading from pos %ld\n", device, seek_spot);
+		syslog(LOG_INFO, "%s: reading from pos %ld", device, seek_spot);
 	}
 
 	if (flags & O_DIRECT) {
@@ -93,22 +118,22 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
 		res = ioctl(device_fd, BLKSSZGET, &sec_size);
 #endif
 		if (res < 0) {
-			fprintf(stderr, "Failed to get block device sector size for %s: %s\n", device, strerror(errno));
+			syslog(LOG_ERR, "Failed to get block device sector size for %s: %s", device, strerror(errno));
 			goto error;
 		}
 
 		if (posix_memalign(&buffer, sysconf(_SC_PAGESIZE), sec_size) != 0) {
-			fprintf(stderr, "Failed to allocate aligned memory: %s\n", strerror(errno));
+			syslog(LOG_ERR, "Failed to allocate aligned memory: %s", strerror(errno));
 			goto error;
 		}
 		res = read(device_fd, buffer, sec_size);
 		free(buffer);
 		if (res < 0) {
-			fprintf(stderr, "Failed to read %s: %s\n", device, strerror(errno));
+			syslog(LOG_ERR, "Failed to read %s: %s", device, strerror(errno));
 			goto error;
 		}
 		if (res < sec_size) {
-			fprintf(stderr, "Failed to read %d bytes from %s, got %d\n", sec_size, device, res);
+			syslog(LOG_ERR, "Failed to read %d bytes from %s, got %d", sec_size, device, res);
 			goto error;
 		}
 	} else {
@@ -116,28 +141,28 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
 
 		res = read(device_fd, buffer, sizeof(buffer));
 		if (res < 0) {
-			fprintf(stderr, "Failed to read %s: %s\n", device, strerror(errno));
+			syslog(LOG_ERR, "Failed to read %s: %s", device, strerror(errno));
 			goto error;
 		}
 		if (res < (int)sizeof(buffer)) {
-			fprintf(stderr, "Failed to read %ld bytes from %s, got %d\n", sizeof(buffer), device, res);
+			syslog(LOG_ERR, "Failed to read %ld bytes from %s, got %d", sizeof(buffer), device, res);
 			goto error;
 		}
 	}
 
 	/* Fake an error */
 	if (inject_error_percent && ((rand() % 100) < inject_error_percent)) {
-		fprintf(stderr, "People, please fasten your seatbelts, injecting errors!\n");
+		syslog(LOG_ERR, "People, please fasten your seatbelts, injecting errors!");
 		goto error;
 	}
 	res = close(device_fd);
 	if (res != 0) {
-		fprintf(stderr, "Failed to close %s: %s\n", device, strerror(errno));
+		syslog(LOG_ERR, "Failed to close %s: %s", device, strerror(errno));
 		exit(-1);
 	}
 
 	if (verbose) {
-		printf("%s: done\n", device);
+		syslog(LOG_INFO, "%s: done", device);
 	}
 	exit(0);
 
@@ -146,32 +171,225 @@ error:
 	exit(-1);
 }
 
-int main(int argc, char *argv[])
+static void
+child_shutdown(int nsig)
 {
-	char *devices[MAX_DEVICES];
-	int scores[MAX_DEVICES];
+	exit(1);
+}
+
+static gboolean
+timer_cb(gpointer data)
+{
 	pid_t test_forks[MAX_DEVICES];
-	size_t device_count = 0;
-	size_t score_count = 0;
 	size_t finished_count = 0;
-	int timeout = DEFAULT_TIMEOUT;
 	struct timespec ts;
 	time_t start_time;
 	size_t i;
 	int final_score = 0;
+	const char *value;
+	pid_t pid, wpid;
+	int wstatus;
+
+	if (shutting_down == TRUE) {
+		goto done;
+	}
+
+	memset(test_forks, 0, sizeof(test_forks));
+	for (i=0; i<device_count; i++) {
+		test_forks[i] = fork();
+		if (test_forks[i] < 0) {
+			syslog(LOG_ERR, "Error spawning fork for %s: %s", devices[i], strerror(errno));
+			/* Just test the devices we have */
+			break;
+		}
+		/* child */
+		if (test_forks[i] == 0) {
+			signal(SIGTERM, &child_shutdown);
+			test_device(devices[i]);
+		}
+	}
+
+	/* See if they have finished */
+	clock_gettime(CLOCK_REALTIME, &ts);
+	start_time = ts.tv_sec;
+
+	while ((finished_count < device_count) && ((start_time + timeout) > ts.tv_sec)) {
+		for (i=0; i<device_count; i++) {
+			if (test_forks[i] > 0) {
+				wpid = waitpid(test_forks[i], &wstatus, WUNTRACED | WNOHANG | WCONTINUED);
+				if (wpid < 0) {
+					syslog(LOG_ERR, "waitpid on %s failed: %s", devices[i], strerror(errno));
+					goto done;
+				}
+
+				if (wpid == test_forks[i]) {
+					if (WIFEXITED(wstatus)) {
+						if (WEXITSTATUS(wstatus) != 0) {
+							syslog(LOG_ERR, "I/O error detected on %s", devices[i]);
+							final_score += scores[i];
+						}
+
+						finished_count++;
+						test_forks[i] = 0;
+					}
+				}
+			}
+		}
+
+		usleep(100000);
+
+		clock_gettime(CLOCK_REALTIME, &ts);
+	}
+
+	/* See which threads have not finished */
+	for (i=0; i<device_count; i++) {
+		if (test_forks[i] != 0) {
+			syslog(LOG_ERR, "I/O error detected on %s (check did not complete within %ds)", devices[i], timeout);
+			final_score += scores[i];
+		}
+	}
+
+	/* Update node health attribute */
+	value = (final_score > 0) ? "red" : "green";
+	pid = fork();
+	if (pid == 0) {
+		char path[PATH_MAX];
+		snprintf(path, PATH_MAX, "%s/attrd_updater", ha_sbin_dir);
+		execl(path, "attrd_updater", "-n", attrname, "-U", value, "-d", "5s", NULL);
+		syslog(LOG_ERR, "Failed to execute %s: %s", path, strerror(errno));
+		exit(1);
+	} else if (pid < 0) {
+		syslog(LOG_ERR, "Error spawning fork for attrd_updater: %s", strerror(errno));
+		goto done;
+	}
+	wpid = waitpid(pid, &wstatus, 0);
+	if (wpid < 0) {
+		syslog(LOG_ERR, "failed to wait for attrd_updater: %s", strerror(errno));
+		goto done;
+	}
+	if (WIFEXITED(wstatus) && (WEXITSTATUS(wstatus) != 0)) {
+		syslog(LOG_ERR, "failed to update attribute (%s=%s): attrd_updater exited %d", attrname, value, WEXITSTATUS(wstatus));
+		goto done;
+	}
+	if (verbose) {
+		syslog(LOG_INFO, "Updated node health attribute: %s=%s", attrname, value);
+	}
+
+	/* See if threads have finished */
+	while (finished_count < device_count) {
+		for (i=0; i<device_count; i++) {
+			if (test_forks[i] > 0
+			    && waitpid(test_forks[i], &wstatus, WUNTRACED | WNOHANG | WCONTINUED) == test_forks[i]
+			    && WIFEXITED(wstatus)) {
+				finished_count++;
+				test_forks[i] = 0;
+			}
+		}
+		usleep(100000);
+	}
+
+	if (shutting_down == TRUE) {
+		goto done;
+	}
+	if (data != NULL) {
+		g_source_remove(timer);
+		timer = g_timeout_add(*(int *)data * 1000, timer_cb, NULL);
+	}
+	return TRUE;
+
+done:
+	g_main_loop_quit(mainloop);
+	return FALSE;
+}
+
+int
+write_pid_file(const char *pidfile)
+{
+	char *pid;
+	char *dir, *str = NULL;
+	int fd = -1;
+	int rc = -1;
+	int i, len;
+
+	if (asprintf(&pid, "%jd", (intmax_t)getpid()) < 0) {
+		syslog(LOG_ERR, "Failed to allocate memory to store PID");
+		pid = NULL;
+		goto done;
+	}
+
+	str = strdup(pidfile);
+	if (str == NULL) {
+		syslog(LOG_ERR, "Failed to duplicate string ['%s']", pidfile);
+		goto done;
+	}
+	dir = dirname(str);
+	for (i = 1, len = strlen(dir); i < len; i++) {
+		if (dir[i] == '/') {
+			dir[i] = 0;
+			if ((mkdir(dir, 0640) < 0) && (errno != EEXIST)) {
+				syslog(LOG_ERR, "Failed to create directory %s: %s", dir, strerror(errno));
+				goto done;
+			}
+			dir[i] = '/';
+		}
+	}
+	if ((mkdir(dir, 0640) < 0) && (errno != EEXIST)) {
+		syslog(LOG_ERR, "Failed to create directory %s: %s", dir, strerror(errno));
+		goto done;
+	}
+
+	fd = open(pidfile, O_CREAT | O_WRONLY, 0640);
+	if (fd < 0) {
+		syslog(LOG_ERR, "Failed to open %s: %s", pidfile, strerror(errno));
+		goto done;
+	}
+
+	if (write(fd, pid, strlen(pid)) != strlen(pid)) {
+		syslog(LOG_ERR, "Failed to write '%s' to %s: %s", pid, pidfile, strerror(errno));
+		goto done;
+	}
+	close(fd);
+	rc = 0;
+done:
+	if (pid != NULL) {
+		free(pid);
+	}
+	if (str != NULL) {
+		free(str);
+	}
+	return rc;
+}
+
+static void
+daemon_shutdown(int nsig)
+{
+	shutting_down = TRUE;
+	g_source_remove(timer);
+	timer = g_timeout_add(0, timer_cb, NULL);
+}
+
+int main(int argc, char *argv[])
+{
+	int interval = DEFAULT_INTERVAL;
+	const char *pidfile = DEFAULT_PIDFILE;
+	size_t score_count = 0;
 	int opt, option_index;
-	int verbose = 0;
-	int inject_error_percent = 0;
 	struct option long_options[] = {
 		{"timeout", required_argument, 0, 't' },
 		{"device",  required_argument, 0, 'd' },
 		{"score",   required_argument, 0, 's' },
+		{"interval", required_argument, 0, 'i' },
+		{"pidfile", required_argument, 0, 'p' },
+		{"attrname", required_argument, 0, 'a' },
+		{"ha-sbin-dir", required_argument, 0, 0 },
 		{"inject-errors-percent",   required_argument, 0, 0 },
 		{"verbose", no_argument, 0, 'v' },
 		{"help",    no_argument, 0,       'h' },
 		{0,         0,           0,        0  }
 	};
-	while ( (opt = getopt_long(argc, argv, "hvt:d:s:",
+	struct sigaction sa;
+
+	while ( (opt = getopt_long(argc, argv, "hvt:d:s:i:p:a:",
 				   long_options, &option_index)) != -1 ) {
 		switch (opt) {
 			case 0: /* Long-only options */
@@ -182,10 +400,21 @@ int main(int argc, char *argv[])
 						return -1;
 					}
 				}
+				if (strcmp(long_options[option_index].name, "ha-sbin-dir") == 0) {
+					ha_sbin_dir = strdup(optarg);
+					if (ha_sbin_dir == NULL) {
+						fprintf(stderr, "Failed to duplicate string ['%s']\n", optarg);
+						return -1;
+					}
+				}
 				break;
 			case 'd':
 				if (device_count < MAX_DEVICES) {
 					devices[device_count++] = strdup(optarg);
+					if (devices[device_count - 1] == NULL) {
+						fprintf(stderr, "Failed to duplicate string ['%s']\n", optarg);
+						return -1;
+					}
 				} else {
 					fprintf(stderr, "too many devices, max is %d\n", MAX_DEVICES);
 					return -1;
@@ -214,6 +443,27 @@ int main(int argc, char *argv[])
 					return -1;
 				}
 				break;
+			case 'i':
+				interval = atoi(optarg);
+				if (interval < 1) {
+					fprintf(stderr, "invalid interval %d. Min 1, default is %d\n", interval, DEFAULT_INTERVAL);
+					return -1;
+				}
+				break;
+			case 'p':
+				pidfile = strdup(optarg);
+				if (pidfile == NULL) {
+					fprintf(stderr, "Failed to duplicate string ['%s']\n", optarg);
+					return -1;
+				}
+				break;
+			case 'a':
+				attrname = strdup(optarg);
+				if (attrname == NULL) {
+					fprintf(stderr, "Failed to duplicate string ['%s']\n", optarg);
+					return -1;
+				}
+				break;
 			case 'h':
 				usage(argv[0], stdout);
 				return 0;
@@ -237,67 +487,31 @@ int main(int argc, char *argv[])
 
 	openlog("storage_mon", 0, LOG_DAEMON);
 
-	memset(test_forks, 0, sizeof(test_forks));
-	for (i=0; i<device_count; i++) {
-		test_forks[i] = fork();
-		if (test_forks[i] < 0) {
-			fprintf(stderr, "Error spawning fork for %s: %s\n", devices[i], strerror(errno));
-			syslog(LOG_ERR, "Error spawning fork for %s: %s\n", devices[i], strerror(errno));
-			/* Just test the devices we have */
-			break;
-		}
-		/* child */
-		if (test_forks[i] == 0) {
-			test_device(devices[i], verbose, inject_error_percent);
-		}
+	if (daemon(0, 0) < 0) {
+		syslog(LOG_ERR, "Failed to daemonize: %s", strerror(errno));
+		return -1;
 	}
 
-	/* See if they have finished */
-	clock_gettime(CLOCK_REALTIME, &ts);
-	start_time = ts.tv_sec;
+	umask(S_IWGRP | S_IWOTH | S_IROTH);
 
-	while ((finished_count < device_count) && ((start_time + timeout) > ts.tv_sec)) {
-		for (i=0; i<device_count; i++) {
-			int wstatus;
-			pid_t w;
-
-			if (test_forks[i] > 0) {
-				w = waitpid(test_forks[i], &wstatus, WUNTRACED | WNOHANG | WCONTINUED);
-				if (w < 0) {
-					fprintf(stderr, "waitpid on %s failed: %s\n", devices[i], strerror(errno));
-					return -1;
-				}
-
-				if (w == test_forks[i]) {
-					if (WIFEXITED(wstatus)) {
-						if (WEXITSTATUS(wstatus) != 0) {
-							syslog(LOG_ERR, "Error reading from device %s", devices[i]);
-							final_score += scores[i];
-						}
-
-						finished_count++;
-						test_forks[i] = 0;
-					}
-				}
-			}
-		}
-
-		usleep(100000);
-
-		clock_gettime(CLOCK_REALTIME, &ts);
+	memset(&sa, 0, sizeof(struct sigaction));
+	sa.sa_handler = daemon_shutdown;
+	sa.sa_flags = SA_RESTART;
+	if ((sigemptyset(&sa.sa_mask) < 0) || (sigaction(SIGTERM, &sa, NULL) < 0)) {
+		syslog(LOG_ERR, "Failed to set handler for signal: %s", strerror(errno));
+		return -1;
 	}
 
-	/* See which threads have not finished */
-	for (i=0; i<device_count; i++) {
-		if (test_forks[i] != 0) {
-			syslog(LOG_ERR, "Reading from device %s did not complete in %d seconds timeout", devices[i], timeout);
-			fprintf(stderr, "Thread for device %s did not complete in time\n", devices[i]);
-			final_score += scores[i];
-		}
+	if (write_pid_file(pidfile) < 0) {
+		return -1;
 	}
 
-	if (verbose) {
-		printf("Final score is %d\n", final_score);
-	}
-	return final_score;
+	mainloop = g_main_loop_new(NULL, FALSE);
+	timer = g_timeout_add(0, timer_cb, &interval);
+	g_main_loop_run(mainloop);
+	g_main_loop_unref(mainloop);
+
+	unlink(pidfile);
+
+	return 0;
 }


### PR DESCRIPTION
This patch is intended to avoid the issue (#1809) of an increasing number of child processes that do not finish.
 * Based on discussion in https://github.com/ClusterLabs/resource-agents/pull/1812, changed storage_mon to run as a daemon.