### PR TITLE
storage_mon: Fix printf format string on i686

### DIFF
--- a/tools/storage_mon.c
+++ b/tools/storage_mon.c
@@ -67,7 +67,7 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
 		goto error;
 	}
 	if (verbose) {
-		printf("%s: opened %s O_DIRECT, size=%zu\n", device, (flags & O_DIRECT)?"with":"without", devsize);
+		printf("%s: opened %s O_DIRECT, size=%llu\n", device, (flags & O_DIRECT)?"with":"without", devsize);
 	}
 
 	/* Don't fret about real randomness */
@@ -120,7 +120,7 @@ static void *test_device(const char *device, int verbose, int inject_error_perce
 			goto error;
 		}
 		if (res < (int)sizeof(buffer)) {
-			fprintf(stderr, "Failed to read %ld bytes from %s, got %d\n", sizeof(buffer), device, res);
+			fprintf(stderr, "Failed to read %zd bytes from %s, got %d\n", sizeof(buffer), device, res);
 			goto error;
 		}
 	}


### PR DESCRIPTION
Fix build errors on i686:
```console
storage_mon.c: In function 'test_device':
storage_mon.c:63:45: error: format '%zu' expects argument of type 'size_t', but argument 4 has type 'uint64_t' {aka 'long long unsigned int'} [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat=-Werror=format=8;;]
   63 |                 fprintf(stderr, "%s: size=%zu\n", device, devsize);
      |                                           ~~^             ~~~~~~~
      |                                             |             |
      |                                             unsigned int  uint64_t {aka long long unsigned int}
      |                                           %llu
storage_mon.c:87:51: error: format '%ld' expects argument of type 'long int', but argument 3 has type 'unsigned int' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat=-Werror=format=8;;]
   87 |                 fprintf(stderr, "Failed to read %ld bytes from %s, got %d\n", sizeof(buffer), device, res);
      |                                                 ~~^                           ~~~~~~~~~~~~~~
      |                                                   |                           |
      |                                                   long int                    unsigned int
      |                                                 %d
```