### PR TITLE
OCPBUGS-76538: podman-etcd: monitor/stop hardening

### DIFF
--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -371,26 +371,36 @@ monitor_cmd_exec()
 {
 	local rc=$OCF_SUCCESS
 	local out
+	local attempt
+	# 3 attempts × 8s = 24s worst case, fits within the 25s monitor timeout.
+	# The health check normally completes in <1s; the 8s per-attempt timeout
+	# is a safety net for when the container's process namespace is slow.
+	local max_attempts=3
+	local attempt_timeout=8
 
-	out=$(podman exec ${CONTAINER} $OCF_RESKEY_monitor_cmd 2>&1)
-	rc=$?
-	# 125: no container with name or ID ${CONTAINER} found
-	# 126: container state improper (not running)
-	# 127: any other error
-	# 255: podman 2+: container not running
-	case "$rc" in
-		125|126|255)
-			rc=$OCF_NOT_RUNNING
-			;;
-		0)
-			ocf_log debug "monitor cmd passed: exit code = $rc"
-			;;
-		*)
-			ocf_exit_reason "monitor cmd failed (rc=$rc), output: $out"
-			rc=$OCF_ERR_GENERIC
-			;;
-	esac
+	for attempt in $(seq 1 $max_attempts); do
+		out=$(timeout $attempt_timeout podman exec ${CONTAINER} $OCF_RESKEY_monitor_cmd 2>&1)
+		rc=$?
+		# 125: no container with name or ID ${CONTAINER} found
+		# 126: container state improper (not running)
+		# 127: any other error
+		# 255: podman 2+: container not running
+		case "$rc" in
+			125|126|255)
+				rc=$OCF_NOT_RUNNING
+				;;
+			0)
+				ocf_log debug "monitor cmd passed: exit code = $rc"
+				return $OCF_SUCCESS
+				;;
+			*)
+				ocf_log warn "monitor cmd failed (rc=$rc), output: $out"
+				rc=$OCF_ERR_GENERIC
+				;;
+		esac
+	done
 
+	ocf_exit_reason "monitor cmd failed after $max_attempts attempts (last rc=$rc), output: $out"
 	return $rc
 }
 
@@ -986,7 +996,7 @@ attribute_node_revision()
 		update)
 			if ! crm_attribute --type nodes --node "$NODENAME" --name "$attribute" --update "$value"; then
 				rc=$?
-				ocf_log err "could not update etcd $revision, error code: $rc"
+				ocf_log err "could not update etcd $attribute, error code: $rc"
 				return "$rc"
 			fi
 			;;
@@ -1038,11 +1048,11 @@ attribute_node_member_id()
 			;;
 		update)
 			local member_list_json
-			member_list_json=$(get_member_list_json)
+			member_list_json=$(get_member_list_json "$MONITOR_ETCDCTL_TIMEOUT")
 			ocf_log info "member list: $member_list_json"
 			if [ -z "$member_list_json" ] ; then
 				ocf_log err "could not get $attribute: could not get member list JSON"
-				return "$rc"
+				return $OCF_ERR_GENERIC
 			fi
 
 			local value value_hex
