### PR TITLE
portblock: fix iptables version detection

### DIFF
--- a/heartbeat/portblock
+++ b/heartbeat/portblock
@@ -618,7 +618,7 @@ if [ -z "$OCF_RESKEY_action" ]; then
 fi 
 
 # iptables v1.4.20+ is required to use -w (wait)
-version=$(iptables -V | awk -F ' v' '{print $NF}')
+version=$(iptables -V | grep -oE '[0-9]+(\.[0-9]+)+')
 ocf_version_cmp "$version" "1.4.19.1"
 if [ "$?" -eq "2" ]; then
     wait="-w"

--- a/heartbeat/portblock
+++ b/heartbeat/portblock
@@ -618,7 +618,7 @@ if [ -z "$OCF_RESKEY_action" ]; then
 fi 
 
 # iptables v1.4.20+ is required to use -w (wait)
-version=$(iptables -V | grep -oE '[0-9]+(\.[0-9]+)+')
+version=$(iptables -V | grep -oE '[0-9]+[\.0-9]+')
 ocf_version_cmp "$version" "1.4.19.1"
 if [ "$?" -eq "2" ]; then
     wait="-w"


### PR DESCRIPTION
With current versions of iptables there are suffixes (nf_tables) or (legacy) after the version string printed by iptables -V

The awk script does not remove those suffixes after the version string. ocf_version_cmp fails to compare this string. wait option will never be added if (nf_tables) or (legacy) is present after vX.Y.Z

In my lab ports listed in block/unblock primitives were never unblocked when a group was stated to be successfully started. DROP entries are accumulating with every restart.

With the corrected version detection this was fixed and worked as expected.