### PR TITLE
azure-events-az: use attr_healthstate variable in crm_attribute call in putNodeOnline()

### DIFF
--- a/heartbeat/azure-events-az.in
+++ b/heartbeat/azure-events-az.in
@@ -571,7 +571,7 @@ class Node:
 
 		clusterHelper._exec("crm_attribute",
 							"--node", node,
-							"--name", "#health-azure",
+							"--name", attr_healthstate,
 							"--update", "0",
 							"--lifetime=forever")
 


### PR DESCRIPTION
Change putNodeOnline block to use value in previously defined attr_healthstate variable instead of "#health-azure" string literal, making it consistent with the earlier putNodeStandby block