### PR TITLE
OCPBUGS-86897: podman-etcd: stop triggering restart on cert rotation

### DIFF
--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -1826,9 +1826,13 @@ podman_monitor()
 			;;
 	esac
 
-	# Check if certificate files have changed, if they have, etcd needs to be restarted
+	# etcd 3.6+ hot-reloads TLS certificates on each new handshake.
+	# Update the stored hash so we don't re-detect the same change, but do NOT
+	# trigger a restart — if the new certs cause a real TLS failure,
+	# monitor_cmd_exec will catch it below.
 	if ! etcd_certificates_hash_manager "check"; then
-		return $OCF_ERR_GENERIC
+		ocf_log info "certificate files changed — updating hash (etcd hot-reloads TLS certs)"
+		etcd_certificates_hash_manager "update"
 	fi
 
 	if is_learner; then


### PR DESCRIPTION
## Problem

On TNF clusters, every cert rotation of any kind triggers an unnecessary full etcd member self-removal via the podman-etcd OCF agent. The cert hash monitor detects changes, triggers a stop, which calls `leave_etcd_member_list()` causing self-removal, wipes `/var/lib/etcd/member`, then rejoins as a learner with a new member ID.

This happens **silently** on every cert rotation CI run: node removal, signer rotation, leaf cert recreation, trust bundle recreation. CI analysis confirmed the bug fires **10 times per run** (5 cert changes × 2 nodes) on both PASS and FAIL runs. Tests don't catch it because they check CEO-side revision stability, not podman-etcd lifecycle. Self-heals in ~30s, so it's been invisible.

On standard OCP, CEO handles cert rotation via an in-place static pod restart (same member ID, same data). The podman-etcd agent is the only path that treats cert changes as a cluster leave event.

## Solution

**etcd 3.6+ (OCP 4.22) hot-reloads TLS certificates** on each new handshake via Go's `GetCertificate` callback ([etcd PR #7829](https://github.com/etcd-io/etcd/pull/7829)). No restart is needed for cert rotation.

The fix changes `podman_monitor()` to update the stored hash and return `$OCF_SUCCESS` instead of triggering a restart. If a new cert causes a real TLS failure, `monitor_cmd_exec` catches it on the same or next cycle via the existing health check path.

## Impact

- Eliminates ~10 unnecessary etcd member self-removal + learner rejoin cycles per cert rotation CI run
- Member IDs remain stable across cert rotations (same as standard OCP behavior)
- Reduces cert rotation disruption from ~30s (learner rejoin) to zero

## Testing

- **Test 1** (`oc delete node`): CEO triggered revisions 14+15, monitor updated hash, zero disruption
- **Test 2** (simulated cert change): Hash update only, no self-removal
- **Test 3** (dual-node simultaneous cert change): Hash updates only on both nodes
- **Test 4** (container failure negative baseline): Normal recovery via `force_new_cluster`, no regression
- **TNF cert rotation suite** (`openshift-tests`): 0 `leaving members list` entries, 7 zero-disruption hash updates across both nodes. Member IDs stable throughout.

Related: OCPBUGS-86897
