### PR TITLE
OCPBUGS-86897: podman-etcd: replace fatal abort with FNC tiebreaker

### DIFF
--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -2179,6 +2179,7 @@ podman_start()
 		local fnc_holder_count
 		fnc_holder_count=$(echo "$fnc_holders" | wc -w)
 		if [ "$fnc_holder_count" -gt 1 ]; then
+			# Tiebreaker: highest revision wins; tied or unavailable revisions fall back to alphabetical node name
 			ocf_log warn "force_new_cluster set on multiple nodes ($fnc_holders) — resolving with revision tiebreaker"
 			local tiebreaker_winner=""
 
@@ -2211,6 +2212,7 @@ podman_start()
 				fi
 			fi
 
+			# Tied revisions (or both unavailable): fall back to alphabetical node name
 			if [ -z "$tiebreaker_winner" ]; then
 				local node_names_sorted
 				node_names_sorted=$(echo "$OCF_RESKEY_node_ip_map" | sed 's/:[^;]*//g; s/;/ /g' | tr ' ' '\n' | sort | tr '\n' ' ')
@@ -2306,6 +2308,7 @@ podman_start()
 					# TODO: can we start "normally", regardless the revisions, if the container-id is the same on both nodes?
 					ocf_log info "peer starting"
 					if [ "$revision_compare_result" = "newer" ]; then
+						ocf_log warn "local revision is newer but peer is also starting — investigate if peer was fenced mid-operation"
 						if ! set_force_new_cluster; then
 							ocf_log err "could not set force_new_cluster (peer may already hold it)"
 							return "$OCF_ERR_GENERIC"

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -2173,8 +2173,43 @@ podman_start()
 		local fnc_holder_count
 		fnc_holder_count=$(echo "$fnc_holders" | wc -w)
 		if [ "$fnc_holder_count" -gt 1 ]; then
