### PR TITLE
nfsserver: fix "server scope" to live with additional drop-in files

### DIFF
--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -711,7 +711,9 @@ inject_unshare_uts_name_into_systemd_units ()
 		test -d "$dir" || mkdir -p "$dir"
 		test -e "$dropin" && rm -f "$dropin"
 
-		edited_exec_start=$(systemctl cat $svc | sed -ne "s#^ExecStart=\\([-+:!@]*\\)\\(.*\\)#ExecStart=\\1/usr/bin/unshare --uts /bin/sh -c 'hostname \${NFS_SERVER_SCOPE}; exec \"\$@\"' -- \\2#p")
+		# NOTE: additional ExecStart= might exist in the drop-in files, eg. openSUSE
+		edited_exec_start=$(systemctl cat $svc | sed -ne "s#^ExecStart=\\([-+:!@]*\\)\\(.\+\\)#ExecStart=\\1/usr/bin/unshare --uts /bin/sh -c 'hostname \${NFS_SERVER_SCOPE}; exec \"\$@\"' -- \\2#p" | tail -1)
+
 		cat > "$dropin" <<___
 [Service]
 EnvironmentFile=$SYSTEMD_ENVIRONMENT_FILE_NFS_SERVER_SCOPE


### PR DESCRIPTION

Symptom:

The distro may have additional drop-in files to override `ExecStart=`, eg. openSUSE. In that case, the result drop-in file is messed up with several ExecStart= generated. For example,

cat
/run/systemd/system/nfs-server.service.d/51-resource-agents-unshare-uts.conf

[Service]
EnvironmentFile=/run/sysconfig/nfs-server-scope

ExecStart=
ExecStart=/usr/bin/unshare --uts /bin/sh -c 'hostname ${NFS_SERVER_SCOPE}; exec "$@"' -- /usr/sbin/rpc.nfsd ExecStart=/usr/bin/unshare --uts /bin/sh -c 'hostname ${NFS_SERVER_SCOPE}; exec "$@"' -- 
ExecStart=-/usr/bin/unshare --uts /bin/sh -c 'hostname ${NFS_SERVER_SCOPE}; exec "$@"' -- /usr/sbin/rpc.nfsd $NFSD_OPTIONS

Indeed, only the last ExecStart= is needed.
