### PR TITLE
nfsserver: Stop fsidd when stopping nfs-server

### DIFF
--- a/heartbeat/nfsserver
+++ b/heartbeat/nfsserver
@@ -1010,6 +1010,18 @@ nfsserver_stop ()
 		  		return $OCF_ERR_GENERIC
 		  	fi
 		  fi
+
+          nfs_exec stop fsidd > /dev/null 2>&1
+          ocf_log info "Stop: fsidd"
+          fn=`mktemp`
+          nfs_exec status fsidd > $fn 2>&1
+          rc=$?
+          ocf_log debug "$(cat $fn)"
+          rm -f $fn
+          if [ "$rc" -eq "0" ]; then
+            ocf_exit_reason "Failed to stop fsidd"
+            return $OCF_ERR_GENERIC
+          fi
 	esac
 
 


### PR DESCRIPTION
Stop fsidd.service as in some cases it can block unmouting bind mounts when using `nfs_shared_infodir`

Fixes: https://github.com/ClusterLabs/resource-agents/issues/2164