### PR TITLE
Doc: Delay: Drop old comments

### DIFF
--- a/heartbeat/Delay
+++ b/heartbeat/Delay
@@ -4,22 +4,9 @@
 # Support:      users@clusterlabs.org
 # License:      GNU General Public License (GPL)
 #
-#	This script is a test resource for introducing delay.
+#	This script is a resource for introducing a delay.
 #
-#	usage: $0  {start|stop|status|monitor|meta-data}
-#
-#	  OCF parameters are as below:
-#		OCF_RESKEY_startdelay
-#		OCF_RESKEY_stopdelay
-#		OCF_RESKEY_mondelay
-#
-#	
-#		OCF_RESKEY_startdelay defaults to 20 (seconds)
-#		OCF_RESKEY_stopdelay defaults to $OCF_RESKEY_startdelay
-#		OCF_RESKEY_mondelay defaults to $OCF_RESKEY_startdelay
-#
-#
-#	This is really a test resource script.
+#	usage: $0 {start|stop|status|monitor|meta-data}
 #
 
 #######################################################################
@@ -54,7 +41,7 @@ meta_data() {
 <version>1.0</version>
 
 <longdesc lang="en">
-This script is a test resource for introducing delay.
+This script is a resource for introducing a delay.
 </longdesc>
 <shortdesc lang="en">Waits for a defined timespan</shortdesc>
 


### PR DESCRIPTION
`stopdelay` and `mondelay` do not default to `startdelay`. Should have been done with fe8a807d.

Also remove comments that are redundant with the metadata, and remove descriptions of this as a "test" resource. This has valid uses in some production environments.