### PR TITLE
findif.sh: fix loopback handling

### DIFF
--- a/heartbeat/findif.sh
+++ b/heartbeat/findif.sh
@@ -29,10 +29,10 @@ prefixcheck() {
   fi
   return 0
 }
-getnetworkinfo()
+getloopbackinfo()
 {
   local line netinfo
-  ip -o -f inet route list match $OCF_RESKEY_ip scope host | (while read line;
+  ip -o -f inet route list match $OCF_RESKEY_ip table local scope host | (while read line;
   do
     netinfo=`echo $line | awk '{print $2}'`
     case $netinfo in
@@ -222,7 +222,7 @@ findif()
   if [ $# = 0 ] ; then
     case $OCF_RESKEY_ip in
     127.*)
-      set -- `getnetworkinfo`
+      set -- `getloopbackinfo`
       shift;;
     esac
   fi


### PR DESCRIPTION
`tools/ocft/IPaddr2` fails the loopback test because of the missing `table local` parameter:

```
$ ip -o -f inet route list match 127.0.0.3 scope host

$ ip -o -f inet route list match 127.0.0.3 table local scope host
local 127.0.0.0/8 dev lo proto kernel src 127.0.0.1
```

Also rename the function because it is called only in for the special loopback address case.