@@ -1383,23 +1393,25 @@ get_all_etcd_endpoints() {
 get_endpoint_status_json()
 {
 	# Get the status of all endpoints
+	local cmd_timeout="${1:-5s}"
 	local all_etcd_endpoints
 
 	all_etcd_endpoints=$(get_all_etcd_endpoints)
-	podman exec "${CONTAINER}" etcdctl endpoint status --endpoints="$all_etcd_endpoints" -w json
+	podman exec "${CONTAINER}" etcdctl endpoint status --command-timeout="$cmd_timeout" --endpoints="$all_etcd_endpoints" -w json
 }
 
 get_member_list_json() {
 	# Get the list of members visible to the current node
+	local cmd_timeout="${1:-5s}"
 	local this_node_endpoint
 
 	this_node_endpoint="$(ip_url $(attribute_node_ip get)):2379"
-	podman exec "${CONTAINER}" etcdctl member list --endpoints="$this_node_endpoint" -w json
+	podman exec "${CONTAINER}" etcdctl member list --command-timeout="$cmd_timeout" --endpoints="$this_node_endpoint" -w json
 }
 
 detect_cluster_leadership_loss()
 {
-	endpoint_status_json=$(get_endpoint_status_json)
+	endpoint_status_json=$(get_endpoint_status_json "$MONITOR_ETCDCTL_TIMEOUT")
 	ocf_log info "endpoint status: $endpoint_status_json"
 
 	count_endpoints=$(printf "%s" "$endpoint_status_json" | jq -r ".[].Endpoint" | wc -l)
@@ -1489,7 +1501,7 @@ check_peer()
 		return $OCF_SUCCESS
 	fi
 
-	if ! member_list_json=$(get_member_list_json); then
+	if ! member_list_json=$(get_member_list_json "$MONITOR_ETCDCTL_TIMEOUT"); then
 		ocf_log info "podman failed to get member list, error code: $?"
 		detect_cluster_leadership_loss
 		return $?
@@ -2288,8 +2300,9 @@ leave_etcd_member_list()
 	ocf_log info "leaving members list as member with ID $member_id"
 	local endpoint
 	endpoint="$(ip_url $(attribute_node_ip get)):2379"
-	if ! ocf_run podman exec "$CONTAINER" etcdctl member remove "$member_id" --endpoints="$endpoint"; then
-		rc=$?
+	ocf_run podman exec "$CONTAINER" etcdctl member remove "$member_id" --endpoints="$endpoint"
+	rc=$?
+	if [ $rc -ne 0 ]; then
 		ocf_log err "error leaving members list, error code: $rc"
 	fi
 }
@@ -2310,14 +2323,23 @@ podman_stop()
 	attribute_node_revision update
 	attribute_node_cluster_id update
 
-	podman_simple_status
-	if [ $? -eq  $OCF_NOT_RUNNING ]; then
+	# Use podman inspect instead of podman exec (podman_simple_status) to check
+	# container state. podman exec enters the container's process namespace and
+	# hangs when etcd is unresponsive — the typical scenario that triggers a stop.
+	local container_running
+	container_running=$(podman inspect --format '{{.State.Running}}' "$CONTAINER" 2>/dev/null)
+	if [ "$container_running" != "true" ]; then
 		ocf_log info "could not leave members list: etcd container not running"
 		attribute_node_member_id clear
 		return $OCF_SUCCESS
 	fi
 
-	leave_etcd_member_list
+	# Time-box the member list removal so it cannot consume the entire stop
+	# budget when etcd is unresponsive. 30s accommodates the etcdctl call
+	# plus the optional DELAY_SECOND_NODE_LEAVE_SEC (10s) sleep.
+	timeout 30 leave_etcd_member_list || \
+		ocf_log warn "could not leave member list within 30s, proceeding with stop"
+
 	# clear node_member_id CIB attribute only after leaving the member list
 	attribute_node_member_id clear
 
@@ -2461,6 +2483,9 @@ ETCD_CERTS_HASH_FILE="${OCF_RESKEY_config_location}/certs.hash"
 # This is intentional - reboots are controlled stops, not failures requiring detection.
 CONTAINER_HEARTBEAT_FILE=${HA_RSCTMP}/podman-container-last-running
 DELAY_SECOND_NODE_LEAVE_SEC=10
+# Shorter etcdctl command-timeout for monitor-path calls to prevent
+# consuming the 25s monitor budget. Non-monitor callers use the default 5s.
+MONITOR_ETCDCTL_TIMEOUT="3s"
 
 # Note: we currently monitor podman containers by with the "podman exec"
 # command, so make sure that invocation is always valid by enforcing the

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -989,8 +989,8 @@ attribute_node_revision()
 	value=$(jq -r ".maxRaftIndex" "$ETCD_REVISION_JSON")
 	rc=$?
 	if [ $rc -ne 0 ]; then
-		ocf_log err "could not get $attribute, error code: $rc"
-		return "$rc"
+		ocf_log err "could not get $attribute from revision JSON file '$ETCD_REVISION_JSON'"
+		return "$OCF_ERR_GENERIC"
 	fi
 
 	case "$action" in

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -1574,7 +1574,7 @@ check_peer()
 	fi
 
 	if ! member_list_json=$(get_member_list_json); then
-		ocf_log info "podman failed to get member list, error code: $?"
+		ocf_log info "podman failed to get member list"
 		detect_cluster_leadership_loss
 		return $?
 	fi

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -400,7 +400,6 @@ monitor_cmd_exec()
 		esac
 	done
 
-	ocf_exit_reason "monitor cmd failed after $max_attempts attempts (last rc=$rc), output: $out"
 	return $rc
 }
 

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -1422,6 +1422,11 @@ detect_cluster_leadership_loss()
 	endpoint_status_json=$(get_endpoint_status_json)
 	ocf_log info "endpoint status: $endpoint_status_json"
 
