### PR TITLE
spec: fix sbin dependencies for ELN

### DIFF
--- a/resource-agents.spec.in
+++ b/resource-agents.spec.in
@@ -107,7 +107,7 @@ Requires: /sbin/fsck
 %endif
 Requires: /usr/sbin/fsck.ext2 /usr/sbin/fsck.ext3 /usr/sbin/fsck.ext4
 Requires: /usr/sbin/fsck.xfs
-%if 0%{?fedora} > 40 || 0%{?suse_version}
+%if 0%{?fedora} > 40 || 0%{?rhel} > 10 || 0%{?suse_version}
 Requires: /usr/sbin/mount.nfs /usr/sbin/mount.nfs4
 %else
 Requires: /sbin/mount.nfs /sbin/mount.nfs4
@@ -127,7 +127,7 @@ Requires: /sbin/ip
 Requires: /usr/sbin/lvm
 
 # nfsserver / netfs.sh
-%if 0%{?fedora} > 40 || 0%{?suse_version}
+%if 0%{?fedora} > 40 || 0%{?rhel} > 10 || 0%{?suse_version}
 Requires: /usr/sbin/rpc.statd
 %else
 Requires: /sbin/rpc.statd


### PR DESCRIPTION
Like in Fedora 41, ELN (the future RHEL 11) also defaults to dnf5 and therefore only can use /usr/bin and /usr/sbin file dependencies.

https://src.fedoraproject.org/rpms/resource-agents/pull-request/7
https://src.fedoraproject.org/rpms/resource-agents/pull-request/9