### PR TITLE
OCPBUGS-64765: podman-etcd: add -a option to crictl ps

### DIFF
--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -737,7 +737,7 @@ archive_data_folder()
 
 etcd_pod_container_exists() {
 	local count_matches
-	# Check whether the etcd pod exists on the same node (header line included)
+	# Check whether the etcd pod exists on the same node (including stopped/exited containers)
 	count_matches=$(crictl pods --label app=etcd -q | xargs -I {} crictl ps -a --pod {} -o json | jq -r '.containers[].metadata | select ( .name == "etcd" ).name' | wc -l)
 	if [ "$count_matches" -eq 1 ]; then
 		# etcd pod found


### PR DESCRIPTION
This PR improves the detection of the etcd static pod prior to effective handover of etcd to Pacemaker. 
Without this change, there is a race condition where pacemaker could detect the static pod as gone while it still was being deleted. In this situation, it would try to start the podman etcd container and fail due to an address/port conflict with the static pod.

The addition of "-a" makes it so that Pacemaker's start of the podman etcd container will only happen once the static pod is completely absent. 

Without this change, assisted-service installations get stuck, as explained in: https://issues.redhat.com/browse/OCPBUGS-64765