+	if [ -z "$endpoint_status_json" ] || ! printf "%s" "$endpoint_status_json" | jq -e '.' >/dev/null 2>&1; then
+		ocf_log err "failed to retrieve endpoint status (podman exec may have failed): $endpoint_status_json"
+		return $OCF_ERR_GENERIC
+	fi
+
 	count_endpoints=$(printf "%s" "$endpoint_status_json" | jq -r ".[].Endpoint" | wc -l)
 	if [ "$count_endpoints" -eq 1 ]; then
 		ocf_log info "one endpoint only: checking status errors"
@@ -1509,8 +1514,11 @@ check_peer()
 		return $OCF_SUCCESS
 	fi
 
-	if ! member_list_json=$(get_member_list_json); then
-		ocf_log info "podman failed to get member list, error code: $?"
+	local rc
+	member_list_json=$(get_member_list_json)
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		ocf_log info "podman failed to get member list, error code: $rc"
 		detect_cluster_leadership_loss
 		return $?
 	fi

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -372,11 +372,11 @@ monitor_cmd_exec()
 	local rc=$OCF_SUCCESS
 	local out
 	local attempt
-	# 3 attempts × 8s = 24s worst case, fits within the 25s monitor timeout.
-	# The health check normally completes in <1s; the 8s per-attempt timeout
+	# 3 attempts × 5s = 15s worst case, fits within the 25s monitor timeout.
+	# The health check normally completes in <1s; the 5s per-attempt timeout
 	# is a safety net for when the container's process namespace is slow.
 	local max_attempts=3
-	local attempt_timeout=8
+	local attempt_timeout=5
 
 	for attempt in $(seq 1 $max_attempts); do
 		out=$(timeout $attempt_timeout podman exec ${CONTAINER} $OCF_RESKEY_monitor_cmd 2>&1)
@@ -536,8 +536,9 @@ get_env_from_manifest() {
 		exit "$OCF_ERR_INSTALLED"
 	fi
 
-	if ! env_var_value=$(jq -r ".spec.containers[].env[] | select( .name == \"$env_var_name\" ).value" "$OCF_RESKEY_pod_manifest"); then
-		rc=$?
+	env_var_value=$(jq -r ".spec.containers[].env[] | select( .name == \"$env_var_name\" ).value" "$OCF_RESKEY_pod_manifest")
+	rc=$?
+	if [ $rc -ne 0 ]; then
 		ocf_log err "could not find environment variable $env_var_name in etcd pod manifest, error code: $rc"
 		exit "$OCF_ERR_INSTALLED"
 	fi
@@ -944,8 +945,10 @@ attribute_node_cluster_id()
 {
 	local action="$1"
 	local value
-	if ! value=$(jq -r ".clusterId" "$ETCD_REVISION_JSON"); then
-		rc=$?
+	local rc
+	value=$(jq -r ".clusterId" "$ETCD_REVISION_JSON")
+	rc=$?
+	if [ $rc -ne 0 ]; then
 		ocf_log err "could not get cluster_id, error code: $rc"
 		return "$rc"
 	fi
@@ -955,8 +958,9 @@ attribute_node_cluster_id()
 			echo "$value"
 			;;
 		update)
-			if ! crm_attribute --type nodes --node "$NODENAME" --name "cluster_id" --update "$value"; then
-				rc=$?
+			crm_attribute --type nodes --node "$NODENAME" --name "cluster_id" --update "$value"
+			rc=$?
+			if [ $rc -ne 0 ]; then
 				ocf_log err "could not update cluster_id, error code: $rc"
 				return "$rc"
 			fi
@@ -981,9 +985,11 @@ attribute_node_revision()
 	local action="$1"
 	local value
 	local attribute="revision"
+	local rc
 
-	if ! value=$(jq -r ".maxRaftIndex" "$ETCD_REVISION_JSON"); then
-		rc=$?
+	value=$(jq -r ".maxRaftIndex" "$ETCD_REVISION_JSON")
+	rc=$?
+	if [ $rc -ne 0 ]; then
 		ocf_log err "could not get $attribute, error code: $rc"
 		return "$rc"
 	fi
@@ -993,8 +999,9 @@ attribute_node_revision()
 			echo "$value"
 			;;
 		update)
