### PR TITLE
Mid: ocf-shellfuncs: Explicitly specify $OCF_RESOURCE_INSTANCE in the p parameter for compatibility.

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -1052,7 +1052,7 @@ ocf_promotion_score() {
 	ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.10.0"
 	res=$?
 	if [ $res -eq 2 ] || [ $res -eq 1 ] || ! have_binary "crm_master"; then
-		${HA_SBIN_DIR}/crm_attribute -p $@
+		${HA_SBIN_DIR}/crm_attribute -p ${OCF_RESOURCE_INSTANCE} $@
 	else
 		${HA_SBIN_DIR}/crm_master -l reboot $@
 	fi


### PR DESCRIPTION
Hi All,

The following fixes were made in pacemaker:
 - https://github.com/ClusterLabs/pacemaker/pull/3039

For compatibility, specify the option specification explicitly.

Best Regards,
Hideo Yamauchi.

