### PR TITLE
storage_mon: remove unused macro variables

### DIFF
--- a/tools/storage_mon.c
+++ b/tools/storage_mon.c
@@ -33,9 +33,6 @@
 #define DEFAULT_PIDFILE HA_VARRUNDIR "storage_mon.pid"
 #define DEFAULT_ATTRNAME "#health-storage_mon"
 #define SMON_GET_RESULT_COMMAND "get_check_value"
-#define SMON_RESULT_OK "green"
-#define SMON_RESULT_NG "red"
-#define SMON_RESULT_COMMAND_ERROR "unknown command"
 #define SMON_BUFF_1MEG 1048576
 #define SMON_MAX_IPCSNAME 256
 #define SMON_MAX_MSGSIZE 128


### PR DESCRIPTION
Hi,

The following macro variables are defined in storage_mon.c, but it seems they’re unused. To simplify the code, how about removing them?

#define SMON_RESULT_OK "green"
#define SMON_RESULT_NG "red"
#define SMON_RESULT_COMMAND_ERROR "unknown command"

Regards,