-			if ! crm_attribute --type nodes --node "$NODENAME" --name "$attribute" --update "$value"; then
-				rc=$?
+			crm_attribute --type nodes --node "$NODENAME" --name "$attribute" --update "$value"
+			rc=$?
+			if [ $rc -ne 0 ]; then
 				ocf_log err "could not update etcd $attribute, error code: $rc"
 				return "$rc"
 			fi
@@ -1047,27 +1054,31 @@ attribute_node_member_id()
 			;;
 		update)
 			local member_list_json
-			member_list_json=$(get_member_list_json "$MONITOR_ETCDCTL_TIMEOUT")
+			member_list_json=$(get_member_list_json)
 			ocf_log info "member list: $member_list_json"
 			if [ -z "$member_list_json" ] ; then
 				ocf_log err "could not get $attribute: could not get member list JSON"
 				return $OCF_ERR_GENERIC
 			fi
 
-			local value value_hex
-			if ! value=$(echo -n "$member_list_json" | jq -r ".header.member_id"); then
-				rc=$?
+			local value value_hex rc
+			value=$(echo -n "$member_list_json" | jq -r ".header.member_id")
+			rc=$?
+			if [ $rc -ne 0 ]; then
 				ocf_log err "could not get $attribute from member list JSON, error code: $rc"
 				return "$rc"
 			fi
 
 			# JSON member_id is decimal, while etcdctl command needs the hex version
-			if ! value_hex=$(decimal_to_hex "$value"); then
-				ocf_log err "could not convert decimal member_id '$value' to hex, error code: $?"
+			value_hex=$(decimal_to_hex "$value")
+			rc=$?
+			if [ $rc -ne 0 ]; then
+				ocf_log err "could not convert decimal member_id '$value' to hex, error code: $rc"
 				return $OCF_ERR_GENERIC
 			fi
-			if ! crm_attribute --type nodes --node "$NODENAME" --name "$attribute" --update "$value_hex"; then
-				rc=$?
+			crm_attribute --type nodes --node "$NODENAME" --name "$attribute" --update "$value_hex"
+			rc=$?
+			if [ $rc -ne 0 ]; then
 				ocf_log err "could not update etcd $attribute, error code: $rc"
 				return "$rc"
 			fi
@@ -1392,25 +1403,23 @@ get_all_etcd_endpoints() {
 get_endpoint_status_json()
 {
 	# Get the status of all endpoints
-	local cmd_timeout="${1:-5s}"
 	local all_etcd_endpoints
 
 	all_etcd_endpoints=$(get_all_etcd_endpoints)
-	podman exec "${CONTAINER}" etcdctl endpoint status --command-timeout="$cmd_timeout" --endpoints="$all_etcd_endpoints" -w json
+	podman exec "${CONTAINER}" etcdctl endpoint status --command-timeout="$MONITOR_ETCDCTL_TIMEOUT" --endpoints="$all_etcd_endpoints" -w json
 }
 
 get_member_list_json() {
 	# Get the list of members visible to the current node
-	local cmd_timeout="${1:-5s}"
 	local this_node_endpoint
 
 	this_node_endpoint="$(ip_url $(attribute_node_ip get)):2379"
-	podman exec "${CONTAINER}" etcdctl member list --command-timeout="$cmd_timeout" --endpoints="$this_node_endpoint" -w json
+	podman exec "${CONTAINER}" etcdctl member list --command-timeout="$MONITOR_ETCDCTL_TIMEOUT" --endpoints="$this_node_endpoint" -w json
 }
 
 detect_cluster_leadership_loss()
 {
-	endpoint_status_json=$(get_endpoint_status_json "$MONITOR_ETCDCTL_TIMEOUT")
+	endpoint_status_json=$(get_endpoint_status_json)
 	ocf_log info "endpoint status: $endpoint_status_json"
 
 	count_endpoints=$(printf "%s" "$endpoint_status_json" | jq -r ".[].Endpoint" | wc -l)
@@ -1500,7 +1509,7 @@ check_peer()
 		return $OCF_SUCCESS
 	fi
 
-	if ! member_list_json=$(get_member_list_json "$MONITOR_ETCDCTL_TIMEOUT"); then
+	if ! member_list_json=$(get_member_list_json); then
 		ocf_log info "podman failed to get member list, error code: $?"
 		detect_cluster_leadership_loss
 		return $?
@@ -2299,7 +2308,7 @@ leave_etcd_member_list()
 	ocf_log info "leaving members list as member with ID $member_id"
 	local endpoint
 	endpoint="$(ip_url $(attribute_node_ip get)):2379"
-	ocf_run podman exec "$CONTAINER" etcdctl member remove "$member_id" --endpoints="$endpoint"
+	ocf_run timeout 30 podman exec "$CONTAINER" etcdctl member remove "$member_id" --endpoints="$endpoint"
 	rc=$?
 	if [ $rc -ne 0 ]; then
 		ocf_log err "error leaving members list, error code: $rc"
@@ -2333,11 +2342,7 @@ podman_stop()
 		return $OCF_SUCCESS
 	fi
 
-	# Time-box the member list removal so it cannot consume the entire stop
-	# budget when etcd is unresponsive. 30s accommodates the etcdctl call
-	# plus the optional DELAY_SECOND_NODE_LEAVE_SEC (10s) sleep.
-	timeout 30 leave_etcd_member_list || \
-		ocf_log warn "could not leave member list within 30s, proceeding with stop"
+	leave_etcd_member_list
 
 	# clear node_member_id CIB attribute only after leaving the member list
 	attribute_node_member_id clear

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -387,7 +387,7 @@ monitor_cmd_exec()
 		# 255: podman 2+: container not running
 		case "$rc" in
 			125|126|255)
-				rc=$OCF_NOT_RUNNING
+				return $OCF_NOT_RUNNING
 				;;
 			0)
 				ocf_log debug "monitor cmd passed: exit code = $rc"
