### PR TITLE
postfix: Update permission check from su to runuser/su

### DIFF
--- a/heartbeat/postfix
+++ b/heartbeat/postfix
@@ -44,11 +44,11 @@ USAGE="Usage: $0 {start|stop|reload|monitor|validate-all|meta-data}";
 
 ##########################################################################
 
-# Check availability of the runuser command, otherwise use sudo
+# Check availability of the runuser command, otherwise use su
 if [ -x /sbin/runuser ]; then
-    SUDO=runuser
+    SU=runuser
 else
-    SUDO=sudo
+    SU=su
 fi
 
 usage() {
@@ -297,7 +297,7 @@ postfix_validate_all()
         if ocf_is_true $status_support; then
             user=`postconf $OPTION_CONFIG_DIR -h mail_owner 2>/dev/null`
             for dir in $data_dir; do
-                if ! $SUDO -u $user -- test -w $dir; then
+                if ! $SU -s /bin/sh -l $user -c "test -w $dir"; then
                     if ocf_is_probe; then
                         ocf_log info "Directory '$dir' is not writable by user '$user' during probe."
                     else

--- a/heartbeat/postfix
+++ b/heartbeat/postfix
@@ -297,7 +297,7 @@ postfix_validate_all()
         if ocf_is_true $status_support; then
             user=`postconf $OPTION_CONFIG_DIR -h mail_owner 2>/dev/null`
             for dir in $data_dir; do
-                if ! $SU -s /bin/sh -l $user -c "test -w $dir"; then
+                if ! $SU -s /bin/sh - $user -c "test -w $dir"; then
                     if ocf_is_probe; then
                         ocf_log info "Directory '$dir' is not writable by user '$user' during probe."
                     else

--- a/heartbeat/postfix
+++ b/heartbeat/postfix
@@ -44,6 +44,13 @@ USAGE="Usage: $0 {start|stop|reload|monitor|validate-all|meta-data}";
 
 ##########################################################################
 
+# Check availability of the runuser command, otherwise use sudo
+if [ -x /sbin/runuser ]; then
+    SUDO=runuser
+else
+    SUDO=sudo
+fi
+
 usage() {
     echo $USAGE >&2
 }
@@ -290,7 +297,7 @@ postfix_validate_all()
         if ocf_is_true $status_support; then
             user=`postconf $OPTION_CONFIG_DIR -h mail_owner 2>/dev/null`
             for dir in $data_dir; do
-                if ! su -s /bin/sh - $user -c "test -w $dir"; then
+                if ! $SUDO -u $user -- test -w $dir; then
                     if ocf_is_probe; then
                         ocf_log info "Directory '$dir' is not writable by user '$user' during probe."
                     else


### PR DESCRIPTION
In the postfix resource agent, changed the check for a writable config directory to use sudo rather than su. Using su is prone to authentication failures while sudo works well.