### PR TITLE
Fix shellcheck errors on output redirection [SC2328]

### DIFF
--- a/heartbeat/ZFS
+++ b/heartbeat/ZFS
@@ -87,10 +87,11 @@ zpool_is_imported () {
 	if [ -d  /proc/spl/kstat/zfs/ ] ; then
 		# Check the existence of kstats for the pool. If the stats exists, the pool was imported.
 		[ -d  /proc/spl/kstat/zfs/"${OCF_RESKEY_pool}" ]
-		rc=$? 
+		rc=$?
 	else
 		# If ZFS kstats do not exists, fallback to the standard check
-		rc=$(zpool list -H "$OCF_RESKEY_pool" > /dev/null)
+		zpool list -H "$OCF_RESKEY_pool" > /dev/null
+		rc=$?
 	fi
 	return $rc
 }

--- a/heartbeat/iface-bridge
+++ b/heartbeat/iface-bridge
@@ -678,7 +678,7 @@ bridge_start() {
 		mcrouter=0
 	fi
 	if [ -e "/sys/class/net/$OCF_RESKEY_bridge_name/bridge/multicast_router" ]; then
-		error="$(echo $mcrouter > /sys/class/net/$OCF_RESKEY_bridge_name/bridge/multicast_router 2>&1)"
+		error="$(echo $mcrouter 2>&1 >/sys/class/net/$OCF_RESKEY_bridge_name/bridge/multicast_router)"
 		if [ "$?" != "0" ]; then
 			ocf_log err "Unable to set OCF_RESKEY_multicast_router for bridge $OCF_RESKEY_bridge_name: $error"
 			return $OCF_ERR_GENERIC
@@ -694,7 +694,7 @@ bridge_start() {
 		mcsnooping=0
 	fi
 	if [ -e "/sys/class/net/$OCF_RESKEY_bridge_name/bridge/multicast_snooping" ]; then
-		error="$(echo $mcsnooping > /sys/class/net/$OCF_RESKEY_bridge_name/bridge/multicast_snooping 2>&1)"
+		error="$(echo $mcsnooping 2>&1 >/sys/class/net/$OCF_RESKEY_bridge_name/bridge/multicast_snooping)"
 		if [ "$?" != "0" ]; then
 			ocf_log err "Unable to set OCF_RESKEY_multicast_snooping for bridge $OCF_RESKEY_bridge_name: $error"
 			return $OCF_ERR_GENERIC
@@ -710,7 +710,7 @@ bridge_start() {
 		mcquerier=0
 	fi
 	if [ -e "/sys/class/net/$OCF_RESKEY_bridge_name/bridge/multicast_querier" ]; then
-		error="$(echo $mcquerier > /sys/class/net/$OCF_RESKEY_bridge_name/bridge/multicast_querier 2>&1)"
+		error="$(echo $mcquerier 2>&1 >/sys/class/net/$OCF_RESKEY_bridge_name/bridge/multicast_querier)"
 		if [ "$?" != "0" ]; then
 			ocf_log err "Unable to set OCF_RESKEY_multicast_querier for bridge $OCF_RESKEY_bridge_name: $error"
 			return $OCF_ERR_GENERIC
@@ -723,7 +723,7 @@ bridge_start() {
 	if [ -n "$OCF_RESKEY_multicast_port_router" ]; then
 		split_string $OCF_RESKEY_multicast_port_router | { while read iface mcport; do
 			if [ -e "/sys/class/net/$iface/brport/multicast_router" ]; then
-				error="$(echo $mcport > /sys/class/net/$iface/brport/multicast_router 2>&1)"
+				error="$(echo $mcport 2>&1 >/sys/class/net/$iface/brport/multicast_router)"
 				if [ "$?" != "0" ]; then
 					ocf_log err "Unable to set OCF_RESKEY_multicast_port_router $mcport for interface $iface on bridge $OCF_RESKEY_bridge_name : $error"
 					return $OCF_ERR_GENERIC

--- a/heartbeat/jira.in
+++ b/heartbeat/jira.in
@@ -75,7 +75,7 @@ jira_start() {
     waittime=300
     su -m $jira_user -c "$jira_installation/bin/startup.sh &> /dev/null"
     while [[ $waittime -gt 0 ]]; do
-      if $(curl --connect-timeout 1 --max-time 3 -s ${statusurl} | grep '{"state":"RUNNING"}' > /dev/null); then
+      if curl --connect-timeout 1 --max-time 3 -s ${statusurl} | grep '{"state":"RUNNING"}' > /dev/null; then
         waittime=0
       else
         sleep 1
@@ -146,7 +146,7 @@ jira_monitor() {
 
     if $(kill -0 $(cat ${jira_installation}/work/catalina.pid 2> /dev/null) 2> /dev/null) ; then
       # Is jira working
-      if $(curl --connect-timeout 1 --max-time 3 -s ${statusurl} | grep '{"state":"RUNNING"}' > /dev/null) ; then
+      if curl --connect-timeout 1 --max-time 3 -s ${statusurl} | grep '{"state":"RUNNING"}' > /dev/null; then
         rc=0
       else
         # Jira has a problem

--- a/heartbeat/kamailio.in
+++ b/heartbeat/kamailio.in
@@ -477,20 +477,20 @@ kamailio_status() {
 
     errorfile=`mktemp`
     case ${OCF_RESKEY_proto} in
-    udp)  output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport udp>/dev/null 2>>$errorfile`
+    udp)  output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport udp 2>>$errorfile`
           result=$?
           ;;
-    tcp)  output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport tcp>/dev/null 2>>$errorfile`
+    tcp)  output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport tcp 2>>$errorfile`
           result=$?
           ;;
-    udptcp) output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport tcp>/dev/null 2>>$errorfile`
+    udptcp) output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport tcp 2>>$errorfile`
             result=$?
             if [ $result -eq 0 ]; then
-                output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport udp>/dev/null 2>>$errorfile`
+                output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport udp 2>>$errorfile`
                 result=$?
             fi
             ;;
-    *)  output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport udp>/dev/null 2>>$errorfile`
+    *)  output=`$OCF_RESKEY_sipsak -s sip:monitor@$OCF_RESKEY_monitoring_ip:${OCF_RESKEY_port} -H localhost --transport udp 2>>$errorfile`
         result=$?
         ;;
     esac

--- a/heartbeat/minio
+++ b/heartbeat/minio
@@ -123,7 +123,7 @@ minio_status()
         # Minio is probably running
                 PID=`head -n 1 $OCF_RESKEY_pidfile`
                 if [ ! -z "$PID" ] ; then
-                        isRunning "$PID" && `ps -p $PID | grep minio-server > /dev/null 2>&1`
+                        isRunning "$PID" && ps -p $PID | grep minio-server > /dev/null 2>&1
                         return $?
                 fi
         fi

--- a/heartbeat/proftpd
+++ b/heartbeat/proftpd
@@ -142,7 +142,7 @@ proftpd_status()
 	# Proftpd is probably running
 		PID=`head -n 1 $OCF_RESKEY_pidfile`
 		if [ ! -z "$PID" ] ; then
-			isRunning "$PID" && `ps -p $PID | grep proftpd > /dev/null 2>&1`
+			isRunning "$PID" && ps -p $PID | grep proftpd > /dev/null 2>&1
 			return $?
 		fi
 	fi

--- a/heartbeat/smb-share.in
+++ b/heartbeat/smb-share.in
@@ -433,7 +433,7 @@ smb_share_stop() {
 }
 
 smb_share_monitor() {
-        RES=$(smbcontrol smbd ping > /dev/null 2>&1)
+        smbcontrol smbd ping > /dev/null 2>&1
         if [ $? -eq 0 ];then
             if [ $(testparm -s 2>/dev/null| $EGREP -c \\[$OCF_RESKEY_share\\]) -eq 1 ];then
                 return $OCF_SUCCESS
@@ -447,7 +447,7 @@ smb_share_monitor() {
 
 smb_share_state() {
         smb_share_checktmpmount
-        RES=$(smbcontrol smbd ping > /dev/null 2>&1)
+        smbcontrol smbd ping > /dev/null 2>&1
         if [ $? -eq 0 ];then
             if [ $(testparm -s 2>/dev/null| $EGREP -c \\[$OCF_RESKEY_share\\]) -eq 1 ];then
                 ocf_log info "Samba share $OCF_RESKEY_share is active"


### PR DESCRIPTION
shellcheck v0.11.0 reports the following new errors that cause tests to fail:

```
heartbeat/smb-share:436:36: error: This redirection takes output away from the command substitution. [SC2328]
heartbeat/smb-share:450:36: error: This redirection takes output away from the command substitution. [SC2328]
heartbeat/jira:78:95: error: This redirection takes output away from the command substitution. [SC2328]
heartbeat/jira:149:95: error: This redirection takes output away from the command substitution. [SC2328]
heartbeat/proftpd:145:51: error: This redirection takes output away from the command substitution. [SC2328]
heartbeat/minio:126:77: error: This redirection takes output away from the command substitution. [SC2328]
heartbeat/iface-bridge:681:27: error: This redirection takes output away from the command substitution (use tee to duplicate). [SC2328]
heartbeat/iface-bridge:697:29: error: This redirection takes output away from the command substitution (use tee to duplicate). [SC2328]
heartbeat/iface-bridge:713:28: error: This redirection takes output away from the command substitution (use tee to duplicate). [SC2328]
heartbeat/iface-bridge:726:27: error: This redirection takes output away from the command substitution (use tee to duplicate). [SC2328]
heartbeat/kamailio:480:126: error: This redirection takes output away from the command substitution. [SC2328]
heartbeat/kamailio:483:126: error: This redirection takes output away from the command substitution. [SC2328]
heartbeat/kamailio:486:128: error: This redirection takes output away from the command substitution. [SC2328]
heartbeat/kamailio:489:132: error: This redirection takes output away from the command substitution. [SC2328]
heartbeat/kamailio:493:124: error: This redirection takes output away from the command substitution. [SC2328]
heartbeat/ZFS:93:41: error: This redirection takes output away from the command substitution. [SC2328]
```