@@ -948,8 +948,10 @@ attribute_node_cluster_id()
 	value=$(jq -r ".clusterId" "$ETCD_REVISION_JSON")
 	rc=$?
 	if [ $rc -ne 0 ]; then
+		# Log the error but return success to avoid monitor failure if the file is not available yet. 
+		#This should not block cluster recovery.
 		ocf_log err "could not get cluster_id, error code: $rc"
-		return "$rc"
+		return $OCF_SUCCESS
 	fi
 
 	case "$action" in
@@ -960,8 +962,9 @@ attribute_node_cluster_id()
 			crm_attribute --type nodes --node "$NODENAME" --name "cluster_id" --update "$value"
 			rc=$?
 			if [ $rc -ne 0 ]; then
+			 	# Log the error but return success to avoid monitor failure if we can not update the attribute.
 				ocf_log err "could not update cluster_id, error code: $rc"
-				return "$rc"
+				return $OCF_SUCCESS
 			fi
 			;;
 		*)
@@ -999,8 +1002,9 @@ attribute_node_revision()
 			crm_attribute --type nodes --node "$NODENAME" --name "$attribute" --update "$value"
 			rc=$?
 			if [ $rc -ne 0 ]; then
+				# Log the error but return success to avoid monitor failure if we can not update the attribute.
 				ocf_log err "could not update etcd $attribute, error code: $rc"
-				return "$rc"
+				return $OCF_SUCCESS
 			fi
 			;;
 		*)
@@ -1062,8 +1066,9 @@ attribute_node_member_id()
 			value=$(echo -n "$member_list_json" | jq -r ".header.member_id")
 			rc=$?
 			if [ $rc -ne 0 ]; then
+				# Log the error but return success to avoid monitor failure if the file is not available yet.
 				ocf_log err "could not get $attribute from member list JSON, error code: $rc"
-				return "$rc"
+				return $OCF_SUCCESS
 			fi
 
 			# JSON member_id is decimal, while etcdctl command needs the hex version
@@ -1076,8 +1081,9 @@ attribute_node_member_id()
 			crm_attribute --type nodes --node "$NODENAME" --name "$attribute" --update "$value_hex"
 			rc=$?
 			if [ $rc -ne 0 ]; then
+				# Log the error but return success to avoid monitor failure if we can not update the attribute.
 				ocf_log err "could not update etcd $attribute, error code: $rc"
-				return "$rc"
+				return $OCF_SUCCESS
 			fi
 			;;
 		clear)
@@ -1567,11 +1573,8 @@ check_peer()
 		return $OCF_SUCCESS
 	fi
 
-	local rc
-	member_list_json=$(get_member_list_json)
-	rc=$?
-	if [ $rc -ne 0 ]; then
-		ocf_log info "podman failed to get member list, error code: $rc"
+	if ! member_list_json=$(get_member_list_json); then
+		ocf_log info "podman failed to get member list, error code: $?"
 		detect_cluster_leadership_loss
 		return $?
 	fi

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -2337,7 +2337,7 @@ podman_stop()
 	local container_running
 	container_running=$(podman inspect --format '{{.State.Running}}' "$CONTAINER" 2>/dev/null)
 	if [ "$container_running" != "true" ]; then
