### PR TITLE
OCPBUGS-84695: podman-etcd single-node cluster handling and transitions

### DIFF
--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -1300,6 +1300,16 @@ clear_standalone_node()
 	crm_attribute --name "standalone_node" --delete
 }
 
+is_single_node()
+{
+	# Check if this is a single-node cluster by examining node_ip_map
+	# Returns 0 (true) if only one node is configured, 1 (false) otherwise
+	local peer_count
+
+	peer_count=$(echo "$OCF_RESKEY_node_ip_map" | tr ';' '\n' | grep -vF "$NODENAME" | wc -l)
+	[ "$peer_count" -eq 0 ]
+}
+
 
 # Promotes an etcd learner member to a voting member
 # Args: $1 - learner member ID in decimal format
@@ -1517,6 +1527,38 @@ manage_peer_membership()
 	local peer_member_name
 	local peer_member_ip
 	local peer_member_id
+
+	# Check if this is a single-node cluster
+	if is_single_node; then
+		# Single-node cluster - no peer to manage
+		ocf_log info "Single-node cluster detected (node_ip_map: '$OCF_RESKEY_node_ip_map')"
+
+		# Clean up any learners from the member list (could be left over from 2→1 transition)
+		local learner_member_id
+		learner_member_id=$(printf "%s" "$member_list_json" | jq -r ".members[] | select( .isLearner==true ).ID")
+		if [ -n "$learner_member_id" ]; then
+			ocf_log warn "Single-node cluster has learner member $learner_member_id - removing to ensure clean state"
+			local learner_member_id_hex
+			if learner_member_id_hex=$(decimal_to_hex "$learner_member_id"); then
+				local endpoint_url
+				endpoint_url=$(ip_url $(attribute_node_ip get))
+				if podman exec "${CONTAINER}" etcdctl --endpoints="$endpoint_url:2379" member remove "$learner_member_id_hex" 2>&1; then
+					ocf_log info "Successfully removed learner member $learner_member_id_hex"
+				else
+					ocf_log warn "Failed to remove learner member $learner_member_id_hex"
+				fi
+			else
+				ocf_log err "Could not convert learner member ID to hex: $learner_member_id"
+			fi
+		fi
+
+		# Ensure standalone_node is set (may have been cleared during 2-node operation)
+		if ! is_standalone; then
+			ocf_log info "Setting standalone_node for single-node cluster"
+			set_standalone_node
+		fi
+		return $OCF_SUCCESS
+	fi
 
 	# Get peer node name and IP
 	peer_ip_map_entry=$(echo "$OCF_RESKEY_node_ip_map" | tr ';' '\n' | grep -vF "$NODENAME")
@@ -2110,16 +2152,26 @@ podman_start()
 				start_resources_count=$(echo "$OCF_RESKEY_CRM_meta_notify_start_resource" | wc -w)
 				ocf_log info "found '$start_resources_count' starting etcd resources (meta notify environment variable: '$OCF_RESKEY_CRM_meta_notify_start_resource')"
 
-				# we need to compare the revisions in any of the following branches
-				# so call the function only once here
-				if ! revision_compare_result=$(compare_revision); then
-					ocf_log err "could not compare revisions, error code: $?"
-					return "$OCF_ERR_GENERIC"
+				# Single-node clusters can't compare revisions with a peer
+				if is_single_node; then
+					ocf_log info "Single-node cluster: starting normally without revision comparison"
+					# No need to set force_new_cluster or compare revisions
+				else
+					# we need to compare the revisions in any of the following branches
+					# so call the function only once here
+					if ! revision_compare_result=$(compare_revision); then
+						ocf_log err "could not compare revisions, error code: $?"
+						return "$OCF_ERR_GENERIC"
+					fi
 				fi
 				case "$start_resources_count" in
 				1)
 					ocf_log debug "peer not starting: ensure we can start a new cluster"
-					if [ "$revision_compare_result" != "older" ]; then
+					if is_single_node; then
+						# Single-node cluster: start normally without revision comparison
+						ocf_log info "Single-node cluster: starting normally"
+						set_standalone_node
+					elif [ "$revision_compare_result" != "older" ]; then
 						# If our revision is the same as or newer than the peer's last saved
 						# revision, and the peer agent isn't currently starting, we can
 						# restore e-quorum by forcing a new cluster.
@@ -2315,7 +2367,13 @@ podman_start()
 					add_member_as_learner "$peer_node_name" "$peer_node_ip"
 					set_standalone_node
 				else
