### PR TITLE
Low: IPaddr2: Remove stray backslash

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -624,7 +624,7 @@ find_interface() {
 	# List interfaces but exclude FreeS/WAN ipsecN virtual interfaces
 	#
 	local iface="`$IP2UTIL -o -f $FAMILY addr show \
-		| grep "\ $ipaddr/$netmask" \
+		| grep " $ipaddr/$netmask" \
 		| cut -d ' ' -f2 \
 		| grep -v '^ipsec[0-9][0-9]*$'`"
 


### PR DESCRIPTION
Fixes this warning (which gets logged on every recurring monitor for a Pacemaker resource):
```
$ OCF_ROOT=/usr/lib/ocf OCF_RESKEY_ip=192.168.22.41     \
        /usr/lib/ocf/resource.d/heartbeat/IPaddr2 monitor
grep: warning: stray \ before white space
```