### PR TITLE
IPaddr2/IPsrcaddr: add "skip_more_than_one_route_matches_check" parameter

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -92,6 +92,7 @@ OCF_RESKEY_nodad_default=false
 OCF_RESKEY_noprefixroute_default="false"
 OCF_RESKEY_preferred_lft_default="forever"
 OCF_RESKEY_network_namespace_default=""
+OCF_RESKEY_skip_more_than_one_route_matches_check_default="false"
 
 : ${OCF_RESKEY_ip=${OCF_RESKEY_ip_default}}
 : ${OCF_RESKEY_cidr_netmask=${OCF_RESKEY_cidr_netmask_default}}
@@ -116,6 +117,7 @@ OCF_RESKEY_network_namespace_default=""
 : ${OCF_RESKEY_noprefixroute=${OCF_RESKEY_noprefixroute_default}}
 : ${OCF_RESKEY_preferred_lft=${OCF_RESKEY_preferred_lft_default}}
 : ${OCF_RESKEY_network_namespace=${OCF_RESKEY_network_namespace_default}}
+: ${OCF_RESKEY_skip_more_than_one_route_matches_check=${OCF_RESKEY_skip_more_than_one_route_matches_check_default}}
 
 #######################################################################
 
@@ -448,6 +450,16 @@ the namespace.
 </longdesc>
 <shortdesc lang="en">Network namespace to use</shortdesc>
 <content type="string" default="${OCF_RESKEY_network_namespace_default}"/>
+</parameter>
+
+<parameter name="skip_more_than_one_route_matches_check">
+<longdesc lang="en">
+Skip More than 1 route matches check.
+Might cause issues in some edge cases, and could result in unexpected changes
+in the routing table being ignored.
+</longdesc>
+<shortdesc lang="en">Skip "More than 1 routes match" check</shortdesc>
+<content type="string" default="${OCF_RESKEY_skip_more_than_one_route_matches_check_default}"/>
 </parameter>
 </parameters>
 

--- a/heartbeat/IPsrcaddr
+++ b/heartbeat/IPsrcaddr
@@ -62,6 +62,7 @@ OCF_RESKEY_proto_default=""
 OCF_RESKEY_metric_default=""
 OCF_RESKEY_pref_default=""
 OCF_RESKEY_table_default=""
+OCF_RESKEY_skip_more_than_one_route_matches_check_default="false"
 
 : ${OCF_RESKEY_ipaddress=${OCF_RESKEY_ipaddress_default}}
 : ${OCF_RESKEY_cidr_netmask=${OCF_RESKEY_cidr_netmask_default}}
@@ -70,6 +71,7 @@ OCF_RESKEY_table_default=""
 : ${OCF_RESKEY_metric=${OCF_RESKEY_metric_default}}
 : ${OCF_RESKEY_pref=${OCF_RESKEY_pref_default}}
 : ${OCF_RESKEY_table=${OCF_RESKEY_table_default}}
+: ${OCF_RESKEY_skip_more_than_one_route_matches_check=${OCF_RESKEY_skip_more_than_one_route_matches_check_default}}
 #######################################################################
 
 [ -z "$OCF_RESKEY_proto" ] && PROTO="" || PROTO="proto $OCF_RESKEY_proto"
@@ -176,6 +178,16 @@ This can be used for policy based routing. See man ip-rule(8).
 </longdesc>
 <shortdesc lang="en">Table</shortdesc>
 <content type="string" default="${OCF_RESKEY_table_default}" />
+</parameter>
+
+<parameter name="skip_more_than_one_route_matches_check">
+<longdesc lang="en">
+Skip More than 1 route matches check.
+Might cause issues in some edge cases, and could result in unexpected changes
+in the routing table being ignored.
+</longdesc>
+<shortdesc lang="en">Skip "More than 1 routes match" check</shortdesc>
+<content type="string" default="${OCF_RESKEY_skip_more_than_one_route_matches_check_default}"/>
 </parameter>
 
 </parameters>

--- a/heartbeat/findif.sh
+++ b/heartbeat/findif.sh
@@ -225,7 +225,7 @@ findif()
     routematch=$(echo "$routematch" | grep -v "^default")
   fi
 
-  if [ $(echo "$routematch" | wc -l) -gt 1 ]; then
+  if ! ocf_is_true "$OCF_RESKEY_skip_more_than_one_route_matches_check" && [ $(echo "$routematch" | wc -l) -gt 1 ]; then
     ocf_exit_reason "More than 1 routes match $match. Unable to decide which route to use."
     return $OCF_ERR_GENERIC
   fi


### PR DESCRIPTION
Fixes https://github.com/ClusterLabs/resource-agents/issues/2001.