### PR TITLE
Feature: Add reload feature for trace_ra to prevent resource restarts

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -147,6 +147,14 @@ IPADDR2_CIP_IPTABLES=$IPTABLES
 #######################################################################
 
 meta_data() {
+	local reloadable_attr=""
+	local reload_action=""
+	ocf_version_cmp "${OCF_RESKEY_crm_feature_set:-3.10.0}" "3.10.0"
+	local res=$?
+	if [ $res -eq 0 ] || [ $res -eq 2 ]; then
+		reloadable_attr=' reloadable="1"'
+		reload_action='<action name="reload" timeout="20s" />'
+	fi
 	cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
@@ -472,7 +480,7 @@ Consider the resource failed if the interface has status DOWN or LOWERLAYERDOWN.
 <content type="string" default="${OCF_RESKEY_check_link_status_default}"/>
 </parameter>
 
-<parameter name="trace_ra">
+<parameter name="trace_ra"${reloadable_attr}>
 <longdesc lang="en">
 Set to 1 to turn on resource agent tracing (expect large output)
 The trace output will be saved to trace_file, if set, or by default to
@@ -489,7 +497,7 @@ e.g. $HA_VARLIB/trace_ra/oracle/db.start.2012-11-27.08:37:08
 <action name="stop"    timeout="20s" />
 <action name="status" depth="0"  timeout="20s" interval="10s" />
 <action name="monitor" depth="0"  timeout="20s" interval="10s" />
-<action name="reload"  timeout="20s" />
+${reload_action}
 <action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="20s" />
 </actions>

--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -471,6 +471,17 @@ Consider the resource failed if the interface has status DOWN or LOWERLAYERDOWN.
 <shortdesc lang="en">Consider the resource failed if the interface has status DOWN or LOWERLAYERDOWN</shortdesc>
 <content type="string" default="${OCF_RESKEY_check_link_status_default}"/>
 </parameter>
+
+<parameter name="trace_ra">
+<longdesc lang="en">
+Set to 1 to turn on resource agent tracing (expect large output)
+The trace output will be saved to trace_file, if set, or by default to
+$HA_VARLIB/trace_ra/&lt;type&gt;/&lt;id&gt;.&lt;action&gt;.&lt;timestamp&gt;
+e.g. $HA_VARLIB/trace_ra/oracle/db.start.2012-11-27.08:37:08
+</longdesc>
+<shortdesc lang="en">Set to 1 to turn on resource agent tracing (expect large output)</shortdesc>
+<content type="integer"/>
+</parameter>
 </parameters>
 
 <actions>
@@ -478,6 +489,7 @@ Consider the resource failed if the interface has status DOWN or LOWERLAYERDOWN.
 <action name="stop"    timeout="20s" />
 <action name="status" depth="0"  timeout="20s" interval="10s" />
 <action name="monitor" depth="0"  timeout="20s" interval="10s" />
+<action name="reload"  timeout="20s" />
 <action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="20s" />
 </actions>
@@ -1269,6 +1281,11 @@ ip_monitor() {
 	esac
 }
 
+ip_reload() {
+	ocf_trace_reload
+	return $OCF_SUCCESS
+}
+
 # make sure that we have something to send ARPs with
 set_send_arp_program() {
     ARP_SENDER=send_arp
@@ -1419,6 +1436,8 @@ status)		ip_status=`ip_served`
 		fi
 		;;
 monitor)	ip_monitor
+		;;
+reload)		ip_reload
 		;;
 validate-all)	;;
 *)		ip_usage

--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -480,7 +480,7 @@ $HA_VARLIB/trace_ra/&lt;type&gt;/&lt;id&gt;.&lt;action&gt;.&lt;timestamp&gt;
 e.g. $HA_VARLIB/trace_ra/oracle/db.start.2012-11-27.08:37:08
 </longdesc>
 <shortdesc lang="en">Set to 1 to turn on resource agent tracing (expect large output)</shortdesc>
-<content type="integer"/>
+<content type="boolean"/>
 </parameter>
 </parameters>
 
@@ -1281,11 +1281,6 @@ ip_monitor() {
 	esac
 }
 
-ip_reload() {
-	ocf_trace_reload
-	return $OCF_SUCCESS
-}
-
 # make sure that we have something to send ARPs with
 set_send_arp_program() {
     ARP_SENDER=send_arp
@@ -1437,7 +1432,7 @@ status)		ip_status=`ip_served`
 		;;
 monitor)	ip_monitor
 		;;
