### PR TITLE
Mid: IPaddr2: To allow Pacemaker to handle error handling, it returns NOT_RUNNING even when down.

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -1256,11 +1256,8 @@ ip_monitor() {
 		run_arp_sender refresh
 		return $OCF_SUCCESS
 		;;
-	no)
+	no|down)
 		exit $OCF_NOT_RUNNING
-		;;
-	down)
-		exit $OCF_ERR_INSTALLED
 		;;
 	*)
 		# Errors on this interface?


### PR DESCRIPTION
Hi All,

This fix is ​​based on the following issue.
 - https://github.com/ClusterLabs/resource-agents/issues/2113

Best Regards,
Hideo  Yamauchi.