### PR TITLE
Filesystem: modify the return code when a mismatch between mount state and configuration is detected in monitor operation

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -1029,7 +1029,11 @@ Filesystem_status()
 					rc=$OCF_NOT_RUNNING
 				else
 					ocf_exit_reason "Another device ($mounted_device) is already mounted on $MOUNTPOINT"
-					rc=$OCF_ERR_CONFIGURED
+					if [ "$__OCF_ACTION" = "monitor" ]; then
+						rc=$OCF_ERR_GENERIC
+					else
+						rc=$OCF_ERR_CONFIGURED
+					fi
 				fi
 			fi
 		else


### PR DESCRIPTION
Hi all,

I encountered an unexpected service stop when using Filesystem resources with udev-renamed devices.

When a disk failure occurs on the ACTIVE node, 
the resource does not fail over but stops instead.
This seems to be caused by Filesystem_status() returning OCF_ERR_CONFIGURED on mount/config mismatch,
likely due to failure to canonicalize device names (e.g., resolving udev aliases).
While this return code makes sense during start op,
it appears inappropriate in monitor context, as it leads to service stop rather than recovery.

This patch changes the monitor behavior to return OCF_ERR_GENERIC instead.
(For now, the behavior for the status operation is left unchanged, as it is not guaranteed to be executed after start.)

I would appreciate feedback on whether this approach is appropriate.


Best regards,
Satomi OSAWA