### PR TITLE
Filesystem: modify the check for the exit code of the child process.

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -704,8 +704,8 @@ timeout_child() {
 	wait $pid
 	ret=$?
 
-	# ret would be 127 + child exit code if the timeout expired
-	[ $ret -lt 128 ] && kill -s KILL $killer
+	# ret would be 128 + signal number if the timeout expired
+	[ $ret -lt 129 ] && kill -s KILL $killer
 	return $ret
 }
 fs_stop_loop() {


### PR DESCRIPTION
Hi All,

I found something a bit off with the check for the exit code of the child process.
It's in the stop operation.
According to TLDP,  the exit code when a process is signaled is expected to be "128 + signal number", 
not "127 + child exit code".
(FYI: https://tldp.org/LDP/abs/html/exitcodes.html)
So, I've done some small tweaks.
I hope this will help.

Best Regards,
SatomiOSAWA