### PR TITLE
IPaddr2: add support for network interfaces altname in the monitor operation

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -635,8 +635,9 @@ find_interface() {
 		| grep " $ipaddr/$netmask" \
 		| cut -d ' ' -f2 \
 		| grep -v '^ipsec[0-9][0-9]*$'`"
+        local iface_altname="`$IP2UTIL -f inet link show dev $iface | grep "altname" | sed 's/^[[:space:]]*//; s/altname //g' | tr '\n' ' '`"
 
-	echo "$iface"
+	echo "$iface $iface_altname"
 	return 0
 }
 


### PR DESCRIPTION
Currently, it's not possible to use an interface's `altname` by specifying it in the `nic=` proprerty because the `monitor` routine fails to recognize that the IP is configured on the proper interface.

This patch fixes that by returning all the `altname` properties of an interface alongside its main name.