### PR TITLE
ocf-shellfuncs: remove extra sleep from curl_retry

### DIFF
--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -708,7 +708,9 @@ curl_retry()
 			[ $? -ne 0 ] && exit $OCF_ERR_GENERIC
 			args=$(echo "$args" | sed "s/$OLD_TOKEN/$TOKEN/")
 		fi
-		sleep $sleep
+		if [ $try -lt $tries ]; then  
+			sleep $sleep
+   		fi
 	done
 
 	if [ $rc -ne 0 ]; then


### PR DESCRIPTION
With the [current defaults](https://github.com/ClusterLabs/resource-agents/blob/main/heartbeat/aws.sh#L12C1-L13C34) of:
```
OCF_RESKEY_curl_retries_default="4"
OCF_RESKEY_curl_sleep_default="3"
```
one would expect a total failure to take about 12 seconds, but with the function as written, there is an extra sleep after the last retry. 
When debugging with defaults, I see this in the logs: `(execution time 15.119s)`.

This is a simple PR that skips the sleep  after the last retry, which results in a more predictable overall sleep time in my tests: `(execution time 12.127s)`