### PR TITLE
Filesystem: fix to avoid killing unrelated processes

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -664,7 +664,7 @@ get_pids()
 		if [ "X${HOSTOS}" = "XOpenBSD" ];then
 			fstat | grep $dir | awk '{print $3}'
 		else
-			$FUSER -m $dir 2>/dev/null
+			$FUSER -Mm $dir 2>/dev/null
 		fi
 	elif [ "$FORCE_UNMOUNT" = "safe" ]; then
 		procs=$(find /proc/[0-9]*/ -type l -lname "${dir}/*" -or -lname "${dir}" 2>/dev/null | awk -F/ '{print $3}')


### PR DESCRIPTION
Fixes #1944 by passing to the `fuser` command the argument to tell it to not fallback on other filesystems.