### PR TITLE
storage-mon: log "storage_mon is already running" in start-action

### DIFF
--- a/heartbeat/storage-mon.in
+++ b/heartbeat/storage-mon.in
@@ -313,6 +313,7 @@ storage_mon_start() {
 	else
 		storage_mon_monitor pid_check_only
 		if [ $? -eq $OCF_SUCCESS ]; then
+			ocf_log info "storage_mon is already running. PID=`cat $PIDFILE`"
 			return $OCF_SUCCESS
 		fi
 		storage_mon_init


### PR DESCRIPTION
As suggested by @HideoYamauchi in https://github.com/ClusterLabs/resource-agents/pull/2017.