-reload)		ip_reload
+reload)		exit $OCF_SUCCESS
 		;;
 validate-all)	;;
 *)		ip_usage

--- a/heartbeat/anything
+++ b/heartbeat/anything
@@ -193,6 +193,11 @@ anything_monitor() {
 	fi
 }
 
+anything_reload() {
+	ocf_trace_reload
+	return $OCF_SUCCESS
+}
+
 # FIXME: Attributes special meaning to the resource id
 process="$OCF_RESOURCE_INSTANCE"
 binfile="$OCF_RESKEY_binfile"
@@ -308,11 +313,23 @@ before sending kill -SIGKILL. Defaults to 2/3 of the stop operation timeout.
 <shortdesc lang="en">Seconds to wait after having sent SIGTERM before sending SIGKILL in stop operation</shortdesc>
 <content type="string" default="${OCF_RESKEY_stop_timeout_default}"/>
 </parameter>
+
+<parameter name="trace_ra">
+<longdesc lang="en">
+Set to 1 to turn on resource agent tracing (expect large output)
+The trace output will be saved to trace_file, if set, or by default to
+$HA_VARLIB/trace_ra/&lt;type&gt;/&lt;id&gt;.&lt;action&gt;.&lt;timestamp&gt;
+e.g. $HA_VARLIB/trace_ra/oracle/db.start.2012-11-27.08:37:08
+</longdesc>
+<shortdesc lang="en">Set to 1 to turn on resource agent tracing (expect large output)</shortdesc>
+<content type="integer"/>
+</parameter>
 </parameters>
 <actions>
 <action name="start"   timeout="20s" />
 <action name="stop"    timeout="20s" />
 <action name="monitor" depth="0"  timeout="20s" interval="10s" />
+<action name="reload"  timeout="20s" />
 <action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="5s" />
 </actions>
@@ -333,6 +350,9 @@ case "$1" in
 	;;
 	monitor)
 		anything_monitor
+	;;
+	reload)
+		anything_reload
 	;;
 	validate-all)
 		anything_validate

--- a/heartbeat/anything
+++ b/heartbeat/anything
@@ -193,11 +193,6 @@ anything_monitor() {
 	fi
 }
 
-anything_reload() {
-	ocf_trace_reload
-	return $OCF_SUCCESS
-}
-
 # FIXME: Attributes special meaning to the resource id
 process="$OCF_RESOURCE_INSTANCE"
 binfile="$OCF_RESKEY_binfile"
@@ -322,7 +317,7 @@ $HA_VARLIB/trace_ra/&lt;type&gt;/&lt;id&gt;.&lt;action&gt;.&lt;timestamp&gt;
 e.g. $HA_VARLIB/trace_ra/oracle/db.start.2012-11-27.08:37:08
 </longdesc>
 <shortdesc lang="en">Set to 1 to turn on resource agent tracing (expect large output)</shortdesc>
-<content type="integer"/>
+<content type="boolean"/>
 </parameter>
 </parameters>
 <actions>
@@ -352,7 +347,7 @@ case "$1" in
 		anything_monitor
 	;;
 	reload)
-		anything_reload
+		exit $OCF_SUCCESS
 	;;
 	validate-all)
 		anything_validate

