### PR TITLE
conntrackd: fix monitor/start logic

### DIFF
--- a/heartbeat/conntrackd.in
+++ b/heartbeat/conntrackd.in
@@ -119,11 +119,10 @@ conntrackd_monitor() {
 	local conntrack_socket=$(awk '/^[ \t]*UNIX[ \t]*{/,/^[ \t]*}/ { if ($1 == "Path") { print $2 } }' $OCF_RESKEY_config)
 	[ -S "$conntrack_socket" ] && rc=$OCF_SUCCESS
 	if [ "$rc" -eq "$OCF_SUCCESS" ]; then
-		# conntrackd is running
+		# socket exists
 		# now see if it acceppts queries
 		if ! $OCF_RESKEY_binary -C $OCF_RESKEY_config -s > /dev/null 2>&1; then
-			rc=$OCF_ERR_GENERIC
-			ocf_exit_reason "conntrackd is running but not responding to queries"
+			return $OCF_NOT_RUNNING
 		fi
 		if conntrackd_is_master; then
 			rc=$OCF_RUNNING_MASTER
@@ -162,6 +161,14 @@ conntrackd_start() {
 			break
 			;;
 		$OCF_NOT_RUNNING)
+			# The socket is dead, so we can remove lockfile as well
+			local lockfile=$(awk '/^[ \t]*LockFile[ \t]*/ { print $2 }' $OCF_RESKEY_config)
+			if test -e "$lockfile"
+			then
+				ocf_log info "Removing stale lockfile $lockfile"
+				rm -f "$lockfile"
+			fi
+
 			ocf_log info "Starting conntrackd"
 			$OCF_RESKEY_binary -C $OCF_RESKEY_config -d
 			;;


### PR DESCRIPTION
The logic in conntrackd resource agent is incorrect:

conntrackd RA tests whether the conntrackd socket exists, and if so, it tries to connect to the socket using conntrackd -s. If it does not respond (conntrackd -s fails), the presumed reason is that conntrackd is running, but it is not responsive. The real reason is that the socket is stale after a daemon or system crash, and the daemon is not running anymore.

The second problem is that conntrackd has a lockfile, but this lockfile is useless for detection whether the daemon is running, as it is not a pidfile where a PID can be checked. Fedora/RH packages of conntrack-tools run

	ExecStartPre=/bin/rm -f /var/lock/conntrack.lock

from conntrackd.service unconditionally. The file mentions Red Hat bugzilla bug##1255578 (apparently not publicly viewable). When we determine that the daemon is not running (no socket at all or stale socket, see above), we may remove the lockfile as well.