### PR TITLE
Please don't suggest /tmp/mysql-proxy.sock, that is bad practice.

### DIFF
--- a/heartbeat/mysql-proxy
+++ b/heartbeat/mysql-proxy
@@ -171,7 +171,7 @@ Address:port of the remote (read only) unpromoted-server (default: ).
 <parameter name="proxy_address" unique="0" required="0">
 <longdesc lang="en">
 Listening address:port of the proxy server (default: :4040).
-You can also specify a socket like "/tmp/mysql-proxy.sock".
+You can also specify a socket like "/var/run/mysql-proxy.sock".
 </longdesc>
 <shortdesc lang="en">MySQL Proxy listening address</shortdesc>
 <content type="string" default="${OCF_RESKEY_proxy_address_default}" />


### PR DESCRIPTION
Use one of the directories where this socket can be provided securely