### PR TITLE
pgsql: Fixed an issue where tmpdir was not created when rep_mode was set to slave.

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1990,6 +1990,16 @@ validate_ocf_check_level_10() {
         fi
     fi
 
+    # For slave mode in PostgreSQL 12 and later, create the tmp directory to place recovery.conf.
+    ocf_version_cmp "$version" "12"
+    rc=$?
+    if [ $rc -eq 1 ]||[ $rc -eq 2 ]; then  # PosrgreSQL 12 or later.
+        if ! mkdir -p $OCF_RESKEY_tmpdir || ! chown $OCF_RESKEY_pgdba $OCF_RESKEY_tmpdir || ! chmod 700 $OCF_RESKEY_tmpdir; then
+            ocf_exit_reason "Can't create directory $OCF_RESKEY_tmpdir or it is not readable by $OCF_RESKEY_pgdba"
+            return $OCF_ERR_PERM
+        fi
+    fi
+
     if use_replication_slot; then
         ocf_version_cmp "$version" "9.4"
         rc=$?


### PR DESCRIPTION
## Problem Details  
When starting a pgsql resource with rep_mode="slave", the following error occurred, causing the start operation to fail.  
The error message is as follows:  

```
Failed Resource Actions:
  * remote-site-pgsql_start_0 on dr-standby1 'error' (1): call=34, status='complete', exitreason='Can't create recovery.conf.', last-rc-change='Thu Sep  4 11:59:06 2025', queued=0ms, exec=309ms
```

## Environment  
* PostgreSQL 17  
* Resource setting: rep_mode="slave"  

## Solution  
In the current code, the tmp directory is not created when rep_mode="slave".  
The existing code creates the tmp directory only if the result of is_replication() is true within the validate_ocf_check_level_10 function.  
To resolve this issue, I modified the validate_ocf_check_level_10 function to create the tmp directory even when rep_mode="slave" is set.