### PR TITLE
Filesystem: Adjusted to shorten the duration of the stop operation.

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -711,11 +711,11 @@ timeout_child() {
 fs_stop_loop() {
 	local SUB="$1" signals="$2" sig
 	while true; do
+		try_umount "$SUB" && return $OCF_SUCCESS
 		for sig in $signals; do
 			signal_processes "$SUB" $sig
 		done
 		sleep $OCF_RESKEY_signal_delay
-		try_umount "$SUB" && return $OCF_SUCCESS
 	done
 }
 fs_stop() {


### PR DESCRIPTION
Hi all,

I have noticed that Filesystem’s stop operation in RHEL 9.3 takes longer than before.
(I already reported it in Issue #1907.)
While the extension of the duration for each stop operation may not be significant, it seems that every little bit adds up.
Therefore, I attempted to improve it.
I believe it works well.

Now, I have 10 Filesystems in a group.
I measured the time it takes to stop all 10 Filesystems under some conditions.
I conducted the measurements 5 times and calculated the average.
And the results are as follows:
```
 1. @RHEL9.2                               : avg.  2.6s
 2. @RHEL9.3, signal_delay=1               : avg. 25.8s
 3. @RHEL9.3, signal_delay=0               : avg. 12.6s
 4. @RHEL9.3, signal_delay=1, with this PR : avg.  2.8s
```

During the measurements,
No processes was accessing the mounted devices.
And I had no errors.
I simply did that
```
 # pcs cluster start --all
 # pcs cluster cib-push cib.xml
 # pcs cluster stop --all
```
and checked /var/log/messages.

With this PR,
if any processes were accessing mounted devices when initiating the stop operation,
the umount command would immediately fail, and the processes would be killed.
And then, after sleeping for signal_delay seconds,
the umount command will be executed again.
This behavior is the same as in RHEL 9.2.

Any opinions or suggestions are welcome.


Best Regards,
Satomi OSAWA



 === FYI ===
  *  Resources
```
 # pcs status --full
Cluster name: my_cluster
Cluster Summary:
  * Stack: corosync (Pacemaker is running)
  * Current DC: rhel93a (1) (version 2.1.6-9.el9-6fdc9deea29) - partition with quorum
  * Last updated: Tue Feb 27 14:03:28 2024 on rhel93a
  * Last change:  Tue Feb 27 14:02:38 2024 by hacluster via crmd on rhel93a
  * 2 nodes configured
  * 12 resource instances configured

Node List:
  * Node rhel93a (1): online, feature set 3.17.4
  * Node rhel93b (2): online, feature set 3.17.4

Full List of Resources:
  * Resource Group: fs-group:
    * filesystem1       (ocf:heartbeat:Filesystem):      Started rhel93a
    * filesystem2       (ocf:heartbeat:Filesystem):      Started rhel93a
    * filesystem3       (ocf:heartbeat:Filesystem):      Started rhel93a
    * filesystem4       (ocf:heartbeat:Filesystem):      Started rhel93a
    * filesystem5       (ocf:heartbeat:Filesystem):      Started rhel93a
    * filesystem6       (ocf:heartbeat:Filesystem):      Started rhel93a
    * filesystem7       (ocf:heartbeat:Filesystem):      Started rhel93a
    * filesystem8       (ocf:heartbeat:Filesystem):      Started rhel93a
    * filesystem9       (ocf:heartbeat:Filesystem):      Started rhel93a
    * filesystem10      (ocf:heartbeat:Filesystem):      Started rhel93a
  * fence1-ipmilan      (stonith:fence_ipmilan):         Started rhel93b
  * fence2-ipmilan      (stonith:fence_ipmilan):         Started rhel93a

(snip)
```
   *  Log examples
```
Feb 26 19:11:38 rhel93a <daemon.notice> pacemaker-controld[281626]: notice: Initiating stop operation filesystem10_stop_0 locally on rhel93a
Feb 26 19:11:38 rhel93a <daemon.notice> pacemaker-controld[281626]: notice: Requesting local execution of stop operation for filesystem10 on rhel93a
Feb 26 19:11:38 rhel93a <daemon.notice> pacemaker-controld[281626]: notice: Initiating stop operation fence2-ipmilan_stop_0 locally on rhel93a
Feb 26 19:11:38 rhel93a <daemon.notice> pacemaker-controld[281626]: notice: Requesting local execution of stop operation for fence2-ipmilan on rhel93a
Feb 26 19:11:38 rhel93a <daemon.notice> pacemaker-controld[281626]: notice: Result of stop operation for fence2-ipmilan on rhel93a: ok
Feb 26 19:11:38 rhel93a <daemon.info> Filesystem(filesystem10)[289173]:INFO: Running stop for /dev/sdb10 on /mnt/disk9
Feb 26 19:11:38 rhel93a <daemon.info> Filesystem(filesystem10)[289173]:INFO: Trying to unmount /mnt/disk9
Feb 26 19:11:39 rhel93a <daemon.info> Filesystem(filesystem10)[289173]:INFO: No processes on /mnt/disk9 were signalled. force_unmount is set to 'safe'
Feb 26 19:11:40 rhel93a <kern.notice> kernel:XFS (sdb10): Unmounting Filesystem
Feb 26 19:11:40 rhel93a <daemon.info> systemd[1]:mnt-disk9.mount: Deactivated successfully.
Feb 26 19:11:40 rhel93a <daemon.info> Filesystem(filesystem10)[289173]:INFO: unmounted /mnt/disk9 successfully
Feb 26 19:11:40 rhel93a <daemon.notice> pacemaker-controld[281626]: notice: Result of stop operation for filesystem10 on rhel93a: ok
Feb 26 19:11:40 rhel93a <daemon.notice> pacemaker-controld[281626]: notice: Initiating stop operation filesystem9_stop_0 locally on rhel93a
Feb 26 19:11:40 rhel93a <daemon.notice> pacemaker-controld[281626]: notice: Requesting local execution of stop operation for filesystem9 on rhel93a

(snip)

Feb 26 19:12:01 rhel93a <daemon.notice> pacemaker-controld[281626]: notice: Initiating stop operation filesystem1_stop_0 locally on rhel93a
Feb 26 19:12:01 rhel93a <daemon.notice> pacemaker-controld[281626]: notice: Requesting local execution of stop operation for filesystem1 on rhel93a
Feb 26 19:12:01 rhel93a <daemon.info> Filesystem(filesystem1)[291881]:INFO: Running stop for /dev/sdb1 on /mnt/disk0
Feb 26 19:12:01 rhel93a <daemon.info> Filesystem(filesystem1)[291881]:INFO: Trying to unmount /mnt/disk0
Feb 26 19:12:02 rhel93a <daemon.info> Filesystem(filesystem1)[291881]:INFO: No processes on /mnt/disk0 were signalled. force_unmount is set to 'safe'
Feb 26 19:12:03 rhel93a <daemon.info> systemd[1]:mnt-disk0.mount: Deactivated successfully.
Feb 26 19:12:03 rhel93a <kern.notice> kernel:XFS (sdb1): Unmounting Filesystem
Feb 26 19:12:03 rhel93a <daemon.info> Filesystem(filesystem1)[291881]:INFO: unmounted /mnt/disk0 successfully
Feb 26 19:12:04 rhel93a <daemon.notice> pacemaker-controld[281626]: notice: Result of stop operation for filesystem1 on rhel93a: ok
```