### PR TITLE
db2: fix OCF_SUCESS name in db2_notify

### DIFF
--- a/heartbeat/db2
+++ b/heartbeat/db2
@@ -848,7 +848,7 @@ db2_notify() {
 
     # only interested in pre-start
     [  $OCF_RESKEY_CRM_meta_notify_type = pre \
-    -a $OCF_RESKEY_CRM_meta_notify_operation = start ] || return $OCF_SUCESS
+    -a $OCF_RESKEY_CRM_meta_notify_operation = start ] || return $OCF_SUCCESS
 
     # gets FIRST_ACTIVE_LOG
     db2_get_cfg $dblist || return $?


### PR DESCRIPTION
fix OCF_SUCESS to OCF_SUCCESS  in db2_notify

db2_notify returns RC=1 due to misspelled variable name:
.
.
+ 10:08:48: db2_validate:221: return 0 
+ 10:08:49: main:899: db2_notify
+ 10:08:49: db2_notify:845: local node
+ 10:08:49: db2_notify:848: '[' pre = pre -a demote = start ']'
+ 10:08:49: db2_notify:849: return
+ 10:08:49: main:900: exit 1