--- a/heartbeat/anything
+++ b/heartbeat/anything
@@ -233,6 +233,14 @@ anything_validate() {
 }
 
 anything_meta() {
+local reloadable_attr=""
+local reload_action=""
+ocf_version_cmp "${OCF_RESKEY_crm_feature_set:-3.10.0}" "3.10.0"
+local res=$?
+if [ $res -eq 0 ] || [ $res -eq 2 ]; then
+	reloadable_attr=' reloadable="1"'
+	reload_action='<action name="reload" timeout="20s" />'
+fi
 cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
@@ -309,7 +317,7 @@ before sending kill -SIGKILL. Defaults to 2/3 of the stop operation timeout.
 <content type="string" default="${OCF_RESKEY_stop_timeout_default}"/>
 </parameter>
 
-<parameter name="trace_ra">
+<parameter name="trace_ra"${reloadable_attr}>
 <longdesc lang="en">
 Set to 1 to turn on resource agent tracing (expect large output)
 The trace output will be saved to trace_file, if set, or by default to
@@ -324,7 +332,7 @@ e.g. $HA_VARLIB/trace_ra/oracle/db.start.2012-11-27.08:37:08
 <action name="start"   timeout="20s" />
 <action name="stop"    timeout="20s" />
 <action name="monitor" depth="0"  timeout="20s" interval="10s" />
-<action name="reload"  timeout="20s" />
+${reload_action}
 <action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="5s" />
 </actions>

--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -1137,14 +1137,6 @@ ocf_stop_trace() {
 	set +x
 }
 
-ocf_trace_reload() {
-	if ocf_is_true "$OCF_RESKEY_trace_ra"; then
-		ocf_start_trace
-	else
-		ocf_stop_trace
-	fi
-}
-
 # Helper functions to map from nodename/bundle-name and physical hostname
 # list_index_for_word "node0 node1 node2 node3 node4 node5" node4 --> 5
 # list_word_at_index "NA host1 host2 host3 host4 host5" 3      --> host2

--- a/heartbeat/ocf-shellfuncs.in
+++ b/heartbeat/ocf-shellfuncs.in
@@ -1137,6 +1137,14 @@ ocf_stop_trace() {
 	set +x
 }
 
+ocf_trace_reload() {
+	if ocf_is_true "$OCF_RESKEY_trace_ra"; then
+		ocf_start_trace
+	else
+		ocf_stop_trace
+	fi
+}
+
 # Helper functions to map from nodename/bundle-name and physical hostname
 # list_index_for_word "node0 node1 node2 node3 node4 node5" node4 --> 5
 # list_word_at_index "NA host1 host2 host3 host4 host5" 3      --> host2


### PR DESCRIPTION
**Note on AI Usage: > For full transparency, the code and architecture in this PR were developed with the assistance of the Claude AI model .** 


Currently, enabling trace_ra=1 forces Pacemaker to perform a full stop/start cycle on the resource. In production environments, this causes unnecessary service downtime just to enable debug logging.

This PR introduces a zero-downtime solution by leveraging the reload action:

Added a shared ocf_trace_reload function to ocf-shellfuncs.in.

Updated IPaddr2 and anything to include the trace_ra parameter, the <reload> metadata action, and the reload handler.

Tested successfully on a live RHEL 10 Pacemaker cluster. Updating the trace_ra parameter and triggering a reload successfully enables/disables the trace output while the IPaddr2 resource remains in the Started state without any downtime or transition restarts.

```
[root@rhel10node1 ~]# cat /etc/redhat-release
Red Hat Enterprise Linux release 10.0 (Coughlan)
[root@rhel10node1 ~]# date;pcs resource config VirtualIP
Fri Apr 10 05:50:08 AM BST 2026
Resource: VirtualIP (class=ocf provider=heartbeat type=IPaddr2)
  Attributes: VirtualIP-instance_attributes
    ip=192.168.21.211
    trace_ra=0
  Meta Attributes: VirtualIP-meta_attributes
    resource-stickiness=100
  Operations:
    start: VirtualIP-start-interval-0s
      interval=0s timeout=20s
    stop: VirtualIP-stop-interval-0s
      interval=0s timeout=20s
    monitor: VirtualIP-monitor-interval-10s
      interval=10s
[root@rhel10node1 ~]# pcs resource update VirtualIP trace_ra=1
```


- Logs from DC node: 


```
Apr 10 05:50:51 localhost pacemaker-schedulerd[6351]: notice: Actions: Reload     VirtualIP    ( rhel10node2 )
Apr 10 05:50:51 localhost pacemaker-schedulerd[6351]: notice: Calculated transition 58, saving inputs in /var/lib/pacemaker/pengine/pe-input-14.bz2
Apr 10 05:50:51 localhost pacemaker-controld[6352]: notice: Requesting local execution of reload operation for VirtualIP on rhel10node2
Apr 10 05:50:52 localhost IPaddr2(VirtualIP)[425166]: INFO: Enabling trace_ra
Apr 10 05:50:52 localhost pacemaker-controld[6352]: notice: Result of reload operation for VirtualIP on rhel10node2: OK
Apr 10 05:50:52 localhost pacemaker-controld[6352]: notice: Requesting local execution of monitor operation for VirtualIP on rhel10node2
Apr 10 05:50:52 localhost pacemaker-controld[6352]: notice: Result of monitor operation for VirtualIP on rhel10node2: OK
Apr 10 05:50:52 localhost pacemaker-controld[6352]: notice: Transition 58 (Complete=2, Pending=0, Fired=0, Skipped=0, Incomplete=0, Source=/var/lib/pacemaker/pengine/pe-input-14.bz2): Complete
Apr 10 05:50:52 localhost pacemaker-controld[6352]: notice: State transition S_TRANSITION_ENGINE -> S_IDLE
Apr 10 05:54:49 localhost systemd[423612]: Created slice background.slice - User Background Tasks Slice.
Apr 10 05:54:49 localhost systemd[423612]: Starting systemd-tmpfiles-clean.service - Cleanup of User's Temporary Files and Directories...
Apr 10 05:54:49 localhost systemd[423612]: Finished systemd-tmpfiles-clean.service - Cleanup of User's Temporary Files and Directories.
```

```
root@rhel10node1 ~]# pcs resource describe IPaddr2 | egrep -i 'trace|reload'
Assumed agent name 'ocf:heartbeat:IPaddr2' (deduced from 'IPaddr2')
  trace_ra
    Description: Set to 1 to enable resource agent tracing for this resource instance. This parameter can be modified at runtime via the reload action to enable or disable tracing without service interruption.
  reload:
```

```
[root@rhel10node2 ~]# cd /var/lib/heartbeat/trace_ra/IPaddr2/VirtualIP.
Display all 131 possibilities? (y or n)
VirtualIP.monitor.2026-04-09.19:07:34  VirtualIP.monitor.2026-04-09.19:13:10  VirtualIP.monitor.2026-04-10.05:53:25  VirtualIP.monitor.2026-04-10.05:57:27  VirtualIP.monitor.2026-04-10.06:01:29  VirtualIP.monitor.2026-04-10.06:05:31
...
```



- Disabling trace_ra: 

```
[root@rhel10node1 ~]# date;pcs resource config VirtualIP
Fri Apr 10 06:07:35 AM BST 2026
Resource: VirtualIP (class=ocf provider=heartbeat type=IPaddr2)
  Attributes: VirtualIP-instance_attributes
    ip=192.168.21.211
    trace_ra=1
  Meta Attributes: VirtualIP-meta_attributes
    resource-stickiness=100
  Operations:
    start: VirtualIP-start-interval-0s
      interval=0s timeout=20s
    stop: VirtualIP-stop-interval-0s
      interval=0s timeout=20s
    monitor: VirtualIP-monitor-interval-10s
      interval=10s
```

```
[root@rhel10node1 ~]# date;pcs resource update VirtualIP trace_ra=0
Fri Apr 10 06:08:16 AM BST 2026
```

- Logs from DC node showing reload of the metadata instead of restarting entire resource : 

```
Apr 10 06:08:18 localhost pacemaker-controld[6352]: notice: Populating nodes and starting an election after cib_diff_notify event triggered by cibadmin
Apr 10 06:08:18 localhost pacemaker-controld[6352]: notice: State transition S_IDLE -> S_ELECTION
Apr 10 06:08:18 localhost pacemaker-controld[6352]: notice: State transition S_ELECTION -> S_INTEGRATION
Apr 10 06:08:18 localhost pacemaker-controld[6352]: notice: Finalizing join-10 for 2 nodes (sync'ing CIB 0.17.1 with schema pacemaker-4.0 and feature set 3.20.1 from rhel10node2)
Apr 10 06:08:18 localhost pacemaker-schedulerd[6351]: notice: Actions: Reload     VirtualIP    ( rhel10node2 )
Apr 10 06:08:18 localhost pacemaker-schedulerd[6351]: notice: Calculated transition 60, saving inputs in /var/lib/pacemaker/pengine/pe-input-16.bz2
Apr 10 06:08:18 localhost pacemaker-controld[6352]: notice: Requesting local execution of reload operation for VirtualIP on rhel10node2
Apr 10 06:08:18 localhost IPaddr2(VirtualIP)[474230]: INFO: Disabling trace_ra
Apr 10 06:08:18 localhost pacemaker-controld[6352]: notice: Result of reload operation for VirtualIP on rhel10node2: OK
Apr 10 06:08:18 localhost pacemaker-controld[6352]: notice: Requesting local execution of monitor operation for VirtualIP on rhel10node2
Apr 10 06:08:18 localhost pacemaker-controld[6352]: notice: Result of monitor operation for VirtualIP on rhel10node2: OK
Apr 10 06:08:18 localhost pacemaker-controld[6352]: notice: Transition 60 (Complete=2, Pending=0, Fired=0, Skipped=0, Incomplete=0, Source=/var/lib/pacemaker/pengine/pe-input-16.bz2): Complete
Apr 10 06:08:18 localhost pacemaker-controld[6352]: notice: State transition S_TRANSITION_ENGINE -> S_IDLE
```

