### PR TITLE
exportfs: fix the error handling during monitoring

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -218,7 +218,9 @@ backup_rmtab() {
 	local dir=$1
 	local rmtab_backup
 	rmtab_backup="$dir/${OCF_RESKEY_rmtab_backup}"
-	grep ":$dir:" /var/lib/nfs/rmtab > ${rmtab_backup}
+	if [ -r /var/lib/nfs/rmtab ]; then
+		grep ":$dir:" /var/lib/nfs/rmtab > ${rmtab_backup}
+	fi
 }
 
 restore_rmtab() {


### PR DESCRIPTION
Issue: the annoying messages during monitoring,

```
notice: p-exportfs_monitor_30000[32157] error output [ grep: /var/lib/nfs/rmtab: No such file or directory ]
```