### PR TITLE
azure-events-az: Update wording in log line

### DIFF
--- a/heartbeat/azure-events-az.in
+++ b/heartbeat/azure-events-az.in
@@ -724,7 +724,7 @@ class raAzEvents:
 					azHelper.forceEvents(eventIDsToForce)
 					self.node.setAttr(attr_lastDocVersion, curDocVersion)
 			else:
-				ocf.logger.info("monitor: some local resources are not clean yet -> wait")
+				ocf.logger.info("monitor: some local resources are not stopped yet -> wait")
 
 		ocf.logger.debug("monitor: finished")
 		return ocf.OCF_SUCCESS


### PR DESCRIPTION
Update log line to improve semantic accuracy.  The word "clean" is used incorrectly to describe whether all resources have been "stopped" on the node.