### PR TITLE
conntrackd/galera/rabbitmq-cluster: avoid deprecated tool options / ocf-shellfuncs: dont use deprecated validate-with="none" in CIB 

### DIFF
--- a/heartbeat/conntrackd.in
+++ b/heartbeat/conntrackd.in
@@ -109,7 +109,7 @@ conntrackd_is_master() {
 }
 
 conntrackd_set_master_score() {
-	${HA_SBIN_DIR}/crm_master -Q -l reboot -v $1
+	${HA_SBIN_DIR}/crm_master -q -l reboot -v $1
 }
 
 conntrackd_monitor() {

--- a/heartbeat/galera.in
+++ b/heartbeat/galera.in
@@ -447,7 +447,7 @@ is_two_node_mode_active()
     # crm_node or corosync-quorumtool cannot access various corosync
     # flags when running inside a bundle, so only count the cluster
     # members
-    ocf_is_true "$OCF_RESKEY_two_node_mode" && crm_mon_no_validation -1X | xmllint --xpath "count(//nodes/node[@type='member'])" - | grep -q -w 2
+    ocf_is_true "$OCF_RESKEY_two_node_mode" && crm_mon_no_validation -1 $XMLOPT | xmllint --xpath "count(//nodes/node[@type='member'])" - | grep -q -w 2
 }
 
 is_last_node_in_quorate_partition()
@@ -458,7 +458,7 @@ is_last_node_in_quorate_partition()
     # is clean), we shouldn't consider ourself quorate.
     local partition_members=$(${HA_SBIN_DIR}/crm_node -p | wc -w)
     local quorate=$(${HA_SBIN_DIR}/crm_node -q)
-    local clean_members=$(crm_mon_no_validation -1X | xmllint --xpath 'count(//nodes/node[@type="member" and @unclean="false"])' -)
+    local clean_members=$(crm_mon_no_validation -1 $XMLOPT | xmllint --xpath 'count(//nodes/node[@type="member" and @unclean="false"])' -)
 
     [ "$partition_members" = 1 ] && [ "$quorate" = 1 ] && [ "$clean_members" = 2 ]
 }
@@ -474,20 +474,6 @@ master_exists()
         return 1
     fi
     # determine if a master instance is already up and is healthy
-    ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.1.0"
-    res=$?
-    if [ -z "$OCF_RESKEY_crm_feature_set" ] || [ $res -eq 2 ]; then
-        XMLOPT="--output-as=xml"
-        ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.2.0"
-        if [ $? -eq 1 ]; then
-            crm_mon_no_validation -1 $XMLOPT >/dev/null 2>&1
-            if [ $? -ne 0 ]; then
-                XMLOPT="--as-xml"
-            fi
-        fi
-    else
-        XMLOPT="--as-xml"
-    fi
     crm_mon_no_validation -1 $XMLOPT | grep -q -i -E "resource.*id=\"${INSTANCE_ATTR_NAME}\".*role=\"(Promoted|Master)\".*active=\"true\".*orphaned=\"false\".*failed=\"false\""
     return $?
 }
@@ -1087,6 +1073,20 @@ if [ -n "${MYSQL_PORT}" ]; then
     MYSQL_OPTIONS_CHECK="$MYSQL_OPTIONS_CHECK -P ${MYSQL_PORT}"
 fi
 
+ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.1.0"
+res=$?
+if [ -z "$OCF_RESKEY_crm_feature_set" ] || [ $res -eq 2 ]; then
+    XMLOPT="--output-as=xml"
+    ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.2.0"
+    if [ $? -eq 1 ]; then
+        crm_mon_no_validation -1 $XMLOPT >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            XMLOPT="--as-xml"
+        fi
+    fi
+else
+    XMLOPT="--as-xml"
+fi
 
 
 # What kind of method was invoked?

--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -728,8 +728,14 @@ ocf_move_to_root_cgroup_if_rt_enabled()
 crm_mon_no_validation()
 {
 	# The subshell prevents parsing error with incompatible shells
-	"$SHELL" -c "CIB_file=<(${HA_SBIN_DIR}/cibadmin -Q | sed 's/validate-with=\"[^\"]*\"/validate-with=\"none\"/') \
-	${HA_SBIN_DIR}/crm_mon \$*" -- $*
+	ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.19.7"
+	if [ $res -eq 2 ] || [ $res -eq 1 ]; then
+		"$SHELL" -c "CIB_file=<(${HA_SBIN_DIR}/cibadmin -Q \
+			${HA_SBIN_DIR}/crm_mon \$*" -- $*
+	else
+		"$SHELL" -c "CIB_file=<(${HA_SBIN_DIR}/cibadmin -Q | sed 's/validate-with=\"[^\"]*\"/validate-with=\"none\"/') \
+			${HA_SBIN_DIR}/crm_mon \$*" -- $*
+	fi
 }
 
 #

--- a/heartbeat/rabbitmq-cluster.in
+++ b/heartbeat/rabbitmq-cluster.in
@@ -195,7 +195,7 @@ rmq_join_list()
 		# ...
 		local remote_join_list=$(cibadmin -Q --xpath "//node_state//nvpair[@name='$RMQ_CRM_ATTR_COOKIE']" | grep "$RMQ_CRM_ATTR_COOKIE" | sed -n -e "s/^.*value=.\(.*\)\".*$/\1/p")
 		# The following expression prepares a filter like '-e overcloud-rabbit-0 -e overcloud-rabbit-1 -e ...'
-		local filter=$(crm_mon_no_validation -r --as-xml | xmllint --format --xpath "//nodes//node[@online='true' and @standby='false']/@name" - | xargs -n1 echo | awk -F= '{print "-e "$2}')
+		local filter=$(crm_mon_no_validation -r $XMLOPT | xmllint --format --xpath "//nodes//node[@online='true' and @standby='false']/@name" - | xargs -n1 echo | awk -F= '{print "-e "$2}')
 		# export the intersection which gives us only the nodes that
 		# a) wrote their namein the cib attrd
 		# b) run on nodes where pacemaker_remote is enabled
@@ -609,6 +609,21 @@ rmq_validate() {
 
 	return $OCF_SUCCESS
 }
+
+ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.1.0"
+res=$?
+if [ -z "$OCF_RESKEY_crm_feature_set" ] || [ $res -eq 2 ]; then
+    XMLOPT="--output-as=xml"
+    ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.2.0"
+    if [ $? -eq 1 ]; then
+        crm_mon_no_validation -1 $XMLOPT >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            XMLOPT="--as-xml"
+        fi
+    fi
+else
+    XMLOPT="--as-xml"
+fi
 
 case $__OCF_ACTION in
 meta-data)	meta_data


### PR DESCRIPTION
Fixes https://github.com/ClusterLabs/resource-agents/issues/1077 and https://github.com/ClusterLabs/resource-agents/issues/1955