### PR TITLE
portblock: fix IPv6 rule detection in the iptables backend (unblock/monitor)

### DIFF
--- a/heartbeat/portblock
+++ b/heartbeat/portblock
@@ -323,7 +323,10 @@ END
 active_grep_pat()
 {
   w="[ 	][ 	]*"
-  any="0\\.0\\.0\\.0/0"
+  case $ip_family in
+    ip6) any="::/0" ;;
+    *)   any="0\\.0\\.0\\.0/0" ;;
+  esac
   src=$any dst=$3
   if [ "$4" = "s" ]; then
     local src=$3
@@ -346,9 +349,9 @@ active_grep_pat()
     fi
   else
     if [ "$method" = "DROP" ]; then
-      echo "^DROP${w}${prot}${w}--${w}${src}${w}${dst}${w}multiport${w}${4}ports${w}${2}$"
+      echo "^DROP${w}${prot}${w}\(--${w}\)\?${src}${w}${dst}${w}multiport${w}${4}ports${w}${2}$"
     else
-      echo "^REJECT${w}${prot}${w}--${w}${src}${w}${dst}${w}multiport${w}${4}ports${w}${2}${w}ctstate${w}NEW,RELATED,ESTABLISHED${w}reject-with${w}tcp-reset$"
+      echo "^REJECT${w}${prot}${w}\(--${w}\)\?${src}${w}${dst}${w}multiport${w}${4}ports${w}${2}${w}ctstate${w}NEW,RELATED,ESTABLISHED${w}reject-with${w}tcp-reset$"
     fi
   fi
 }


### PR DESCRIPTION
## Problem

`ocf:heartbeat:portblock` does not correctly handle IPv6 service IPs on the **iptables** backend. The block path appears to work, but **unblock, stop, and monitor are broken** for IPv6.

The root cause is in `active_grep_pat()`, which builds the regex used to find existing `DROP`/`REJECT` rules in `iptables -L` output:

```sh
active_grep_pat()
{
  w="[ 	][ 	]*"
  any="0\.0\.0\.0/0"      # <-- IPv4 "anywhere", hardcoded
  src=$any dst=$3
  ...
  echo "^DROP${w}${prot}${w}--${w}${src}${w}${dst}${w}multiport${w}${4}ports${w}${2}$"
```

`ip6tables -L` prints `::/0` (not `0.0.0.0/0`) in the "anywhere" source/destination column, so for an IPv6 address the regex never matches an existing rule. `chain_isactive()` therefore always reports the rule as **absent**.

Since rule handling is gated on that detection:

- **`unblock start`** → `DoIptables -D` sees `active=0 want_active=0` ("already in desired state") and **skips the delete** → the DROP rule is never removed → the port stays blocked *after* the protected service is up. This is the headline bug: on failover, the new active node blocks NFS/the service indefinitely.
- **`block stop`** → same path, leaves the DROP rule behind.
- **`monitor`/`status`** → always report inactive for IPv6.
- Repeated starts can **accumulate duplicate** rules.

`block start` *looks* fine only because `IptablesBLOCK()` inserts the rule whenever detection reports it absent — which masks the bug.

The `nft` backend is unaffected: PR #2153 made it family-aware via `$ip_family`. Only the legacy `iptables -L` detection path was left with the hardcoded IPv4 literal.

## Fix

Use the already-defined `$ip_family` to pick the correct "anywhere" literal for the iptables `-L` detection regex:

```sh
  any="0\.0\.0\.0/0"
  [ "$ip_family" = "ip6" ] && any="::/0"
```

Minimal and symmetric with the existing `nft` handling. IPv4 behaviour is byte-for-byte unchanged.

## Test environment

- 3-node **AlmaLinux 9.7** cluster (kernel `5.14.0-611`)
- `iptables` / `ip6tables` **v1.8.10 (nf_tables)**
- Dual-stack VXLAN overlay: IPv4 `10.1.10.0/24` + IPv6 ULA `fd00:10:1:10::/64`
- DRBD 9 + LINSTOR + drbd-reactor; portblock exercised both directly (OCF actions) and end-to-end via LINSTOR Gateway **kernel NFS** with an IPv6 service IP.

### Direct OCF test (service IP `fd00:10:1:10::200`, tcp/12049)

| step | action | expected | before fix | after fix |
|------|--------|----------|------------|-----------|
| 1 | `block start` | DROP added | rule added | ✅ rule added |
| 2 | `block start` again | no duplicate | **2nd rule added** | ✅ still 1 rule |
| 3 | `unblock start` | DROP removed | **rule lingers** | ✅ rule removed |
| 4 | `monitor` (unblock) | reports gone | wrong | ✅ correct |
| 5 | `block stop` | clean | **rule lingers** | ✅ clean |

IPv4 regression (`10.99.99.99`, checked against the v4 table): add → no-duplicate → remove → clean, unchanged.

### End-to-end via LINSTOR Gateway kernel NFS (service IP `fd00:10:1:10::70`, tcp/2049)

Chain emitted: `portblock(block) → IPaddr2 → nfsserver → exportfs → portblock(unblock)`.

The `portunblock` unit's own debug line confirms detection now works:

```
ocf-rs-wrapper: active: 1 want_active: 0
```

`active: 1` means `chain_isactive()` found the existing DROP rule (before the fix this was `active: 0`, so the delete was skipped). After full startup, `ip6tables -L INPUT` shows **no leftover DROP** for the service IP, and an external NFSv4.2 client mounts over IPv6 successfully.

## Scope / notes

- Only the `iptables` backend detection path is touched; `nft` is already correct.
- `tickle_tcp`/`tickle_local` IPv6 handling is out of scope (only relevant when `tickle_dir` is set) and unchanged here.
- Builds on the IPv6 work merged in #2153.
