### PR TITLE
IPaddr2: add support to kill dangling IP connections 

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -696,7 +696,7 @@ kill_ip_connections() {
 		ocf_log error "$ss_output"
 	else
 		ocf_log info "$ss_output"
-        fi
+	fi
 
 	return $OCF_SUCCESS
 }


### PR DESCRIPTION
I have seen some cases where when you delete an ip address while there are stablished connections, the connections stay dangled.
This patch try to avoid that cases.
First it kills connections before deleting the ip address to inform the clients, and after deleting the ip address to kill connections that can initiated between first kill and ip deletion.

Other approach could be to kill connections in fuction "delete_interface", before "addr delete"

To be able to use "ss -K", you need a kernel with config option CONFIG_INET_DIAG_DESTROY set.