### PR TITLE
Filesystem: speed up get pids

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -694,19 +694,26 @@ get_pids()
 		#
 		# Or trust that fuser (above) learned something in the last 15 years
 		# and avoids blocking operations meanwhile?
-		procs=$(exec 2>/dev/null;
-			find /proc -mindepth 1 -maxdepth 3 \
-				-path "/proc/[0-9]*" \
-				-type l \( -lname "${dir}/*" -o -lname "${dir}" \) -print |
-			awk -F/ '{print $3}' | uniq)
+		(
+		# If you want to debug this, drop this redirection.
+		# But it producess too much "No such file" noise for kernel
+		# threads or due to races with exiting processes or closing fds.
+		exec 2>/dev/null;
+		find /proc -mindepth 1 -maxdepth 3 \
+			-path "/proc/[0-9]*" \
+			-type l \( -lname "${dir}/*" -o -lname "${dir}" \) -print |
+		awk -F/ '{print $3}' | uniq
 
-		# memory mappings are also per process, not per task.
-		# This finds only /proc/<pid>/maps, and not /proc/<pid>/task/<tid>/maps;
-		# if you also want the latter, drop -maxdepth.
-		mmap_procs=$(exec 2>/dev/null;
+		# If we have "map_files/", "find" above already found the
+		# relevant symlinks, and we don't need to grep "maps" below.
+		# Available since kernel 3.3, respectively 4.3.
+		test -d /proc/$$/map_files ||
+			# memory mappings are also per process, not per task.
+			# This finds only /proc/<pid>/maps, and not /proc/<pid>/task/<tid>/maps;
+			# if you also want the latter, drop -maxdepth.
 			find /proc -mindepth 2 -maxdepth 2 -path "/proc/[0-9]*/maps" -print |
-			xargs -r grep -l " ${dir}/" | awk -F/ '{print $3}' | uniq)
-		printf "${procs}\n${mmap_procs}" | sort -u
+			xargs -r grep -l " ${dir}/" | awk -F/ '{print $3}' | uniq
+		) | sort -u
 	fi
 }
 


### PR DESCRIPTION

For `force_umount=safe`, we can significantly speed up get_pids() by limiting the search for significant symlinks
to the _process_ and skipping the _tasks_ (or _threads_).

We are interested in `/proc/<pid>/{cwd,root,exe}` and `/proc/<pid>/fd/<fd>` as well as memory mappings.
All of these are per process, not per thread. We can save us a lot of time and effort by not scanning
`/proc/<pid>/taks/<tid>/*`, we'd only to find identical information there.

Even on a mostly idle system with just a few "heavily threaded" processes,
this can speed up the scanning by a factor of 10.

With "modern" linux kernels, we can also drop the "grep" in `maps`, we already found the symlinks in `map_files/`.
