### PR TITLE
podman-etcd: fix port 2380 binding race during install transition

### DIFF
--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -932,7 +932,7 @@ etcd_pod_container_exists() {
 	local count_matches
 	# Check whether the etcd pod exists on the same node (including stopped/exited containers)
 	count_matches=$(crictl pods --label app=etcd -q | xargs -I {} crictl ps -a --pod {} -o json | jq -r '.containers[].metadata | select ( .name == "etcd" ).name' | wc -l)
-	if [ "$count_matches" -eq 1 ]; then
+	if [ "$count_matches" -ge 1 ]; then
 		# etcd pod found
 		return 0
 	fi

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -940,6 +940,25 @@ etcd_pod_container_exists() {
 	return 1
 }
 
+wait_for_etcd_ports_release() {
+	local timeout=${1:-60}
+	local elapsed=0
+	if [ -z "$(ss -Htan '( sport = 2379 or sport = 2380 )')" ]; then
+		return 0
+	fi
+	ocf_log info "waiting for etcd ports 2379/2380 to be released (timeout: ${timeout}s)"
+	while [ -n "$(ss -Htan '( sport = 2379 or sport = 2380 )')" ]; do
+		if [ "$elapsed" -ge "$timeout" ]; then
+			ocf_log err "etcd ports still in use after ${timeout}s"
+			return 1
+		fi
+		sleep 1
+		elapsed=$((elapsed + 1))
+	done
+	ocf_log info "etcd ports released after ${elapsed}s"
+	return 0
+}
+
 attribute_node_cluster_id()
 {
 	local action="$1"
@@ -2265,6 +2284,11 @@ podman_start()
 		fi
 	else
 		ocf_log notice "Pull image not required, ${OCF_RESKEY_image}"
+	fi
+
+	if ! wait_for_etcd_ports_release 60; then
+		ocf_exit_reason "etcd ports 2379/2380 still bound — cannot start container"
+		return $OCF_ERR_GENERIC
 	fi
 
 	if ocf_is_true "$OCF_RESKEY_reuse" && container_exists; then


### PR DESCRIPTION
## Summary

Fixes a regression from PR #2112 (OCPBUGS-64765) that causes install failures in Two Node Fencing (TNF) clusters. During the static-pod to podman-etcd transition, the resource agent starts a new etcd container while the old process still holds port 2380, causing repeated `bind: address already in use` failures, standalone fallback, and install timeout.

**Two fixes:**

- **Count check regression** (`etcd_pod_container_exists`): PR #2112 added `-a` to `crictl ps` to include exited containers, but did not update the count check from `-eq 1` to `-ge 1`. During install, etcd container crashes create exited containers that inflate the count past 1, causing the guard to report "pod not found" despite the pod running. This means `pod_was_running` stays `false`, bypassing the normal start path.

- **Port availability check** (`podman_start`): Added a 60-second `ss`-based wait loop before `podman run`/`podman start` that blocks until ports 2379/2380 are free. Modeled on the existing port check in cluster-etcd-operator's `pod.gotpl.yaml`. This prevents bind errors regardless of guard state (defense-in-depth).

## Why the exited container persists

Kubelet's container GC policy (`MaxPerPodContainerCount=1`) intentionally retains the most recent dead container per pod for debugging (`kubectl logs --previous`). This means the exited etcd container is not a transient artifact — it persists by design until replaced by a newer dead container. The race window is deterministic, not timing-dependent: whenever etcd crashes and restarts during bootstrap, the count will be ≥ 2 and the guard will fail.

## Root Cause Timeline

```
08:14:16  etcd static pod starts (bootstrap)
08:14:22  etcd crashes, kubelet retains exited container (MaxPerPodContainerCount=1)
08:14:33  etcd restarts — now 2 containers named "etcd" (1 exited + 1 running)
08:18:44  Pacemaker starts, etcd_pod_container_exists() counts 2 → -eq 1 fails → guard bypassed
08:23:30  CEO writes manifest, kubelet SIGTERMs old etcd (30s grace)
08:23:31  RA starts new container → "bind: address already in use" (port 2380)
08:23:31–57  22 bind failures
08:24:01  Starts with force-new-cluster → standalone (1 member)
09:51:07  Install timeout
```

## Test plan

- [x] `bash -n heartbeat/podman-etcd` passes (syntax check)
- [x] TNF fencing recovery CI job passes: no "bind: address already in use" in journal
- [x] `etcd_pod_container_exists()` correctly detects running pod when exited containers present
- [x] `wait_for_etcd_ports_release` logs appear during install transition, ports freed before start
- [x] Fencing recovery (no static pod) — port check returns immediately (no wait)

Fixes: [OCPBUGS-83742](https://issues.redhat.com/browse/OCPBUGS-83742)
Related: PR #2112 (OCPBUGS-64765), PR #2023 (original `etcd_pod_container_exists` design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)