### PR TITLE
ganesha-nfs: match IPv4-mapped IPv6 listeners in readiness probe

### DIFF
--- a/heartbeat/ganesha-nfs
+++ b/heartbeat/ganesha-nfs
@@ -194,6 +194,7 @@ port_listening() {
         ss -Hln -tnp "sport = :${port}" 2>/dev/null | \
             awk -v ip="$ip" '
                 { addr=$4; sub(/:[^:]+$/,"",addr); gsub(/[\[\]]/,"",addr);
+                  sub(/^::ffff:/,"",addr);
                   if (addr==ip || addr=="0.0.0.0" || addr=="*" || addr=="::" || addr=="") { found=1 } }
                 END { exit(found?0:1) }'
         return $?


### PR DESCRIPTION
## What

`port_listening()` in `ocf:heartbeat:ganesha-nfs` fails to recognise the listening socket when `nfs_ip` is an IPv4 address, causing `start` to time out spuriously.

## Why

When `nfs_ip` is IPv4 (e.g. `10.1.10.1`), `ganesha.nfsd` binds the socket as an IPv4-mapped IPv6 address, and `ss` reports it as `[::ffff:10.1.10.1]:<port>`. `port_listening()` strips the brackets and the port, then compares the result against the bare `nfs_ip` string — which never matches the `::ffff:` form. As a result:

- `start` waits the full `start_timeout` and then exits `OCF_ERR_GENERIC` ("did not become ready"), even though ganesha is up and serving.
- `monitor` similarly misreports not-listening for an IPv4 `nfs_ip`.

An empty/wildcard `nfs_ip` is unaffected (it takes the other branch), and an IPv6 `nfs_ip` matches directly — which is why this was not caught when the agent was first merged (#2154), where the service IPs used in validation were IPv6.

## Fix

Normalise the IPv4-mapped prefix before comparing:

```sh
sub(/^::ffff:/,"",addr);
```

One line; no behaviour change for IPv6 or wildcard listeners.

## Testing

Reproduced and verified on a 3-node AlmaLinux 9.7 / NFS-Ganesha V5.9 cluster:

- **Before:** `nfs_ip=10.1.10.1` → `ss` shows `[::ffff:10.1.10.1]:2050`; `start` fails with a "did not become ready within Ns" timeout despite a live, mountable NFSv4 export.
- **After:** `start` detects readiness immediately, `monitor` returns success, and an NFSv4 mount from a permitted client succeeds.
