### PR TITLE
aws-vpc-move-ip: Add awscli_timeout option

### DIFF
--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -48,6 +48,7 @@ OCF_RESKEY_interface_default="eth0"
 OCF_RESKEY_iflabel_default=""
 OCF_RESKEY_monapi_default="false"
 OCF_RESKEY_lookup_type_default="InstanceId"
+OCF_RESKEY_awscli_timeout_default=""
 
 : ${OCF_RESKEY_awscli=${OCF_RESKEY_awscli_default}}
 : ${OCF_RESKEY_auth_type=${OCF_RESKEY_auth_type_default}}
@@ -61,6 +62,7 @@ OCF_RESKEY_lookup_type_default="InstanceId"
 : ${OCF_RESKEY_iflabel=${OCF_RESKEY_iflabel_default}}
 : ${OCF_RESKEY_monapi=${OCF_RESKEY_monapi_default}}
 : ${OCF_RESKEY_lookup_type=${OCF_RESKEY_lookup_type_default}}
+: ${OCF_RESKEY_awscli_timeout=${OCF_RESKEY_awscli_timeout_default}}
 #######################################################################
 
 
@@ -208,6 +210,14 @@ curl retries before failing
 curl sleep between tries
 </longdesc>
 <shortdesc lang="en">curl sleep</shortdesc>
+<content type="integer" default="${OCF_RESKEY_curl_sleep_default}" />
+</parameter>
+
+<parameter name="awscli_timeout" unique="0">
+<longdesc lang="en">
+awscli cli-connect-timeout value
+</longdesc>
+<shortdesc lang="en">awscli cli-connect-timeout</shortdesc>
 <content type="integer" default="${OCF_RESKEY_curl_sleep_default}" />
 </parameter>
 
@@ -490,7 +500,11 @@ if ! ocf_is_root; then
 	exit $OCF_ERR_PERM
 fi
 
-AWSCLI_CMD="${OCF_RESKEY_awscli}"
+if [ -n "${OCF_RESKEY_awscli_timeout}" ]; then
+   AWSCLI_CMD="${OCF_RESKEY_awscli} --cli-connect-timeout ${OCF_RESKEY_awscli_timeout}"
+else
+   AWSCLI_CMD="${OCF_RESKEY_awscli}"
+fi
 if [ "x${OCF_RESKEY_auth_type}" = "xkey" ]; then
 	AWSCLI_CMD="$AWSCLI_CMD --profile ${OCF_RESKEY_profile}"
 elif [ "x${OCF_RESKEY_auth_type}" = "xrole" ]; then

--- a/heartbeat/aws-vpc-move-ip
+++ b/heartbeat/aws-vpc-move-ip
@@ -218,7 +218,7 @@ curl sleep between tries
 awscli cli-connect-timeout value
 </longdesc>
 <shortdesc lang="en">awscli cli-connect-timeout</shortdesc>
-<content type="integer" default="${OCF_RESKEY_curl_sleep_default}" />
+<content type="integer" default="${OCF_RESKEY_awscli_timeout_default}" />
 </parameter>
 
 </parameters>


### PR DESCRIPTION
This change adds a new option ```awscli_timeout``` to the ```aws-vpc-move-ip``` resource agent to let the cluster control the timeout of AWS CLI.

The default timeout is 60s, and in certain configurations and network topologies it has shown to be too high when more aggressive Service Level Objectives are required Adding this option lets the cluster admin to fine tune the timeout value to better suit their use case.

Sample configuration:

```
primitive res_aws_vpc_ip ocf:heartbeat:aws-vpc-move-ip \
    params \
        ip="10.0.0.100" \
        routing_table="rtb-12345678" \
        interface="eth0" \
        auth_type="role" \
        region="us-west-2" \
        awscli_timeout="10" \                        -----> NEW OPTION
    op start timeout="180s" interval="0" \
    op stop timeout="180s" interval="0" \
    op monitor timeout="30s" interval="60s"
```