### PR TITLE
doc: Fix links after master->main rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ in the OCF Resource Agent Developer's guide (link below).
 ## Where can I find more information?
 
 * [ClusterLabs website](http://www.clusterlabs.org/)
-* [OCF Resource Agent Developer's guide](https://github.com/ClusterLabs/resource-agents/blob/master/doc/dev-guides/ra-dev-guide.asc)
+* [OCF Resource Agent Developer's guide](https://github.com/ClusterLabs/resource-agents/blob/main/doc/dev-guides/ra-dev-guide.asc)
 * Mailing lists for [users](http://oss.clusterlabs.org/mailman/listinfo/users) and [developers](http://oss.clusterlabs.org/mailman/listinfo/developers)
 * [ClusterLabs IRC channel](https://wiki.clusterlabs.org/wiki/ClusterLabs_IRC_channel)

--- a/heartbeat/lxc.in
+++ b/heartbeat/lxc.in
@@ -1,6 +1,6 @@
 #!@BASH_SHELL@
 # Should now conform to guidelines:
-# https://github.com/ClusterLabs/resource-agents/blob/master/doc/dev-guides/ra-dev-guide.asc
+# https://github.com/ClusterLabs/resource-agents/blob/main/doc/dev-guides/ra-dev-guide.asc
 #
 #	LXC (Linux Containers) OCF RA.
 #	Used to cluster enable the start, stop and monitoring of a LXC container.

--- a/ldirectord/OCF/ldirectord.in
+++ b/ldirectord/OCF/ldirectord.in
@@ -6,9 +6,9 @@
 #   Tested on SuSE Linux Enterprise Server 10.
 #
 #   Should conform to the specification found at
-#    https://github.com/ClusterLabs/resource-agents/blob/master/doc/dev-guides/ra-dev-guide.asc
+#    https://github.com/ClusterLabs/resource-agents/blob/main/doc/dev-guides/ra-dev-guide.asc
 #   and
-#    https://github.com/ClusterLabs/OCF-spec/blob/master/ra/resource-agent-api.md
+#    https://github.com/ClusterLabs/OCF-spec/blob/main/ra/1.1/resource-agent-api.md
 #
 #   ToDo: Add parameter to start several instances of ldirectord
 #   with different config files.


### PR DESCRIPTION
There are several broken links in the source code, including one in the top-level README.md (and thus on the main github page of the project). These are caused by renaming the default branch from master to main some time in the past.