-			ocf_exit_reason "force_new_cluster attribute is set on multiple nodes ($fnc_holders)"
-			return "$OCF_ERR_CONFIGURED"
+			ocf_log warn "force_new_cluster set on multiple nodes ($fnc_holders) — resolving with revision tiebreaker"
+			local tiebreaker_winner=""
+
+			if revision_compare_result=$(compare_revision); then
+				case "$revision_compare_result" in
+				newer)
+					tiebreaker_winner="$NODENAME"
+					;;
+				older)
+					tiebreaker_winner="peer"
+					;;
+				esac
+			fi
+
+			if [ -z "$tiebreaker_winner" ]; then
+				local node_names_sorted
+				node_names_sorted=$(echo "$OCF_RESKEY_node_ip_map" | sed 's/:[^;]*//g; s/;/ /g' | tr ' ' '\n' | sort | tr '\n' ' ')
+				local first_node
+				first_node=$(echo "$node_names_sorted" | cut -d' ' -f1)
+				if [ "$NODENAME" = "$first_node" ]; then
+					tiebreaker_winner="$NODENAME"
+					ocf_log notice "$NODENAME wins tiebreaker (alphabetical, revisions equal or unavailable)"
+				else
+					tiebreaker_winner="peer"
+					ocf_log notice "$NODENAME loses tiebreaker (alphabetical, revisions equal or unavailable)"
+				fi
+			fi
+
+			if [ "$tiebreaker_winner" = "$NODENAME" ]; then
+				ocf_log notice "$NODENAME wins tiebreaker — keeping force_new_cluster"
+				JOIN_AS_LEARNER=false
+			else
+				ocf_log notice "$NODENAME loses tiebreaker — clearing force_new_cluster, joining as learner"
+				clear_force_new_cluster
+				ocf_log info "fnc cleared after tiebreaker, proceeding as learner"
+				JOIN_AS_LEARNER=true
+			fi
 		fi
 
 		if [ "$fnc_holder_count" -eq 1 ]; then

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -1212,7 +1212,13 @@ add_member_as_learner()
 
 set_force_new_cluster()
 {
-	local rc
+	local rc fnc_holders
+
+	if fnc_holders=$(get_force_new_cluster) && [ -n "$fnc_holders" ]; then
+		ocf_log err "cannot set force_new_cluster: already held by $fnc_holders"
+		return $OCF_ERR_GENERIC
+	fi
+
 	crm_attribute --lifetime reboot --node "$NODENAME" --name "force_new_cluster" --update "$NODENAME"
 	rc=$?
 	if [ $rc -ne 0 ]; then
@@ -2185,6 +2191,24 @@ podman_start()
 					tiebreaker_winner="peer"
 					;;
 				esac
+			else
+				local local_rev peer_rev
+				local_rev=$(attribute_node_revision get)
+				peer_rev=$(attribute_node_revision_peer)
+				local local_has_rev=true peer_has_rev=true
+				if [ "$local_rev" = "" ] || [ "$local_rev" = "null" ]; then
+					local_has_rev=false
+				fi
+				if [ "$peer_rev" = "" ] || [ "$peer_rev" = "null" ]; then
+					peer_has_rev=false
+				fi
+				if [ "$local_has_rev" = true ] && [ "$peer_has_rev" = false ]; then
+					tiebreaker_winner="$NODENAME"
+					ocf_log notice "$NODENAME wins tiebreaker (only node with revision: $local_rev)"
+				elif [ "$local_has_rev" = false ] && [ "$peer_has_rev" = true ]; then
+					tiebreaker_winner="peer"
+					ocf_log notice "$NODENAME loses tiebreaker (peer is only node with revision)"
+				fi
 			fi
 
 			if [ -z "$tiebreaker_winner" ]; then
@@ -2268,7 +2292,10 @@ podman_start()
 						# If our revision is the same as or newer than the peer's last saved
 						# revision, and the peer agent isn't currently starting, we can
 						# restore e-quorum by forcing a new cluster.
-						set_force_new_cluster
+						if ! set_force_new_cluster; then
+							ocf_log err "could not set force_new_cluster (peer may already hold it)"
+							return "$OCF_ERR_GENERIC"
+						fi
 					else
 						ocf_log err "local revision is older and peer is not starting: cannot start"
 						ocf_exit_reason "local revision is older and peer is not starting: cannot start"
@@ -2279,7 +2306,10 @@ podman_start()
 					# TODO: can we start "normally", regardless the revisions, if the container-id is the same on both nodes?
 					ocf_log info "peer starting"
 					if [ "$revision_compare_result" = "newer" ]; then
-						set_force_new_cluster
+						if ! set_force_new_cluster; then
+							ocf_log err "could not set force_new_cluster (peer may already hold it)"
+							return "$OCF_ERR_GENERIC"
+						fi
 					elif [ "$revision_compare_result" = "older" ]; then
 						ocf_log info "$NODENAME shall join as learner"
 						JOIN_AS_LEARNER=true

--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -2210,9 +2210,7 @@ podman_start()
 				ocf_log info "fnc cleared after tiebreaker, proceeding as learner"
 				JOIN_AS_LEARNER=true
 			fi
-		fi
-
-		if [ "$fnc_holder_count" -eq 1 ]; then
+		elif [ "$fnc_holder_count" -eq 1 ]; then
 			if echo "$fnc_holders" | grep -q -w "$NODENAME"; then
 				# Attribute is set on the local node.
 				ocf_log notice "$NODENAME marked to force-new-cluster"


### PR DESCRIPTION
## Problem

When both TNF control-plane nodes race to claim `force_new_cluster` (network partition, simultaneous power events, dual container failures), the previous code aborted with `OCF_ERR_CONFIGURED` on both nodes — causing total etcd outage requiring manual intervention.

## Solution

Replace the fatal abort with a deterministic tiebreaker:
1. **Revision comparison**: Higher etcd data revision wins
2. **One-sided revision**: Node with data wins over node without
3. **Alphabetical fallback**: When revisions are equal or both unavailable, use hostname sort

The loser clears its `force_new_cluster` attribute and joins as learner.

## Additional hardening

- **FNC pre-check**: `set_force_new_cluster` checks if peer already holds FNC before setting, reducing the dual-FNC race window
- **Graceful failure**: Callers at both start-path `set_force_new_cluster` sites check return codes
- **Structural fix**: Changed `if/fi; if/else/fi` → `if/elif/else/fi` so dual-holder, single-holder, and no-holder cases are mutually exclusive (prevents else block from overriding tiebreaker decision)

## Testing

- **Test 5 (network partition)**: Both nodes set FNC during partition recovery. Pre-check prevented dual FNC on first re-run; tiebreaker exercised on initial run (master-0 won alphabetically, master-1 rejoined as learner). Recovery in 15-45s.
- **Test 4 (container failure)**: Normal recovery via `detect_cluster_leadership_loss` → FNC on survivor. No regression.
- **Full openshift-tests DualReplica suite**: 20/20 tests passed with combined cert + FNC fixes

## Known issue (for discussion)

Carlo noted a potential CIB staleness race: during partition recovery, stale peer revision data in the CIB could cause both nodes to think they won the tiebreaker. See `cib-staleness-race.md` in project OCPBUGS-86897 for full analysis. Needs discussion on whether Pacemaker CIB sync guarantees + 200ms timing window is sufficient, or if explicit re-verification is needed.

Related: OCPBUGS-86897
