### PR TITLE
azure-events-az: Remove # from start of attr_healthstate attribute name

### DIFF
--- a/heartbeat/azure-events-az.in
+++ b/heartbeat/azure-events-az.in
@@ -33,7 +33,7 @@ USER_AGENT = "Pacemaker-ResourceAgent/%s %s" % (VERSION, ocf.distro())
 attr_lastDocVersion  = "azure-events-az_lastDocVersion"
 attr_curNodeState = "azure-events-az_curNodeState"
 attr_pendingEventIDs = "azure-events-az_pendingEventIDs"
-attr_healthstate = "#health-azure"
+attr_healthstate = "health-azure"
 
 default_loglevel = ocf.logging.INFO
 default_relevantEventTypes = set(["Reboot", "Redeploy"])

--- a/heartbeat/azure-events-az.in
+++ b/heartbeat/azure-events-az.in
@@ -27,7 +27,7 @@ import ocf
 ##############################################################################
 
 
-VERSION = "0.20"
+VERSION = "0.21"
 USER_AGENT = "Pacemaker-ResourceAgent/%s %s" % (VERSION, ocf.distro())
 
 attr_lastDocVersion  = "azure-events-az_lastDocVersion"


### PR DESCRIPTION
Fix to improve visibility of azure health and increment version number.  See commit 2d52958 for more details.