### PR TITLE
portblock: remove write to tcp_tw_recycle

### DIFF
--- a/heartbeat/portblock
+++ b/heartbeat/portblock
@@ -328,7 +328,6 @@ save_tcp_connections()
 tickle_remote()
 {
 	[ -z "$OCF_RESKEY_tickle_dir" ] && return
-	echo 1 > /proc/sys/net/ipv4/tcp_tw_recycle
 	f=$OCF_RESKEY_tickle_dir/$OCF_RESKEY_ip
 	[ -r $f ] || return
 	$TICKLETCP -n 3 < $f


### PR DESCRIPTION
Currently, the portblock resource agent enables the net.ipv4.tcp_tw_recycle option before sending a tickle ACK packet.

This option is supposed to recycle TCP sockets that are left in the TIME_WAIT state. On the host that initiates the closing of a TCP connection, a socket will be left in this state for about 60 seconds before it finally gets removed (and freed up for further use). This is by design, and it is generally considered useful. [0]

The tcp_tw_recycle option is supposed to shorten the time that a socket spends in the TIME_WAIT state, allowing its slot to be reused more quickly.

Unfortunately, there are no hints left by the previous author about the rationale behind setting this option. One can only guess that they somehow managed to exhaust the number of TCP sockets during testing, and setting this option resolved that immediate issue. It is not entirely clear how this would happen in an actual real-world scenario, since it would require many switchovers in a relatively short period of time.

The problem is that this option has been completely broken starting from Linux 4.10 (since it started randomizing TCP timestamp offsets), and even before that for NAT connections.

Finally, the option has been completely removed in Linux 4.12, which now leads to annoying "No such file or directory" errors whenever the portblock agent runs on a semi-modern kernel.

Thus, remove the line enabling the option.

[0] https://vincent.bernat.ch/en/blog/2014-tcp-time-wait-state-linux