### PR TITLE
Don't build with -ansi by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,7 @@ AC_SUBST(PKGNAME)
 
 AC_ARG_ENABLE([ansi],
 [  --enable-ansi force GCC to compile to ANSI/ANSI standard for older compilers.
-     [default=yes]])
+     [default=no]])
 
 AC_ARG_ENABLE([fatal-warnings],
 [  --enable-fatal-warnings very pedantic and fatal warnings for gcc


### PR DESCRIPTION
-ansi restricts the code to C90 standard which can break some included headers (specifically seen on freebsd-devel), so don't make it the default.