### PR TITLE
LVM-activate: Avoid false positive for VG activation

### DIFF
--- a/heartbeat/LVM-activate
+++ b/heartbeat/LVM-activate
@@ -448,6 +448,10 @@ systemid_check()
 {
 	# system_id_source is set in lvm.conf
 	source=$(lvmconfig 'global/system_id_source' 2>/dev/null | cut -d"=" -f2)
+
+	# Is volume_list set in lvm.conf
+	vol_list=$(lvmconfig 'activation/volume_list' 2>/dev/null | cut -d"=" -f2)
+
 	if [ "$source" = "" ] || [ "$source" = "none" ]; then
 		ocf_exit_reason "system_id_source in lvm.conf is not set correctly!"
 		exit $OCF_ERR_ARGS
@@ -455,6 +459,11 @@ systemid_check()
 
 	if [ -z ${SYSTEM_ID} ]; then
 		ocf_exit_reason "local/system_id is not set!"
+		exit $OCF_ERR_ARGS
+	fi
+
+	if [ -n "$source" ] && [ -n "$vol_list" ]; then
+		ocf_exit_reason "Both system_id_source & volume_list cannot be defined!"
 		exit $OCF_ERR_ARGS
 	fi
 


### PR DESCRIPTION
When lvm.conf file has `volume_list` parameter configured and the cluster is managing the shared storage using `system_id_source`, then the activation of the LV fails to happen. However it is reported as a success.

The fixes will avoid starting of `LVM-activate` resource when the cluster is configured with both `system_id_source` and `volume_list`.