### PR TITLE
Filesystem: always return OCF_ERR_GENERIC when another device is mounted on mountpoint to ensure relocation after trying to restart (default behaviour)

### DIFF
--- a/heartbeat/Filesystem
+++ b/heartbeat/Filesystem
@@ -1029,11 +1029,7 @@ Filesystem_status()
 					rc=$OCF_NOT_RUNNING
 				else
 					ocf_exit_reason "Another device ($mounted_device) is already mounted on $MOUNTPOINT"
-					if [ "$__OCF_ACTION" = "monitor" ]; then
-						rc=$OCF_ERR_GENERIC
-					else
-						rc=$OCF_ERR_CONFIGURED
-					fi
+					rc=$OCF_ERR_GENERIC
 				fi
 			fi
 		else


### PR DESCRIPTION
Solves issue with https://github.com/ClusterLabs/resource-agents/pull/2138 not making the resource relocate after it tried to restart on the same node.