### PR TITLE
exportfs: fix grep error on stop

### DIFF
--- a/heartbeat/exportfs
+++ b/heartbeat/exportfs
@@ -390,10 +390,10 @@ cleanup_export_cache() {
 	local contentfile=/proc/net/rpc/nfsd.export/content
 	local fsid_re
 	local i=1
-	fsid_re="fsid=(echo `forall get_fsid`|sed 's/ /|/g'),"
+	local fsid_all=`forall get_fsid`
+	fsid_re="fsid=(`echo $fsid_all | sed 's/ /|/g'`),"
 	while :; do
-		grep -E -q "$fsid_re" $contentfile ||
-			break
+		grep -E -q "$fsid_re" $contentfile || break
 		ocf_log info "Cleanup export cache ... (try $i)"
 		ocf_run exportfs -f
 		sleep 0.5


### PR DESCRIPTION
Stop operation does not fail but error is recorded in the output:

```
+ fsid_re=fsid=(echo 105 105
106|sed 's/ /|/g'),
+ :
+ grep -E -q fsid=(echo 105 105
106|sed 's/ /|/g'), /proc/net/rpc/nfsd.export/content grep: Unmatched ( or \(
```

fixes #2070