### PR TITLE
azure-events-az: remove unused attr_globalPullState variable

### DIFF
--- a/heartbeat/azure-events-az.in
+++ b/heartbeat/azure-events-az.in
@@ -120,10 +120,6 @@ class azHelper:
 				successful = 1
 				break
 
-		# When no request was successful also with retry enabled, set the cluster to idle
-		if successful is None:
-			clusterHelper.setAttr(attr_globalPullState, "IDLE")
-
 		if data:
 			data = json.loads(data)
 

--- a/heartbeat/azure-events-az.in
+++ b/heartbeat/azure-events-az.in
@@ -30,7 +30,6 @@ import ocf
 VERSION = "0.20"
 USER_AGENT = "Pacemaker-ResourceAgent/%s %s" % (VERSION, ocf.distro())
 
-attr_globalPullState = "azure-events-az_globalPullState"
 attr_lastDocVersion  = "azure-events-az_lastDocVersion"
 attr_curNodeState = "azure-events-az_curNodeState"
 attr_pendingEventIDs = "azure-events-az_pendingEventIDs"


### PR DESCRIPTION
Rewrite of RA does not use this obsolete attribute any more.  Removing unnecessary setAttr action.