### PR TITLE
Fix: openstack-info: Ensure no newlines in openstack_ports

### DIFF
--- a/heartbeat/openstack-info.in
+++ b/heartbeat/openstack-info.in
@@ -164,10 +164,12 @@ OSInfoStats() {
 			--format json \
 			--column fixed_ips \
 			${port_id}")
-		subnet_id=$(echo "$subnet_result" |
+		subnet_ids=$(echo "$subnet_result" |
 			grep -P '\"subnet_id\": \".*\",$' |
 			grep -P -o '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}')
-		value="${value}${subnet_id}:${port_id},"
+		for subnet_id in $subnet_ids; do
+			value="${value}${subnet_id}:${port_id},"
+		done
 	done
 	value=${value%,}
 


### PR DESCRIPTION
This makes the `openstack_ports` variable match the format specified in the `openstack-info` metadata (see `longdesc`). It should be a comma-separated list of `"SUBNET_ID:PORT_ID"`. It should not be
```
SUBNET_A
SUBNET_B:PORT_1,SUBNET_C
SUBNET_D:PORT_2,
```

But rather
```
SUBNET_A:PORT1,SUBNET_B:PORT1,SUBNET_C:PORT2,SUBNET_D:PORT2
```

The newlines caused parsing issues in an experimental version of Pacemaker. Pacemaker is being fixed
(https://github.com/ClusterLabs/pacemaker/pull/3395), but this illustrated an issue in `openstack-info` that makes parsing rather precarious.

`openstack-virtual-ip` is capable of parsing either format without changes on a stable release of Pacemaker.

However, looking ahead, it should be updated to use `attrd_updater --output-as=xml` to query the attribute, as the XML output is much easier and more reliable to parse. (It should check the Pacemaker feature set to determine whether XML output is available for `attrd_updater.`)

---

@oalbrigt if you or someone in QE can sanity-check this in an OSP environment, that would be great, or it can wait until Fabio is back.

I tested this last week when Fabio's test environment was up. It worked fine, and as far as I know the code here is the same as what I tested.