### PR TITLE
docker: Fix RA behavior when Docker service isn't running

### DIFF
--- a/heartbeat/docker
+++ b/heartbeat/docker
@@ -293,8 +293,8 @@ docker_simple_status()
 	VERSION_OUT=$(docker version)
 	version_ret=$?
 	if [ $version_ret -eq 1 ]; then
-		ocf_exit_reason "Docker service is in error state while checking for ${CONTAINER}, based on image, ${OCF_RESKEY_image}: ${VERSION_OUT}"
-		return $OCF_ERR_GENERIC
+		ocf_log err "Docker service is not running or in error state while checking for ${CONTAINER}, based on image, ${OCF_RESKEY_image}: ${VERSION_OUT}"
+		return $OCF_NOT_RUNNING
 	fi
 
 	container_exists


### PR DESCRIPTION
After running into some failed monitor actions using the docker RA on Ubuntu 22.04, reverting some of the behavior of commit b7ae1bf resolves the issues.

Currently, the Docker resource agent works well if you ___do not___ manage the `docker.service` within Pacemaker. On Ubuntu 22.04 using systemd you can set the Docker service to enabled and start Docker before Pacemaker starts (key part).

However, attempting to manage the `docker.service` within Pacemaker causes some issues during the initial monitoring probe and it also completely breaks `stop-all-resources=true` expected behavior as the Docker resource agent's monitoring operations will always fail if the Docker service isn't running. Clean startup and shutdown are also affected and clearing failed actions is needed before resources will start.

As far as "live-restore" goes (referenced in commit b7ae1bf), shouldn't the approach be more along the lines of "don't do that" when managing individual containers using Pacemaker and the Docker resource agent? If the Docker service is unavailable or having issues assume the containers are unavailable/not running and let Pacemaker attempt to restart the Docker service or migrate containers to another node.

I haven't tested it, but after briefly looking at the Podman resource agent, it appears the Podman RA will simply return `$OCF_NOT_RUNNING` if the Podman service isn't running. This PR should bring the Docker and Podman resource agents into alignment regarding this behavior.

If I should create an issue to accompany this PR, just let me know and I'll gladly create one.