### PR TITLE
portblock: fix monitor for action=block instances

### DIFF
--- a/heartbeat/portblock
+++ b/heartbeat/portblock
@@ -30,23 +30,38 @@ OCF_RESKEY_portno_default=""
 OCF_RESKEY_direction_default="in"
 OCF_RESKEY_action_default=""
 OCF_RESKEY_method_default="drop"
-OCF_RESKEY_status_check_default="rule"
 OCF_RESKEY_ip_default="0.0.0.0/0"
 OCF_RESKEY_reset_local_on_unblock_stop_default="false"
 OCF_RESKEY_tickle_dir_default=""
 OCF_RESKEY_sync_script_default=""
 
-: ${OCF_RESKEY_firewall=${OCF_RESKEY_firewall_default}}
-: ${OCF_RESKEY_protocol=${OCF_RESKEY_protocol_default}}
-: ${OCF_RESKEY_portno=${OCF_RESKEY_portno_default}}
-: ${OCF_RESKEY_direction=${OCF_RESKEY_direction_default}}
-: ${OCF_RESKEY_action=${OCF_RESKEY_action_default}}
-: ${OCF_RESKEY_method=${OCF_RESKEY_method_default}}
-: ${OCF_RESKEY_status_check=${OCF_RESKEY_status_check_default}}
-: ${OCF_RESKEY_ip=${OCF_RESKEY_ip_default}}
-: ${OCF_RESKEY_reset_local_on_unblock_stop=${OCF_RESKEY_reset_local_on_unblock_stop_default}}
-: ${OCF_RESKEY_tickle_dir=${OCF_RESKEY_tickle_dir_default}}
-: ${OCF_RESKEY_sync_script=${OCF_RESKEY_sync_script_default}}
+# The typical idiom is:
+#   block start
+#   other services start
+#   unblock start
+# unblock removes the rule, monitor for block with stauts_check=rule
+# would result in an unexpected "not running" failure, and the whole
+# stack would continuously be restarted.
+# Not monitoring "action=block" instances only looks like a solution
+# until the next "probe" results in a restart of the whole stack for the
+# same reason.
+if [ "$OCF_RESKEY_action" = "block" ]; then
+	OCF_RESKEY_status_check_default="pseudo"
+else
+	OCF_RESKEY_status_check_default="rule"
+fi
+
+: "firewall                    ::" ${OCF_RESKEY_firewall=${OCF_RESKEY_firewall_default}}
+: "protocol                    ::" ${OCF_RESKEY_protocol=${OCF_RESKEY_protocol_default}}
+: "portno                      ::" ${OCF_RESKEY_portno=${OCF_RESKEY_portno_default}}
+: "direction                   ::" ${OCF_RESKEY_direction=${OCF_RESKEY_direction_default}}
+: "action                      ::" ${OCF_RESKEY_action=${OCF_RESKEY_action_default}}
+: "method                      ::" ${OCF_RESKEY_method=${OCF_RESKEY_method_default}}
+: "status_check                ::" ${OCF_RESKEY_status_check=${OCF_RESKEY_status_check_default}}
+: "ip                          ::" ${OCF_RESKEY_ip=${OCF_RESKEY_ip_default}}
+: "reset_local_on_unblock_stop ::" ${OCF_RESKEY_reset_local_on_unblock_stop=${OCF_RESKEY_reset_local_on_unblock_stop_default}}
+: "tickle_dir                  ::" ${OCF_RESKEY_tickle_dir=${OCF_RESKEY_tickle_dir_default}}
+: "sync_script                 ::" ${OCF_RESKEY_sync_script=${OCF_RESKEY_sync_script_default}}
 #######################################################################
 CMD=`basename $0`
 TICKLETCP=$HA_BIN/tickle_tcp
@@ -214,6 +229,8 @@ reject: Use REJECT rule w/conntrack to clear connections when blocking.
 Status check:
 rule: Check rule.
 pseudo: Check pseudo status when rule is absent.
+
+Default is "rule" for action=unblock and "pseudo" for action=block.
 </longdesc>
 <shortdesc lang="en">Status check</shortdesc>
 <content type="string" default="${OCF_RESKEY_status_check_default}" />


### PR DESCRIPTION
344beb1 introduced status_check=rule (and set that as default).

This breaks "monitor" and "probe" of "action=block" for existing setups.

As soon as the "unblock" is "started", the rule is no longer active. With status_check=rule (the new default), the next "monitor" (or "probe") will see an unexpected state of the "block" instance, and recover the whole dependency chain. With monitor enabled, this will repeat forever.

Not a fix, even if you think it might be, is to drop the monitor. Because the same "unexpected" state would be detected on any probe.

Probe will happen after you go into and then out of maintenance-mode, after a DC election, for example after cluster partition / rejoin / or other membership change like a peer reboot, even a planned one.
Possibly for other reasons as well.

Any such probe will find the resource in an unexpected state, and "recover" by spuriously restarting the whole dependency chain.

Workaround: explicitly set status_check=pseudo (or any other string not equal to "rule").

Still, without it, existing setups (that don't know about the status_check parameter yet) are broken by a simple update of the portblock resource agent.

Possible "fix": don't set "rule" as the default.

Better fix: always treat "action=block" instances as pseudo resources.

That's basically the same you do for promotable instances, only that the equivalent to the "pseudo" status file
is now the promotion score as found in the cib.

Fixes #2099