### PR TITLE
docker: improve image existence check

### DIFF
--- a/heartbeat/docker
+++ b/heartbeat/docker
@@ -513,17 +513,9 @@ image_exists()
 	# - image
 	# - server_name/image (as extracted above)
 	# - docker.io/image (some distro will display "docker.io/" as prefix)
-	docker image ls --quiet ${IMAGE_NAME}:${IMAGE_TAG} 2>&1 >/dev/null
+	docker image ls --all --format '{{.Repository}}:{{.Tag}}' | $EGREP -q -s "^(docker.io\/|${SERVER_NAME}\/)?${IMAGE_NAME}:${IMAGE_TAG}\$"
 	if [ $? -eq 0 ]; then
 		# image found
-		return $OCF_SUCCESS
-	fi
-	docker image ls --quiet ${SERVER_NAME}/${IMAGE_NAME}:${IMAGE_TAG} 2>&1 >/dev/null
-	if [ $? -eq 0 ]; then
-		return $OCF_SUCCESS
-	fi
-	docker image ls --quiet docker.io/${IMAGE_NAME}:${IMAGE_TAG} 2>&1 >/dev/null
-	if [ $? -eq 0 ]; then
 		return $OCF_SUCCESS
 	fi
 


### PR DESCRIPTION
Query docker explicitly for specific image instead of parsing image list - fixes #2120.

I don't have a testing environment on hand, thus the draft status of this PR - I'll mark it as ready as soon as it's verified to be working correctly.

Any stylistic suggestions or other code improvements are welcome, e.g. I've noticed inconsistent usage of return codes vs `$OCF_SUCCESS`/`$OCF_ERR_ARGS` etc in existing code but I've decided to limit the scope of changes for the time being.