### PR TITLE
nfsserver: fix "server scope" functionality for both potentially other dropins AND multiple ExecStart

### DIFF
--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -711,8 +711,17 @@ inject_unshare_uts_name_into_systemd_units ()
 		test -d "$dir" || mkdir -p "$dir"
 		test -e "$dropin" && rm -f "$dropin"
 
-		# NOTE: additional ExecStart= might exist in the drop-in files, eg. openSUSE
-		edited_exec_start=$(systemctl cat $svc | sed -ne "s#^ExecStart=\\([-+:!@]*\\)\\(.\+\\)#ExecStart=\\1/usr/bin/unshare --uts /bin/sh -c 'hostname \${NFS_SERVER_SCOPE}; exec \"\$@\"' -- \\2#p" | tail -1)
+		# NOTE: multiple ExecStart may exist,
+		# even additional `ExecStart=` to reset the list might exist in the drop-in files.
+		# We are interested in only the "currently relevant" set of ExecStart.
+		local unshare_uts_set_hostname='/usr/bin/unshare --uts /bin/sh -c '\''hostname ${NFS_SERVER_SCOPE}; exec "$@"'\'' -- '
+		edited_exec_start=$(systemctl cat $svc \
+			| sed -n \
+				-e '/^ExecStart=/ H;'				\
+				-e '/^ExecStart=[[:space:]]*$/ {s/.*//;h};'	\
+				-e '${g;s/^\n//;p}' \
+			| sed -e 's#^\(ExecStart=[-+:!@]*\)\(.\+\)#\1'"$unshare_uts_set_hostname"'\2#'
+		)
 
 		cat > "$dropin" <<___
 [Service]


### PR DESCRIPTION
986ebe18 (nfsserver: Fix NFSv4 lock failover: set NFS Server Scope (#1688), 2021-10-13)

Prefixes all `ExecStart=.*` with an unshare --uts. It did not expect an existing "empty, resetting" `ExecStart=`, though, and changed that as well.  The attempt to fix that with

806e3fe9 (nfsserver: fix "server scope" functionality to live with additional drop-in files, 2023-02-15)

it wrong though: it only fixes the _last_ ExecStart found (`|tail -1`). There may be more than one ExecStart (even though arguable some of them should be ExecStartPost).

Without the "only last line", it would be a valid fix, though it would unnecessarily list irrelevant ExecStart lines as well.

My attempt to fix the fix:
Find the set of `ExecStart=...` lines after the last reset (`ExecStart=`), if any. Edit in the "unshare uts" prefix into all of those lines.

(we could also patch only the line containing rpc.nfsd, but I'm sure some distro will find creative ways to break our assumptions again)