### PR TITLE
configure: fix "C preprocessor "gcc -E" fails sanity check" error caused by autoconf 2.72

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,7 @@ fi
 AC_PROG_CC dnl Can force other with environment variable "CC".
 AM_PROG_CC_C_O
 AC_PROG_CC_STDC
+AC_PROG_CPP
 AC_PROG_AWK
 AC_PROG_LN_S
 AC_PROG_INSTALL


### PR DESCRIPTION
Thanks @jfriesse for helping debug the issue.