### PR TITLE
ocf-shellfuncs: set SHELL to default shell if it's set to nologin

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -65,6 +65,8 @@ fi
 # to make sure that ocf_is_probe() always works
 : ${OCF_RESKEY_CRM_meta_interval=0}
 
+[ "${SHELL##*/}" = "nologin" ] && SHELL="$SH"
+
 ocf_is_root() {
 	if [ X`id -u` = X0 ]; then
 		true


### PR DESCRIPTION
Fixes https://github.com/ClusterLabs/resource-agents/issues/2053.