### PR TITLE
docker-compose: use "docker compose" when not using older docker-compose command

### DIFF
--- a/heartbeat/docker-compose
+++ b/heartbeat/docker-compose
@@ -113,7 +113,13 @@ exit $OCF_SUCCESS
 if [ -r "$OCF_RESKEY_binpath" -a -x "$OCF_RESKEY_binpath" ]; then
 	COMMAND="$OCF_RESKEY_binpath"
 else
+	OCF_RESKEY_binpath="$OCF_RESKEY_binpath_default"
 	COMMAND="$OCF_RESKEY_binpath_default"
+fi
+
+if ! $COMMAND -v 2>&1 | grep -q "^docker-compose version 1\."; then
+	OCF_RESKEY_binpath="${OCF_RESKEY_binpath%%-compose}"
+	COMMAND="$OCF_RESKEY_binpath compose"
 fi
 
 DIR="$OCF_RESKEY_dirpath"


### PR DESCRIPTION
Fixes https://github.com/ClusterLabs/resource-agents/issues/1974