### PR TITLE
ocf-shellfuncs: fixed bash systax error added at a25f08

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -742,7 +742,7 @@ crm_mon_no_validation()
 	# The subshell prevents parsing error with incompatible shells
 	ocf_version_cmp "$OCF_RESKEY_crm_feature_set" "3.19.7"
 	if [ $res -eq 2 ] || [ $res -eq 1 ]; then
-		"$SHELL" -c "CIB_file=<(${HA_SBIN_DIR}/cibadmin -Q \
+		"$SHELL" -c "CIB_file=<(${HA_SBIN_DIR}/cibadmin -Q) \
 			${HA_SBIN_DIR}/crm_mon \$*" -- $*
 	else
 		"$SHELL" -c "CIB_file=<(${HA_SBIN_DIR}/cibadmin -Q | sed 's/validate-with=\"[^\"]*\"/validate-with=\"none\"/') \


### PR DESCRIPTION
ocf-shellfuncs: fixed bash systax error added at a25f08cf98d784894df9c52960eff5ccef059393