### PR TITLE
mysql-common: improve error message

### DIFF
--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -254,7 +254,7 @@ mysql_common_start()
     while [ $start_wait = 1 ]; do
         if ! ps $pid > /dev/null 2>&1; then
             wait $pid
-            ocf_exit_reason "MySQL server failed to start (pid=$pid) (rc=$?), please check your installation"
+            ocf_exit_reason "MySQL server failed to start (pid=$pid) (rc=$?), please check your installation, log message you can check $OCF_RESKEY_log"
             return $OCF_ERR_GENERIC
         fi
         mysql_common_status info

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -254,7 +254,7 @@ mysql_common_start()
     while [ $start_wait = 1 ]; do
         if ! ps $pid > /dev/null 2>&1; then
             wait $pid
-            ocf_exit_reason "MySQL server failed to start (pid=$pid) (rc=$?), please check your installation, log message you can check $OCF_RESKEY_log"
+            ocf_exit_reason "MySQL server failed to start (pid=$pid) (rc=$?), Check $OCF_RESKEY_log for details"
             return $OCF_ERR_GENERIC
         fi
         mysql_common_status info

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -254,7 +254,7 @@ mysql_common_start()
     while [ $start_wait = 1 ]; do
         if ! ps $pid > /dev/null 2>&1; then
             wait $pid
-            ocf_exit_reason "MySQL server failed to start (pid=$pid) (rc=$?), Check $OCF_RESKEY_log for details"
+            ocf_exit_reason "MySQL server failed to start (pid=$pid) (rc=$?). Check $OCF_RESKEY_log for details"
             return $OCF_ERR_GENERIC
         fi
         mysql_common_status info


### PR DESCRIPTION
hi , there are situations when MySQL fails to start and the error is sent to standard error/standard out and is not display on the terminal. then i add some log message in ocf_exit_reason . hope it helps