-					ocf_log err "could not add peer as learner (peer node name: ${peer_node_name:-unknown}, peer ip: ${peer_node_ip:-unknown})"
+					# Check if this is a single-node cluster
+					if is_single_node; then
+						ocf_log info "Single-node cluster: setting standalone_node"
+						set_standalone_node
+					else
+						ocf_log err "could not add peer as learner (peer node name: ${peer_node_name:-unknown}, peer ip: ${peer_node_ip:-unknown})"
+					fi
 				fi
 			fi
 			return $OCF_SUCCESS

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -1267,6 +1267,41 @@ clear_standalone_node()
 	crm_attribute --name "standalone_node" --delete
 }
 
+is_single_node()
+{
+	# Check if this is a single-node cluster by examining node_ip_map
+	# Returns 0 (true) if only one node is configured, 1 (false) otherwise
+	# When state is ambiguous or invalid, falls back to multi-node mode (safer)
+	local peer_count node_count
+
+	# Empty node_ip_map - cannot determine topology, fall back to multi-node
+	if [ -z "$OCF_RESKEY_node_ip_map" ]; then
+		ocf_log warn "node_ip_map is empty - cannot determine cluster topology, assuming multi-node operation"
+		return 1
+	fi
+
+	# Check if our node is in the map - if not, we're in an invalid state
+	# Use awk to match node name field exactly (before first colon) to avoid substring matches
+	if ! printf "%s\n" "$OCF_RESKEY_node_ip_map" | tr ';' '\n' | awk -F: -v node="$NODENAME" '$1 == node { found=1 } END { exit !found }'; then
+		ocf_log warn "node $NODENAME not found in node_ip_map ('$OCF_RESKEY_node_ip_map') - invalid state, assuming multi-node operation"
+		return 1
+	fi
+
+	# Count total nodes and peers
+	# Use awk to count entries and match node name field exactly (prevents substring matches like "node1" matching "node10")
+	node_count=$(printf "%s\n" "$OCF_RESKEY_node_ip_map" | tr ';' '\n' | awk 'NF { count++ } END { print count+0 }')
+	peer_count=$(printf "%s\n" "$OCF_RESKEY_node_ip_map" | tr ';' '\n' | awk -F: -v node="$NODENAME" 'NF && $1 != node { count++ } END { print count+0 }')
+
+	# Determine topology based on peer count
+	if [ "$peer_count" -eq 0 ]; then
+		ocf_log debug "Single-node cluster detected (node_count: $node_count, node_ip_map: '$OCF_RESKEY_node_ip_map')"
+		return 0
+	else
+		ocf_log debug "Multi-node cluster detected (node_count: $node_count, peers: $peer_count, node_ip_map: '$OCF_RESKEY_node_ip_map')"
+		return 1
+	fi
+}
+
 
 # Promotes an etcd learner member to a voting member
 # Args: $1 - learner member ID in decimal format
@@ -1538,6 +1573,39 @@ manage_peer_membership()
 	local peer_member_ip
 	local peer_member_id
 
+	# Check if this is a single-node cluster
+	if is_single_node; then
+		# Single-node cluster - no peer to manage
+		ocf_log info "Single-node cluster detected (node_ip_map: '$OCF_RESKEY_node_ip_map')"
+
+		# Clean up any learners from the member list (could be left over from 2→1 transition)
+		local learner_member_id
+		learner_member_id=$(printf "%s" "$member_list_json" | jq -r ".members[] | select( .isLearner==true ).ID")
+		if [ -n "$learner_member_id" ]; then
+			ocf_log warn "Single-node cluster has learner member $learner_member_id - removing to ensure clean state"
+			local learner_member_id_hex
+			if learner_member_id_hex=$(decimal_to_hex "$learner_member_id"); then
+				local endpoint_url
+				endpoint_url=$(ip_url $(attribute_node_ip get))
+				if podman exec "${CONTAINER}" etcdctl --endpoints="$endpoint_url:2379" member remove "$learner_member_id_hex" 2>&1; then
+					ocf_log info "Successfully removed learner member $learner_member_id_hex"
+					attribute_learner_node clear
+				else
+					ocf_log warn "Failed to remove learner member $learner_member_id_hex"
+				fi
+			else
+				ocf_log err "Could not convert learner member ID to hex: $learner_member_id"
+			fi
+		fi
+
+		# Ensure standalone_node is set (may have been cleared during 2-node operation)
+		if ! is_standalone; then
+			ocf_log info "Setting standalone_node for single-node cluster"
+			set_standalone_node
+		fi
+		return $OCF_SUCCESS
+	fi
+
 	# Get peer node name and IP
 	peer_ip_map_entry=$(echo "$OCF_RESKEY_node_ip_map" | tr ';' '\n' | grep -vF "$NODENAME")
 	if [ -z "$peer_ip_map_entry" ]; then
@@ -1729,6 +1797,18 @@ container_health_check()
 	local fnc_holder_count=$(echo "$fnc_holders" | wc -w)
 	if [ "$fnc_holder_count" -gt 0 ]; then
 		ocf_log info "force_new_cluster detected (set by: $fnc_holders), triggering restart"