-		ocf_log info "could not leave members list: etcd container not running"
+		ocf_log info "could not leave members list: $CONTAINER container not running, running state: ${container_running}"
 		attribute_node_member_id clear
 		return $OCF_SUCCESS
 	fi

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -1422,11 +1422,6 @@ detect_cluster_leadership_loss()
 	endpoint_status_json=$(get_endpoint_status_json)
 	ocf_log info "endpoint status: $endpoint_status_json"
 
-	if [ -z "$endpoint_status_json" ] || ! printf "%s" "$endpoint_status_json" | jq -e '.' >/dev/null 2>&1; then
-		ocf_log err "failed to retrieve endpoint status (podman exec may have failed): $endpoint_status_json"
-		return $OCF_ERR_GENERIC
-	fi
-
 	count_endpoints=$(printf "%s" "$endpoint_status_json" | jq -r ".[].Endpoint" | wc -l)
 	if [ "$count_endpoints" -eq 1 ]; then
 		ocf_log info "one endpoint only: checking status errors"

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -2098,7 +2098,7 @@ podman_start()
 	run_opts="$run_opts --oom-score-adj=${OCF_RESKEY_oom}"
 
 	if ocf_is_true "$JOIN_AS_LEARNER"; then
-		local wait_timeout_sec=$((10*60))
+		local wait_timeout_sec=$((2*60))
 		local poll_interval_sec=5
 		local retries=$(( wait_timeout_sec / poll_interval_sec ))
 

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -984,13 +984,11 @@ attribute_node_revision()
 	local action="$1"
 	local value
 	local attribute="revision"
-	local rc
 
-	value=$(jq -r ".maxRaftIndex" "$ETCD_REVISION_JSON")
-	rc=$?
-	if [ $rc -ne 0 ]; then
-		ocf_log err "could not get $attribute from revision JSON file '$ETCD_REVISION_JSON'"
-		return "$OCF_ERR_GENERIC"
+	if ! value=$(jq -r ".maxRaftIndex" "$ETCD_REVISION_JSON"); then
+		rc=$?
+		ocf_log err "could not get $attribute, error code: $rc"
+		return "$rc"
 	fi
 
 	case "$action" in
@@ -1001,7 +999,7 @@ attribute_node_revision()
 			crm_attribute --type nodes --node "$NODENAME" --name "$attribute" --update "$value"
 			rc=$?
 			if [ $rc -ne 0 ]; then
-				ocf_log err "could not update etcd $attribute, error code: $rc"
+				ocf_log err "could not update etcd $attribute from revision JSON file '$ETCD_REVISION_JSON', error code: $rc"
 				return "$rc"
 			fi
 			;;

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -999,7 +999,7 @@ attribute_node_revision()
 			crm_attribute --type nodes --node "$NODENAME" --name "$attribute" --update "$value"
 			rc=$?
 			if [ $rc -ne 0 ]; then
-				ocf_log err "could not update etcd $attribute from revision JSON file '$ETCD_REVISION_JSON', error code: $rc"
+				ocf_log err "could not update etcd $attribute, error code: $rc"
 				return "$rc"
 			fi
 			;;


### PR DESCRIPTION
## Summary

  Harden the podman-etcd resource agent's monitor and stop operations to
  prevent unnecessary fencing cascades in two-node clusters when etcd is
  transiently unresponsive (e.g. during high I/O).

  - **Monitor retry logic**: `monitor_cmd_exec` now retries up to 3 times
    with an 8s per-attempt timeout, preventing a single transient failure
    from triggering a monitor failure. (`podman exec` doesn't have a timeout by default, so if etcd is unresponsive, it will take the whole 25s agent timeout and be killed by pacemaker )
  - **Faster etcdctl failures in monitor**: etcdctl calls in the monitor
    path use a 3s command-timeout (down from the default 5s), keeping
    total monitor execution within the 25s budget (in cases where `podman exec` is responsive, but `etcdctl` takes longer than expected)
  - **Stop no longer hangs on unresponsive etcd**: container state check
    uses `podman inspect` instead of `podman exec`, and
    `leave_etcd_member_list` is time-boxed to 30s

Some minor cosmetic fixes based on what I've found while analyzing some failure logs:
 - uninitialized `$rc` in `attribute_node_member_id`
 - `$?` always 0 after `if !` in `leave_etcd_member_list`
 - `$revision` typo in log message