### PR TITLE
ocft: fix failing tests in resource-agents v4.17.0

### DIFF
--- a/tools/ocft/IPaddr2
+++ b/tools/ocft/IPaddr2
@@ -39,7 +39,7 @@ CASE "check base env: unset 'OCF_RESKEY_ip'"
 CASE "check base env: set invalid 'OCF_RESKEY_ip'"
 	Include prepare
 	Env OCF_RESKEY_ip=not_ip_address
-	AgentRun start OCF_ERR_CONFIGURED
+	AgentRun start OCF_ERR_INSTALLED
 
 CASE "check base env: set 'OCF_RESKEY_cidr_netmask'"
 	Include prepare
@@ -49,7 +49,7 @@ CASE "check base env: set 'OCF_RESKEY_cidr_netmask'"
 CASE "check base env: set invalid 'OCF_RESKEY_cidr_netmask'"
 	Include prepare
 	Env OCF_RESKEY_cidr_netmask=not_netmask
-	AgentRun start OCF_ERR_CONFIGURED
+	AgentRun start OCF_ERR_INSTALLED
 
 CASE "check base env: set 'OCF_RESKEY_broadcast'"
 	Include prepare
@@ -59,7 +59,7 @@ CASE "check base env: set 'OCF_RESKEY_broadcast'"
 CASE "check base env: set invalid 'OCF_RESKEY_broadcast'"
 	Include prepare
 	Env OCF_RESKEY_broadcast=not_broadcast
-	AgentRun start OCF_ERR_CONFIGURED
+	AgentRun start OCF_ERR_INSTALLED
 
 CASE "check base env: set 'OCF_RESKEY_nic'"
 	Include prepare
@@ -69,7 +69,7 @@ CASE "check base env: set 'OCF_RESKEY_nic'"
 CASE "check base env: set invalid 'OCF_RESKEY_nic'"
 	Include prepare
 	Env OCF_RESKEY_nic=not_nic
-	AgentRun start OCF_ERR_CONFIGURED
+	AgentRun start OCF_ERR_INSTALLED
 	AgentRun validate-all OCF_ERR_CONFIGURED
 
 CASE "normal start"

--- a/tools/ocft/nfsserver
+++ b/tools/ocft/nfsserver
@@ -27,11 +27,6 @@ CASE "check base env"
 	Include prepare
 	AgentRun start OCF_SUCCESS
 
-CASE "check base env: invalid 'OCF_RESKEY_nfs_init_script'"
-	Include prepare
-	Env OCF_RESKEY_nfs_init_script=no_such_script
-	AgentRun start OCF_ERR_INSTALLED
-
 CASE "check base env: invalid 'OCF_RESKEY_nfs_notify_cmd'"
 	Include prepare
 	Env OCF_RESKEY_nfs_notify_cmd=no_such_program

--- a/tools/ocft/ocft.in
+++ b/tools/ocft/ocft.in
@@ -482,7 +482,7 @@ else
     echo -en "\\033[31mFAILED\\033[0m. Agent returns unexpected value: '\$__OCFT__retstr'. "
   fi
   echo "See details below:"
-  cat /tmp/.ocft_runlog
+  cat "\${HA_RSCTMP}/.ocft_runlog"
   echo
   quit 1
 fi


### PR DESCRIPTION
IPaddr2: exit code has changed when findif fails
nfsserver: custom init script is ignored with systemd
ocft: make sure correct log is displayed on failure