### PR TITLE
spec: Migrate to SPDX license

### DIFF
--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -45,7 +45,7 @@ Name:		resource-agents
 Summary:	Open Source HA Reusable Cluster Resource Scripts
 Version:	@version@
 Release:	@specver@%{?rcver:%{rcver}}%{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}%{?dist}
-License:	GPLv2+ and LGPLv2+
+License:	GPL-2.0-or-later AND LGPL-2.1-or-later
 URL:		https://github.com/ClusterLabs/resource-agents
 Source0:	%{name}-%{version}%{?rcver:%{rcver}}%{?numcomm:.%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}.tar.bz2
 Obsoletes:	heartbeat-resources <= %{version}
@@ -152,7 +152,7 @@ service managers.
 
 %if %{with linuxha}
 %package -n ldirectord
-License:	GPLv2+
+License:	GPL-2.0-or-later
 Summary:	A Monitoring Daemon for Maintaining High Availability Resources
 Obsoletes:	heartbeat-ldirectord <= %{version}
 Provides:	heartbeat-ldirectord = %{version}


### PR DESCRIPTION
Both Fedora and openSUSE now recommends to use SPDX shortname format for License.