### PR TITLE
Filesystem: list_mounts: fix mount command output parsing

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -355,8 +355,8 @@ list_mounts() {
 		else
 			# <device> on <mountpoint> type <fstype> ...
 			# Use tabs as field separators
-			match_string='\(.*\) on \(.*\) type \([^[:space:]]\)'
-			replace_string="\\1${TAB}\\3${TAB}\\5"
+			match_string='\(.*\) on \(.*\) type \([^[:space:]]\+\) .*'
+			replace_string="\\1${TAB}\\2${TAB}\\3"
 			mount_list=$($MOUNT | sed "s/$match_string/$replace_string/g")
 		fi
 	done


### PR DESCRIPTION
Parsing mount command output in list_mounts() results in a sed error: sed: -e expression #1, char 51: invalid reference \5 on `s' command's RHS

This results in a list_mounts not returning any mounts.

The error is caused due to match_string only providing three capture groups, while the replacement string references a non-existing 5th capture group.

Also, the output for this case differs from the case where the mount list is parsed from /proc/mounts or /etc/mtab as it would include the mount options in the output.

Fixes: a8051cf9e21d ("Filesystem: Support whitespace in device or directory name")