### PR TITLE
mariadb: add SSL/TLS-Support

### DIFF
--- a/heartbeat/mariadb.in
+++ b/heartbeat/mariadb.in
@@ -247,6 +247,39 @@ The port on which the Promoted MariaDB instance is listening.
 <content type="string" default="${OCF_RESKEY_replication_port_default}" />
 </parameter>
 
+<parameter name="replication_require_ssl" unique="0" required="0">
+<longdesc lang="en">
+Enables SSL connection to local MySQL service for replication user.
+i.e. if REQUIRE SSL for replication user in MySQL set, this should be set to "true".
+</longdesc>
+<shortdesc lang="en">MySQL replication require ssl</shortdesc>
+<content type="string" default="${OCF_RESKEY_replication_require_ssl_default}" />
+</parameter>
+
+<parameter name="replication_master_ssl_ca" unique="0" required="0">
+<longdesc lang="en">
+The SSL CA certificate to be used for replication over SSL.
+</longdesc>
+<shortdesc lang="en">MySQL replication SSL CA certificate</shortdesc>
+<content type="string" default="${OCF_RESKEY_replication_master_ssl_ca_default}" />
+</parameter>
+
+<parameter name="replication_master_ssl_cert" unique="0" required="0">
+<longdesc lang="en">
+The SSL CA certificate to be used for replication over SSL.
+</longdesc>
+<shortdesc lang="en">MySQL replication SSL certificate</shortdesc>
+<content type="string" default="${OCF_RESKEY_replication_master_ssl_cert_default}" />
+</parameter>
+
+<parameter name="replication_master_ssl_key" unique="0" required="0">
+<longdesc lang="en">
+The SSL certificate key to be used for replication over SSL.
+</longdesc>
+<shortdesc lang="en">MySQL replication SSL certificate key</shortdesc>
+<content type="string" default="${OCF_RESKEY_replication_master_ssl_key_default}" />
+</parameter>
+
 </parameters>
 
 <actions>
@@ -255,6 +288,7 @@ The port on which the Promoted MariaDB instance is listening.
 <action name="status" timeout="60s" />
 <action name="monitor" depth="0" timeout="30s" interval="20s" />
 <action name="monitor" role="Promoted" depth="0" timeout="30s" interval="10s" />
+<action name="monitor" role="Unpromoted" depth="0" timeout="30s" interval="30s" />
 <action name="promote" timeout="120s" />
 <action name="demote" timeout="120s" />
 <action name="notify" timeout="90s" />
@@ -600,6 +634,7 @@ check_slave() {
 
 set_master() {
     local new_master=$($CRM_ATTR_REPL_INFO --query  -q)
+    local master_ssl_params
 
     # Informs the MariaDB server of the master to replicate
     # from. Accepts one mandatory argument which must contain the host
@@ -607,12 +642,20 @@ set_master() {
     # from the laste master the slave replicated from, or freshly
     # reset with RESET MASTER.
     ocf_log info "Changing MariaDB configuration to replicate from $new_master."
+    if [ -n "$OCF_RESKEY_replication_master_ssl_ca" ] && [ -n "$OCF_RESKEY_replication_master_ssl_cert" ] && [ -n "$OCF_RESKEY_replication_master_ssl_key" ]; then
+        master_ssl_params="MASTER_SSL=1, \
+                MASTER_SSL_CA='$OCF_RESKEY_replication_master_ssl_ca', \
+                MASTER_SSL_CERT='$OCF_RESKEY_replication_master_ssl_cert', \
+                MASTER_SSL_KEY='$OCF_RESKEY_replication_master_ssl_key', "
+    fi
+
 
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
         -e "CHANGE MASTER TO MASTER_HOST='$new_master', \
         MASTER_PORT=$OCF_RESKEY_replication_port, \
         MASTER_USER='$OCF_RESKEY_replication_user', \
         MASTER_PASSWORD='$OCF_RESKEY_replication_passwd', \
+        $master_ssl_params \
         MASTER_USE_GTID=current_pos";
 }
 

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -97,7 +97,14 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 
 MYSQL=$OCF_RESKEY_client_binary
 if ocf_is_true "$OCF_RESKEY_replication_require_ssl"; then
-  MYSQL_OPTIONS_LOCAL_SSL_OPTIONS="--ssl-mode=REQUIRED"
+  if [ "${OCF_RESOURCE_TYPE}" = "mariadb" ] ; then
+    MYSQL_OPTIONS_LOCAL_SSL_OPTIONS="--ssl"
+    if [ -n "${$OCF_RESKEY_replication_master_ssl_ca}" ] ; then
+        MYSQL_OPTIONS_LOCAL_SSL_OPTIONS="${MYSQL_OPTIONS_LOCAL_SSL_OPTIONS} --ssl-ca=${$OCF_RESKEY_replication_master_ssl_ca}"
+    fi
+  else
+    MYSQL_OPTIONS_LOCAL_SSL_OPTIONS="--ssl-mode=REQUIRED"
+  fi
 else
   MYSQL_OPTIONS_LOCAL_SSL_OPTIONS=""
 fi

--- a/heartbeat/mysql-common.sh
+++ b/heartbeat/mysql-common.sh
@@ -99,8 +99,8 @@ MYSQL=$OCF_RESKEY_client_binary
 if ocf_is_true "$OCF_RESKEY_replication_require_ssl"; then
   if [ "${OCF_RESOURCE_TYPE}" = "mariadb" ] ; then
     MYSQL_OPTIONS_LOCAL_SSL_OPTIONS="--ssl"
-    if [ -n "${$OCF_RESKEY_replication_master_ssl_ca}" ] ; then
-        MYSQL_OPTIONS_LOCAL_SSL_OPTIONS="${MYSQL_OPTIONS_LOCAL_SSL_OPTIONS} --ssl-ca=${$OCF_RESKEY_replication_master_ssl_ca}"
+    if [ -n "${OCF_RESKEY_replication_master_ssl_ca}" ] ; then
+        MYSQL_OPTIONS_LOCAL_SSL_OPTIONS="${MYSQL_OPTIONS_LOCAL_SSL_OPTIONS} --ssl-ca=${OCF_RESKEY_replication_master_ssl_ca}"
     fi
   else
     MYSQL_OPTIONS_LOCAL_SSL_OPTIONS="--ssl-mode=REQUIRED"


### PR DESCRIPTION
Needed SSL-Support for a new mariadb-HA-Cluster. Adopted the needed Parameters from mysql RA to keep migration between those too as easy as possible.