### PR TITLE
ZFS: add non-blocking check if pool was imported

### DIFF
--- a/heartbeat/ZFS
+++ b/heartbeat/ZFS
@@ -89,7 +89,7 @@ zpool_is_imported () {
         return `[ -d  /proc/spl/kstat/zfs/"${OCF_RESKEY_pool}" ]`
     else
         # If ZFS kstats do not exists, fallback to the standard check
-		return zpool list -H "$OCF_RESKEY_pool" > /dev/null
+		return `zpool list -H "$OCF_RESKEY_pool" > /dev/null`
 	fi
 }
 

--- a/heartbeat/ZFS
+++ b/heartbeat/ZFS
@@ -83,7 +83,14 @@ END
 }
 
 zpool_is_imported () {
-	zpool list -H "$OCF_RESKEY_pool" > /dev/null
+	# Check if ZFS kstats exists
+    if [ -d  /proc/spl/kstat/zfs/ ] ; then
+		# Check the existence of kstats for the pool. If the stats exists, the pool was imported.
+        return `[ -d  /proc/spl/kstat/zfs/"${OCF_RESKEY_pool}" ]`
+    else
+        # If ZFS kstats do not exists, fallback to the standard check
+		return zpool list -H "$OCF_RESKEY_pool" > /dev/null
+	fi
 }
 
 # Forcibly imports a ZFS pool, mounting all of its auto-mounted filesystems

--- a/heartbeat/ZFS
+++ b/heartbeat/ZFS
@@ -84,13 +84,15 @@ END
 
 zpool_is_imported () {
 	# Check if ZFS kstats exists
-    if [ -d  /proc/spl/kstat/zfs/ ] ; then
+	if [ -d  /proc/spl/kstat/zfs/ ] ; then
 		# Check the existence of kstats for the pool. If the stats exists, the pool was imported.
-        return `[ -d  /proc/spl/kstat/zfs/"${OCF_RESKEY_pool}" ]`
-    else
-        # If ZFS kstats do not exists, fallback to the standard check
-		return `zpool list -H "$OCF_RESKEY_pool" > /dev/null`
+		[ -d  /proc/spl/kstat/zfs/"${OCF_RESKEY_pool}" ]
+		rc=$? 
+	else
+		# If ZFS kstats do not exists, fallback to the standard check
+		rc=$(zpool list -H "$OCF_RESKEY_pool" > /dev/null)
 	fi
+	return $rc
 }
 
 # Forcibly imports a ZFS pool, mounting all of its auto-mounted filesystems


### PR DESCRIPTION
The function  `zpool_is_imported` can be improved to use ZFS kstats instead of blocking `zpool list` calls for newer releases of ZFS.