+		echo "failed-restart-now"
+		return
+	fi
+
+	# Check if this is a single-node cluster - no peer available for recovery
+	if is_single_node; then
+		ocf_log warn "Single-node cluster detected with failed container - no peer available for recovery"
+		# Set standalone_node to ensure proper single-node startup on restart
+		if ! set_standalone_node; then
+			ocf_log err "Failed to set standalone_node attribute, error code: $?"
+		fi
+		# Trigger immediate restart instead of waiting for non-existent peer
 		echo "failed-restart-now"
 		return
 	fi
@@ -2144,16 +2224,39 @@ podman_start()
 				start_resources_count=$(echo "$OCF_RESKEY_CRM_meta_notify_start_resource" | wc -w)
 				ocf_log info "found '$start_resources_count' starting etcd resources (meta notify environment variable: '$OCF_RESKEY_CRM_meta_notify_start_resource')"
 
-				# we need to compare the revisions in any of the following branches
-				# so call the function only once here
-				if ! revision_compare_result=$(compare_revision); then
-					ocf_log err "could not compare revisions, error code: $?"
-					return "$OCF_ERR_GENERIC"
+				# Standalone node doesn't need peer comparison (matches active_resources_count=1 logic)
+				# Check this before is_single_node to handle drift reconciliation where standalone_node
+				# is set but node_ip_map may already include the peer being added
+				if is_standalone; then
+					ocf_log info "standalone node: skip peer comparison during recovery"
+					# Skip peer comparison - standalone_node is a persistent marker indicating we should
+					# force a new cluster on restart (set during quorum loss or single-node operation).
+					# revision_compare_result is intentionally left unset here - the is_single_node check
+					# in the start_resources_count case below will differentiate:
+					#   - True single-node: start normally without force_new_cluster
+					#   - Multi-node with standalone marker: set force_new_cluster (cold start after quorum loss)
+					# Note: This only forces new cluster when start_resources_count=1 (cold start).
+					# If active_resources_count=1 (peer already running), the new node joins as learner
+					# without force_new_cluster (handled in active_resources_count=1 case above).
+				elif is_single_node; then
+					ocf_log info "Single-node cluster: starting normally without revision comparison"
+					# No need to set force_new_cluster or compare revisions
+				else
+					# we need to compare the revisions in any of the following branches
+					# so call the function only once here
+					if ! revision_compare_result=$(compare_revision); then
+						ocf_log err "could not compare revisions, error code: $?"
+						return "$OCF_ERR_GENERIC"
+					fi
 				fi
 				case "$start_resources_count" in
 				1)
 					ocf_log debug "peer not starting: ensure we can start a new cluster"
-					if [ "$revision_compare_result" != "older" ]; then
+					if is_single_node; then
+						# Single-node cluster: start normally without revision comparison
+						ocf_log info "Single-node cluster: starting normally"
+						set_standalone_node
+					elif [ "$revision_compare_result" != "older" ]; then
 						# If our revision is the same as or newer than the peer's last saved
 						# revision, and the peer agent isn't currently starting, we can
 						# restore e-quorum by forcing a new cluster.
@@ -2358,7 +2461,13 @@ podman_start()
 					fi
 					set_standalone_node
 				else
-					ocf_log err "could not add peer as learner (peer node name: ${peer_node_name:-unknown}, peer ip: ${peer_node_ip:-unknown})"
+					# Check if this is a single-node cluster
+					if is_single_node; then
+						ocf_log info "Single-node cluster: setting standalone_node"
+						set_standalone_node
+					else
+						ocf_log err "could not add peer as learner (peer node name: ${peer_node_name:-unknown}, peer ip: ${peer_node_ip:-unknown})"
+					fi
 				fi
 			fi
 			return $OCF_SUCCESS


### PR DESCRIPTION
OCPBUGS-84695: fix(podman-etcd): single-node cluster handling and transitions

Add comprehensive single-node cluster support to podman-etcd resource agent,
including initial deployment, restart scenarios, and transitions between
single-node and two-node configurations.

This PR works in tandem with https://github.com/openshift/cluster-etcd-operator/pull/1605

Changes:
- Add is_single_node() helper function for clean single-node detection
- Handle single-node mode in peer management (clean up learners, set standalone_node)
- Set standalone_node during single-node start to mark standalone state
- Fix monitor path to set standalone_node during two-node to single-node transitions
- Clean up learner members during 2→1 node transitions in monitor path
- Fix restart failures by skipping revision comparison when no peer exists
- Ensure standalone_node attribute is properly maintained across all transitions

Fixes restart failures, 2→1 node transitions, and initial single-node deployments.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>