### PR TITLE
Filesystem: dont report warnings when creating a Filesystem resource

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -1145,7 +1145,7 @@ check_binary $FSCK
 check_binary $MOUNT
 check_binary $UMOUNT
 
-if [ "$OP" != "monitor" ]; then
+if [ "$OP" != "monitor" ] && [ "$OP" != "validate-all" ]; then
 	ocf_log info "Running $OP for $DEVICE on $MOUNTPOINT"
 fi
 


### PR DESCRIPTION
Hi!

On RHEL 10.0 beta with pcs 0.12.0+47-1ba3f.
I received the following warning messages when trying to create a Filesystem resource.

```
[root@rh10-b03 ~]# pcs -f filesystem_resources.xml resource create filesystem1 ocf:heartbeat:Filesystem \
    device="/dev/vdb2" directory="/dbfp/pgdata" fstype="xfs" fast_stop="yes" force_unmount="safe" \
    op start timeout=60s on-fail=restart \
       monitor timeout=60s interval=10s on-fail=restart OCF_CHECK_LEVEL=0 \
       stop timeout=60s on-fail=fence
Warning: Validating resource options using the resource agent itself is enabled by default and produces warnings. In a future version, this might be changed to errors. Specify --agent-validation to switch to the future behavior.
Warning: Validation result from agent:
  Jan 23 11:19:48 INFO: Running validate-all for /dev/vdb2 on /dbfp/pgdata
```

So, I tried to suppress the INFO message to avoid the warnings.
This is a simple attempt to address the issue.
Suggestions for better approaches are always welcome.

Regards,
Satomi OSAWA
