### PR TITLE
High: storage-mon: Fixed a bug in storage-mon's daemon mode that delayed the reflection of initial scores, and made it compliant with OCF specifications.

### DIFF
--- a/heartbeat/storage-mon.in
+++ b/heartbeat/storage-mon.in
@@ -325,6 +325,17 @@ storage-mon_start() {
 		if [ "$?" -ne 0 ]; then
 			return $OCF_ERR_GENERIC
 		fi
+
+		#Wait until monitor confirms the startup pid according to the ocf resource specification.	
+		while true; do
+			storage-mon_monitor pid_check_only
+			rc="$?"
+			if [ $rc -eq $OCF_SUCCESS ]; then
+				break
+			fi
+			sleep 1
+			ocf_log debug "storage-mon daemon still hasn't started yet. Waiting..."
+		done
 	fi
 }
 

--- a/tools/storage_mon.c
+++ b/tools/storage_mon.c
@@ -320,7 +320,14 @@ static int32_t sigchld_handler(int32_t sig, void *data)
 
 						finished_count++;
 						test_forks[index] = 0;
-					
+
+						/* Update the result value for the client response once all checks have completed. */
+						if (device_count == finished_count) { 
+							response_final_score = final_score;
+							if (!daemon_check_first_all_devices) {
+								daemon_check_first_all_devices = TRUE;
+							}
+						}
 					}
 				}
 			} else {
@@ -441,15 +448,7 @@ static int test_device_main(gpointer data)
 		if (is_child_runnning()) {
 			device_check = FALSE;
 		}
-		
-		if (device_count == finished_count && device_check) { 
-			/* Update the result value for the client response once all checks have completed. */
-			response_final_score = final_score;
 
-			if (!daemon_check_first_all_devices) {
-				daemon_check_first_all_devices = TRUE;
-			}
-		}
 	}
 
 	if (device_check) {


### PR DESCRIPTION
Hi All,

Because the score update is delayed when storage-mon is initially started, attribute updates are delayed until the first check_interval occurs.
Because of this bug, the start of a normal cluster configuration using storage-mon in daemon mode does not start until the check_interval.
This fix is ​​very important in order to resolve this issue.

The other fix is ​​to modify the start processing in daemon mode so that the monitor checks the startup of the daemon process in accordance with the OCF specifications.

Best Regards,
Hideo Yamauchi.