### PR TITLE
pgsql: add dynamic replication mode management for out-of-cluster standbys

### DIFF
--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1566,17 +1566,49 @@ set_async_mode() {
 }
 
 set_sync_mode() {
-    local sync_node_in_conf
+    local target_nodes=""
+    local target_count=0
+    local config_node_list
+    local sorted1
+    local sorted2
 
-    sync_node_in_conf=`cat $REP_MODE_CONF | cut -d "'" -f 2`
-    if [ -n "$sync_node_in_conf" ]; then
-        ocf_log debug "$sync_node_in_conf is already sync mode."
+    # Check whether the current settings contain the term FIRST
+    cat $REP_MODE_CONF | cut -d "'" -f 2 | grep -q "^FIRST "
+    rc=$?
+    if [ $rc -eq 0 ]; then
+        # If the setting contains the term FIRST, retrieve the information from within the ()
+        config_node_list=`cat $REP_MODE_CONF | cut -d "(" -f 2 | cut -d ")" -f 1 | sed 's/[",]//g'`
     else
-        ocf_log info "Setup $1 into sync mode."
-        runasowner -q err "echo \"synchronous_standby_names = '\\\"$1\\\"'\" > \"$REP_MODE_CONF\""
-        [ "$RE_CONTROL_SLAVE" = "false" ] && RE_CONTROL_SLAVE="true"
-        exec_with_retry 0 reload_conf
+        # If the setting does not contain the term FIRST, retrieve information from within the ''
+        config_node_list=`cat $REP_MODE_CONF | cut -d "'" -f 2 | sed 's/[",]//g'`
     fi
+
+    sorted1=$(echo "$1" | tr ' ' '\n' | sort)
+    sorted2=$(echo "$config_node_list" | tr ' ' '\n' | sort)
+    if [ "$sorted1" = "$sorted2" ]; then
+       # If the content is the same as the current settings, do not update rep_mode.conf
+       ocf_log debug "The same settings already exist."
+       return 0
+    fi
+
+    for node in $1; do
+        if [ $target_count -eq 0 ]; then
+            target_nodes="\\\"${node}\\\""
+        else
+            target_nodes="$target_nodes, \\\"${node}\\\""
+        fi
+        target_count=$(($target_count + 1))
+    done
+
+    ocf_log info "Setup $target_nodes into sync mode."
+    if [ $target_count -ge 2 ]; then
+        runasowner -q err "echo \"synchronous_standby_names = 'FIRST $target_count ($target_nodes)'\" > \"$REP_MODE_CONF\""
+    else
+        runasowner -q err "echo \"synchronous_standby_names = '$target_nodes'\" > \"$REP_MODE_CONF\""
+    fi
+
+    [ "$RE_CONTROL_SLAVE" = "false" ] && RE_CONTROL_SLAVE="true"
+    exec_with_retry 0 reload_conf
 }
 
 reload_conf() {

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -74,6 +74,7 @@ OCF_RESKEY_xlog_check_count_default="3"
 OCF_RESKEY_crm_attr_timeout_default="5"
 OCF_RESKEY_stop_escalate_in_slave_default=90
 OCF_RESKEY_replication_slot_name_default=""
+OCF_RESKEY_external_standby_node_list_default=""
 
 : ${OCF_RESKEY_pgctl=${OCF_RESKEY_pgctl_default}}
 : ${OCF_RESKEY_psql=${OCF_RESKEY_psql_default}}
@@ -109,6 +110,7 @@ OCF_RESKEY_replication_slot_name_default=""
 : ${OCF_RESKEY_crm_attr_timeout=${OCF_RESKEY_crm_attr_timeout_default}}
 : ${OCF_RESKEY_stop_escalate_in_slave=${OCF_RESKEY_stop_escalate_in_slave_default}}
 : ${OCF_RESKEY_replication_slot_name=${OCF_RESKEY_replication_slot_name_default}}
+: ${OCF_RESKEY_external_standby_node_list=${OCF_RESKEY_external_standby_node_list_default}}
 
 usage() {
     cat <<EOF
@@ -450,6 +452,18 @@ wal receiver is not running in the master and the attribute shows status as
 </longdesc>
 <shortdesc lang="en">check_wal_receiver</shortdesc>
 <content type="boolean" default="${OCF_RESKEY_check_wal_receiver_default}" />
+</parameter>
+
+<parameter name="external_standby_node_list" unique="0" required="0">
+<longdesc lang="en">
+All node names of synchronous standby nodes that may connect from outside
+the Pacemaker cluster. Please separate each node name with a space.
+When set, the RA automatically manages synchronous_standby_names for both
+in-cluster and external standby nodes during monitor.
+This is optional for replication.
+</longdesc>
+<shortdesc lang="en">external standby node list</shortdesc>
+<content type="string" default="${OCF_RESKEY_external_standby_node_list_default}" />
 </parameter>
 </parameters>
 
@@ -1183,6 +1197,9 @@ control_slave_status() {
     local all_data_status
     local tmp_data_status
     local number_of_nodes
+    local target_list
+    local standby_node
+    local found
 
     all_data_status=`exec_sql "$OCF_RESKEY_monitor_user" "${CHECK_REPLICATION_STATE_SQL}"`
     rc=$?
@@ -1224,7 +1241,9 @@ control_slave_status() {
                 change_data_status "$target" "$data_status"
                 if [ "$OCF_RESKEY_rep_mode" = "sync" ]; then
                     change_master_score "$target" "$CAN_NOT_PROMOTE"
-                    set_sync_mode "$target"
+                    if [ -z "$OCF_RESKEY_external_standby_node_list" ]; then
+                        set_sync_mode "$target"
+                    fi
                 else
                     if [ $number_of_nodes -le 2 ]; then
                         change_master_score "$target" "$CAN_PROMOTE"
@@ -1243,20 +1262,51 @@ control_slave_status() {
             "DISCONNECT")
                 change_data_status "$target" "$data_status"
                 change_master_score "$target" "$CAN_NOT_PROMOTE"
-                if [ "$OCF_RESKEY_rep_mode" = "sync" ]; then
+                if [ "$OCF_RESKEY_rep_mode" = "sync" -a -z "$OCF_RESKEY_external_standby_node_list" ]; then
                     set_async_mode "$target"
                 fi
                 ;;
             *)
                 change_data_status "$target" "$data_status"
                 change_master_score "$target" "$CAN_NOT_PROMOTE"
-                if [ "$OCF_RESKEY_rep_mode" = "sync" ]; then
+                if [ "$OCF_RESKEY_rep_mode" = "sync" -a -z "$OCF_RESKEY_external_standby_node_list" ]; then
                     set_async_mode "$target"
                 fi
                 change_pgsql_status "$target" "HS:connected"
                 ;;
         esac
     done
+
+    if [ -n "$OCF_RESKEY_external_standby_node_list" ]; then
+        # Check whether nodes registered in the pg_stat_replication table should be managed by the resource agent.
+        for tmp_data_status in $all_data_status; do
+            found="false"
+            standby_node=`echo $tmp_data_status | cut -d "|" -f 1`
+            for target in $NODE_LIST; do
+                if [ "$standby_node" = "$target" ]; then
+                    found="true"
+                    break
+                fi
+            done
+            for target in $EXTERNAL_STANDBY_NODE_LIST; do
+                if [ "$standby_node" = "$target" ]; then
+                    found="true"
+                    break
+                fi
+            done
+            if [ "$found" = "false" ]; then
+                ocf_log debug "$standby_node is not a node to be synchronized."
+                continue
+            fi
+            if [ -n "$target_list" ]; then
+                target_list="$target_list $standby_node"
+            else
+                target_list="$standby_node"
+            fi
+        done
+        set_sync_mode "$target_list"
+    fi
+
     return 0
 }
 
@@ -1571,6 +1621,7 @@ set_sync_mode() {
     local config_node_list
     local sorted1
     local sorted2
+    local found
 
     # Check whether the current settings contain the term FIRST
     cat $REP_MODE_CONF | cut -d "'" -f 2 | grep -q "^FIRST "
@@ -1590,6 +1641,25 @@ set_sync_mode() {
        ocf_log debug "The same settings already exist."
        return 0
     fi
+
+    for config_node in $config_node_list; do
+        found="false"
+        # Check whether the preconfigured node is included in the node to be configured.
+        for node in $1; do
+            if [ "$config_node" = "$node" ]; then
+                found="true"
+                break
+            fi
+        done
+        if [ "$found" = "false" ]; then
+            for external_node in $OCF_RESKEY_external_standby_node_list; do
+                # If the target node is outside the cluster, output a warning log.
+                if [ "$config_node" = "$external_node" ]; then
+                    ocf_log warn "The synchronous connection from ${config_node} was disconnected."
+                fi
+            done
+        fi
+    done
 
     for node in $1; do
         if [ $target_count -eq 0 ]; then
@@ -1982,6 +2052,10 @@ validate_ocf_check_level_10() {
 
         NODE_LIST=`echo $OCF_RESKEY_node_list | tr '[A-Z]' '[a-z]'`
         RE_CONTROL_SLAVE="false"
+
+        if [ -n "$OCF_RESKEY_external_standby_node_list" ]; then
+            EXTERNAL_STANDBY_NODE_LIST=`echo $OCF_RESKEY_external_standby_node_list | tr '[A-Z]' '[a-z]'`
+        fi
 
         if ! ocf_is_ms; then
             ocf_exit_reason "Replication(rep_mode=async or sync) requires Master/Slave configuration."

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1641,10 +1641,10 @@ set_sync_mode() {
     # correctly whether or not the commas are followed by spaces.
     if [ $rc -eq 0 ]; then
         # If the setting contains the term FIRST, retrieve the information from within the ()
-        config_node_list=`cat $REP_MODE_CONF | cut -d "(" -f 2 | cut -d ")" -f 1 | sed 's/[",]/ /g'`
+        config_node_list=`cat $REP_MODE_CONF | cut -d "(" -f 2 | cut -d ")" -f 1 | sed 's/[",] */ /g'`
     else
         # If the setting does not contain the term FIRST, retrieve information from within the ''
-        config_node_list=`cat $REP_MODE_CONF | cut -d "'" -f 2 | sed 's/[",]/ /g'`
+        config_node_list=`cat $REP_MODE_CONF | cut -d "'" -f 2 | sed 's/[",] */ /g'`
     fi
     # Normalize whitespace between node names.
     config_node_list=`echo $config_node_list`

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -460,6 +460,8 @@ All node names of synchronous standby nodes that may connect from outside
 the Pacemaker cluster. Please separate each node name with a space.
 When set, the RA automatically manages synchronous_standby_names for both
 in-cluster and external standby nodes during monitor.
+Each node name must match the application_name the standby uses to connect.
+This parameter requires rep_mode=sync.
 This is optional for replication.
 </longdesc>
 <shortdesc lang="en">external standby node list</shortdesc>
@@ -1199,6 +1201,7 @@ control_slave_status() {
     local number_of_nodes
     local target_list
     local standby_node
+    local standby_state
     local found
 
     all_data_status=`exec_sql "$OCF_RESKEY_monitor_user" "${CHECK_REPLICATION_STATE_SQL}"`
@@ -1277,11 +1280,18 @@ control_slave_status() {
         esac
     done
 
-    if [ -n "$OCF_RESKEY_external_standby_node_list" ]; then
+    if [ "$OCF_RESKEY_rep_mode" = "sync" -a -n "$OCF_RESKEY_external_standby_node_list" ]; then
         # Check whether nodes registered in the pg_stat_replication table should be managed by the resource agent.
         for tmp_data_status in $all_data_status; do
             found="false"
             standby_node=`echo $tmp_data_status | cut -d "|" -f 1`
+            standby_state=`echo $tmp_data_status | cut -d "|" -f 2`
+            if [ "$standby_state" != "STREAMING" ]; then
+                # Standbys that are still in catchup, backup or startup state
+                # must not block commits via synchronous_standby_names.
+                ocf_log debug "$standby_node is not streaming (state=$standby_state)."
+                continue
+            fi
             for target in $NODE_LIST; do
                 if [ "$standby_node" = "$target" ]; then
                     found="true"
@@ -1616,6 +1626,7 @@ set_async_mode() {
 }
 
 set_sync_mode() {
+    local rc
     local target_nodes=""
     local target_count=0
     local config_node_list
@@ -1632,6 +1643,22 @@ set_sync_mode() {
     else
         # If the setting does not contain the term FIRST, retrieve information from within the ''
         config_node_list=`cat $REP_MODE_CONF | cut -d "'" -f 2 | sed 's/[",]//g'`
+    fi
+
+    if [ -z "$OCF_RESKEY_external_standby_node_list" ]; then
+        # Without external standbys the RA keeps a single sync standby.
+        # Keep the node already in rep_mode.conf, otherwise every monitor
+        # would switch the sync standby back and forth between the
+        # remaining async standbys on clusters with 3 or more nodes.
+        if [ -n "$config_node_list" ]; then
+            ocf_log debug "$config_node_list is already sync mode."
+        else
+            ocf_log info "Setup $1 into sync mode."
+            runasowner -q err "echo \"synchronous_standby_names = '\\\"$1\\\"'\" > \"$REP_MODE_CONF\""
+            [ "$RE_CONTROL_SLAVE" = "false" ] && RE_CONTROL_SLAVE="true"
+            exec_with_retry 0 reload_conf
+        fi
+        return 0
     fi
 
     sorted1=$(echo "$1" | tr ' ' '\n' | sort)
@@ -2063,6 +2090,10 @@ validate_ocf_check_level_10() {
         fi
         if [ ! "$OCF_RESKEY_rep_mode" = "sync" -a ! "$OCF_RESKEY_rep_mode" = "async" ]; then
             ocf_exit_reason "Invalid rep_mode : $OCF_RESKEY_rep_mode"
+            return $OCF_ERR_CONFIGURED
+        fi
+        if [ -n "$OCF_RESKEY_external_standby_node_list" -a ! "$OCF_RESKEY_rep_mode" = "sync" ]; then
+            ocf_exit_reason "external_standby_node_list requires rep_mode=sync."
             return $OCF_ERR_CONFIGURED
         fi
         if [ ! -n "$NODE_LIST" ]; then

--- a/heartbeat/pgsql
+++ b/heartbeat/pgsql
@@ -1265,14 +1265,14 @@ control_slave_status() {
             "DISCONNECT")
                 change_data_status "$target" "$data_status"
                 change_master_score "$target" "$CAN_NOT_PROMOTE"
-                if [ "$OCF_RESKEY_rep_mode" = "sync" -a -z "$OCF_RESKEY_external_standby_node_list" ]; then
+                if [ "$OCF_RESKEY_rep_mode" = "sync" ] && [ -z "$OCF_RESKEY_external_standby_node_list" ]; then
                     set_async_mode "$target"
                 fi
                 ;;
             *)
                 change_data_status "$target" "$data_status"
                 change_master_score "$target" "$CAN_NOT_PROMOTE"
-                if [ "$OCF_RESKEY_rep_mode" = "sync" -a -z "$OCF_RESKEY_external_standby_node_list" ]; then
+                if [ "$OCF_RESKEY_rep_mode" = "sync" ] && [ -z "$OCF_RESKEY_external_standby_node_list" ]; then
                     set_async_mode "$target"
                 fi
                 change_pgsql_status "$target" "HS:connected"
@@ -1280,12 +1280,12 @@ control_slave_status() {
         esac
     done
 
-    if [ "$OCF_RESKEY_rep_mode" = "sync" -a -n "$OCF_RESKEY_external_standby_node_list" ]; then
+    if [ "$OCF_RESKEY_rep_mode" = "sync" ] && [ -n "$OCF_RESKEY_external_standby_node_list" ]; then
         # Check whether nodes registered in the pg_stat_replication table should be managed by the resource agent.
-        for tmp_data_status in $all_data_status; do
+        for data_status in $all_data_status; do
             found="false"
-            standby_node=`echo $tmp_data_status | cut -d "|" -f 1`
-            standby_state=`echo $tmp_data_status | cut -d "|" -f 2`
+            standby_node=`echo $data_status | cut -d "|" -f 1`
+            standby_state=`echo $data_status | cut -d "|" -f 2`
             if [ "$standby_state" != "STREAMING" ]; then
                 # Standbys that are still in catchup, backup or startup state
                 # must not block commits via synchronous_standby_names.
@@ -1630,20 +1630,24 @@ set_sync_mode() {
     local target_nodes=""
     local target_count=0
     local config_node_list
-    local sorted1
-    local sorted2
+    local sorted_nodes
+    local sorted_config_nodes
     local found
 
     # Check whether the current settings contain the term FIRST
     cat $REP_MODE_CONF | cut -d "'" -f 2 | grep -q "^FIRST "
     rc=$?
+    # Replace quotes and commas with spaces so that node names are parsed
+    # correctly whether or not the commas are followed by spaces.
     if [ $rc -eq 0 ]; then
         # If the setting contains the term FIRST, retrieve the information from within the ()
-        config_node_list=`cat $REP_MODE_CONF | cut -d "(" -f 2 | cut -d ")" -f 1 | sed 's/[",]//g'`
+        config_node_list=`cat $REP_MODE_CONF | cut -d "(" -f 2 | cut -d ")" -f 1 | sed 's/[",]/ /g'`
     else
         # If the setting does not contain the term FIRST, retrieve information from within the ''
-        config_node_list=`cat $REP_MODE_CONF | cut -d "'" -f 2 | sed 's/[",]//g'`
+        config_node_list=`cat $REP_MODE_CONF | cut -d "'" -f 2 | sed 's/[",]/ /g'`
     fi
+    # Normalize whitespace between node names.
+    config_node_list=`echo $config_node_list`
 
     if [ -z "$OCF_RESKEY_external_standby_node_list" ]; then
         # Without external standbys the RA keeps a single sync standby.
@@ -1661,9 +1665,9 @@ set_sync_mode() {
         return 0
     fi
 
-    sorted1=$(echo "$1" | tr ' ' '\n' | sort)
-    sorted2=$(echo "$config_node_list" | tr ' ' '\n' | sort)
-    if [ "$sorted1" = "$sorted2" ]; then
+    sorted_nodes=$(echo "$1" | tr ' ' '\n' | sort)
+    sorted_config_nodes=$(echo "$config_node_list" | tr ' ' '\n' | sort)
+    if [ "$sorted_nodes" = "$sorted_config_nodes" ]; then
        # If the content is the same as the current settings, do not update rep_mode.conf
        ocf_log debug "The same settings already exist."
        return 0
@@ -2092,7 +2096,7 @@ validate_ocf_check_level_10() {
             ocf_exit_reason "Invalid rep_mode : $OCF_RESKEY_rep_mode"
             return $OCF_ERR_CONFIGURED
         fi
-        if [ -n "$OCF_RESKEY_external_standby_node_list" -a ! "$OCF_RESKEY_rep_mode" = "sync" ]; then
+        if [ -n "$OCF_RESKEY_external_standby_node_list" ] && [ ! "$OCF_RESKEY_rep_mode" = "sync" ]; then
             ocf_exit_reason "external_standby_node_list requires rep_mode=sync."
             return $OCF_ERR_CONFIGURED
         fi


### PR DESCRIPTION
## Summary

This PR adds a new feature to the pgsql resource agent that dynamically manages the replication mode of PostgreSQL standbys connecting from outside the Pacemaker cluster, targeting multi-site disaster recovery (DR) use cases.

## Motivation

In multi-site DR architectures where independent Pacemaker HA clusters run at separate sites, PostgreSQL data is replicated from the primary site to the DR site using synchronous streaming replication.

The current pgsql RA has no mechanism to manage replication connections from PostgreSQL instances outside the cluster. Administrators must manually change `synchronous_standby_names` to enable synchronous replication with the DR site. When the out-of-cluster synchronous standby disconnects, **client transactions hang** until an administrator manually reverts the configuration.

## Solution

A new optional parameter `external_standby_node_list` is introduced.
When set, the RA automatically:

1. **Detects connections** from listed external nodes via `pg_stat_replication` during the monitor action
2. **Adds connected nodes** to `synchronous_standby_names` (using `FIRST N (...)` syntax when multiple sync targets exist)
3. **Removes disconnected nodes** from `synchronous_standby_names`, preventing client transaction hangs without administrator intervention

## Use case

**Normal operation:**

```
[Primary Site]                       [DR Site]
  Pacemaker Cluster                    Pacemaker Cluster
  +-----------------------+            +-----------------------+
  | primary1      (PRI)   |  sync rep  | dr-standby1     (HS)  |
  | standby1      (HS)    | -------->  |         |             |
  +-----------------------+            |  async rep (cascade)  |
                                       |         v             |
                                       | dr-standby2     (HS)  |
                                       +-----------------------+
```

**When dr-standby1 fails:**

```
[Primary Site]                       [DR Site]
  Pacemaker Cluster                    Pacemaker Cluster
  +-----------------------+            +-----------------------+
  | primary1      (PRI)   |  sync rep  | dr-standby1  (FAILED) |
  | standby1      (HS)    | -------->  |                       |
  +-----------------------+     |      | dr-standby2     (HS)  |
                                |      +-----------------------+
                                |              ^
                                +--------------+
```

```
node_list="primary1 standby1"
external_standby_node_list="dr-standby1 dr-standby2"
```

In this topology:

- `standby1` is an in-cluster synchronous standby managed by the existing `node_list` parameter.
- `dr-standby1` connects from outside the primary site's cluster via synchronous replication. It is listed in `external_standby_node_list`.
- `dr-standby2` normally replicates asynchronously from `dr-standby1` (cascading replication) and does **not** connect directly to the primary. However, it is also listed in `external_standby_node_list` so that if `dr-standby1` fails, `dr-standby2` can connect directly to the primary and be automatically promoted to synchronous standby.

Key behaviors:

1. When `dr-standby1` connects to the primary, the RA adds it to `synchronous_standby_names` automatically.
2. When `dr-standby1` disconnects, the RA removes it, preventing transaction hangs.
3. If `dr-standby2` then connects directly to the primary (as a failover within the DR site), the RA detects this and adds `dr-standby2` to `synchronous_standby_names` automatically.

This means `external_standby_node_list` serves as a **pre-registered list of potential sync standby nodes** — nodes do not need to be connected at the time of configuration.

## Changes

This PR contains two commits:

### Commit 1: `pgsql: enhance set_sync_mode to support multiple sync standby targets`

Refactors `set_sync_mode()` as a prerequisite:

- Accepts a space-separated list of node names (previously single node only)
- Generates `FIRST N (...)` syntax when there are 2+ sync targets
- Adds idempotency check to skip unnecessary `pg_ctl reload`
- Parses both `FIRST N (...)` and plain quoted format from `rep_mode.conf`

No behavioral change when called with a single node argument (existing usage).

### Commit 2: `pgsql: add external_standby_node_list for out-of-cluster sync replication management`

Adds the new feature:

- New parameter `external_standby_node_list` (optional, default: empty)
- Modified `control_slave_status()` to evaluate external nodes and make a consolidated sync mode decision
- Warning log when a synchronous connection from an external node is lost
- Variable initialization in `validate_ocf_check_level_10()`

## Backward compatibility

- When `external_standby_node_list` is not set (default), behavior is **identical** to the existing implementation
- Designed for `rep_mode="sync"` configurations
- `FIRST N` syntax requires PostgreSQL 9.6+; single-target mode works with PostgreSQL 9.1+

## Testing

Tested with:

- Red Hat Enterprise Linux release 9.6
- pacemaker-2.1.9-1.el9.x86_64
- postgresql17-17.6-1PGDG.rhel9.x86_64

Tested topology: primary1 (PRI) + standby1 (sync HS, in-cluster) + dr-standby1 (sync HS, external) + dr-standby2 (async HS, cascading from dr-standby1).

Test scenarios:

- `dr-standby1` connects → automatically added to `synchronous_standby_names`
- `dr-standby1` disconnects → automatically removed (no transaction hang)
- `dr-standby1` fails, `dr-standby2` connects directly to primary → automatically added to `synchronous_standby_names`
- In-cluster standby + external standby connected simultaneously → `FIRST N (...)` syntax generated
- `external_standby_node_list` not set → identical behavior to current code

## AI disclosure

This PR description and commit messages were written with the assistance of Claude (Anthropic). The code itself was designed and implemented by the author. See the `Assisted-by:` trailer in each commit message.