### PR TITLE
OCPBUGS-86897: podman-etcd: remove cert monitoring infrastructure

### DIFF
--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -40,7 +40,6 @@
 # Parameter defaults
 OCF_RESKEY_image_default="default"
 OCF_RESKEY_pod_manifest_default="/etc/kubernetes/static-pod-resources/etcd-certs/configmaps/external-etcd-pod/pod.yaml"
-OCF_RESKEY_etcd_certs_dir_default="/etc/kubernetes/static-pod-resources/etcd-certs"
 OCF_RESKEY_name_default="etcd"
 OCF_RESKEY_nic_default="br-ex"
 OCF_RESKEY_authfile_default="/var/lib/kubelet/config.json"
@@ -54,7 +53,6 @@ OCF_RESKEY_kubeconfig_default="/etc/kubernetes/static-pod-resources/kube-apiserv
 
 : ${OCF_RESKEY_image=${OCF_RESKEY_image_default}}
 : ${OCF_RESKEY_pod_manifest=${OCF_RESKEY_pod_manifest_default}}
-: ${OCF_RESKEY_etcd_certs_dir=${OCF_RESKEY_etcd_certs_dir_default}}
 : ${OCF_RESKEY_name=${OCF_RESKEY_name_default}}
 : ${OCF_RESKEY_nic=${OCF_RESKEY_nic_default}}
 : ${OCF_RESKEY_authfile=${OCF_RESKEY_authfile_default}}
@@ -92,15 +90,6 @@ The Pod manifest with the configuration for Etcd.
 </longdesc>
 <shortdesc lang="en">Etcd pod manifest</shortdesc>
 <content type="string" default="${OCF_RESKEY_pod_manifest_default}"/>
-</parameter>
-
-<parameter name="etcd_certs_dir" required="0" unique="0">
-<longdesc lang="en">
-The Etcd certificates directory mounted into the etcd container.
-The agent will monitor this directory for changes and restart the etcd container if the certificates have changed.
-</longdesc>
-<shortdesc lang="en">Etcd certificates directory</shortdesc>
-<content type="string" default="${OCF_RESKEY_etcd_certs_dir_default}"/>
 </parameter>
 
 <parameter name="image" required="0" unique="0">
@@ -326,60 +315,6 @@ Expects to have a fully populated OCF RA-compliant environment set.
 END
 }
 
-etcd_certificates_hash_manager()
-{
-	local action="$1"
-	local current_hash
-	local stored_hash
-
-	# If the certs directory doesn't exist, consider it unchanged
-	if [ ! -d "$OCF_RESKEY_etcd_certs_dir" ]; then
-		ocf_log warn "certificates directory $OCF_RESKEY_etcd_certs_dir does not exist, skipping certificate monitoring"
-		return $OCF_SUCCESS
-	fi
-
-	# Calculate hash of all certificate files, ignore key files to avoid accidental disclosure of sensitive information
-	# we only need to monitor the certificate files to detect changes.
-	if ! current_hash=$(find "$OCF_RESKEY_etcd_certs_dir" -type f \( -name "*.crt" \) -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1); then
-		ocf_log err "failed to calculate certificate files hash"
-		return $OCF_ERR_GENERIC
-	fi
-
-	# If no stored hash exists, create one and return success
-	if [ ! -f "$ETCD_CERTS_HASH_FILE" ]; then
-		echo "$current_hash" > "$ETCD_CERTS_HASH_FILE"
-		ocf_log info "created initial certificate hash: $current_hash"
-		return $OCF_SUCCESS
-	fi
-
-	case "$action" in
-		"update")
-			if ! echo "$current_hash" > "$ETCD_CERTS_HASH_FILE"; then
-				ocf_log err "failed to update certificate hash file $ETCD_CERTS_HASH_FILE"
-			fi
-			ocf_log info "updated certificate hash: $current_hash"
-			;;
-		"check")
-			if ! stored_hash=$(cat "$ETCD_CERTS_HASH_FILE"); then
-				ocf_log err "failed to read stored certificate hash from $ETCD_CERTS_HASH_FILE"
-				# This should not happen but if for some reason we can not read the stored hash,
-				# use the current hash and log the error but allow etcd to run as long as possible.
-				stored_hash="$current_hash"
-			fi
-			if [ "$current_hash" != "$stored_hash" ]; then
-				ocf_exit_reason "$NODENAME etcd certificate files have changed (stored: $stored_hash, current: $current_hash)"
-				return $OCF_ERR_GENERIC
-			fi
-			;;
-		*)
-			ocf_log err "unsupported action: $action"
-			return $OCF_ERR_GENERIC
-			;;
-	esac
-
-	return $OCF_SUCCESS
-}
-
 monitor_cmd_exec()
 {
 	local rc=$OCF_SUCCESS
@@ -456,7 +391,7 @@ archive_current_container()
 
 	# archive corresponding etcd configuration files
 	local files_to_archive=""
-	for file in "$OCF_RESKEY_authfile" "$POD_MANIFEST_COPY" "$ETCD_CONFIGURATION_FILE" "$ETCD_CERTS_HASH_FILE"; do
+	for file in "$OCF_RESKEY_authfile" "$POD_MANIFEST_COPY" "$ETCD_CONFIGURATION_FILE"; do
 		if [ -f "$file" ]; then
 			files_to_archive="$files_to_archive $file"
 		else
@@ -1826,11 +1761,6 @@ podman_monitor()
 			;;
 	esac
 
-	# Check if certificate files have changed, if they have, etcd needs to be restarted
-	if ! etcd_certificates_hash_manager "check"; then
-		return $OCF_ERR_GENERIC
-	fi
-
 	if is_learner; then
 		ocf_log info "$NODENAME is learner. Cannot get member id"
 		return "$OCF_SUCCESS"
@@ -2138,14 +2068,6 @@ podman_start()
 	done
 	if etcd_pod_container_exists; then
 		ocf_exit_reason "etcd pod is still running after $etcd_pod_wait_timeout_sec seconds."
-		return $OCF_ERR_GENERIC
-	fi
-
-	# Update the certificate hash after the container has started successfully
-	# this is to ensure that the certificate hash is updated after a restart is initiated
-	# by a cert rotation event from the monitor command.
-	if ! etcd_certificates_hash_manager "update"; then
-		ocf_exit_reason "etcd certificate hash manager failed to update the certificate hash"
 		return $OCF_ERR_GENERIC
 	fi
 
@@ -2628,13 +2550,6 @@ podman_validate()
 		exit $OCF_ERR_CONFIGURED
 	fi
 
-	if ! echo "validation test" > "$ETCD_CERTS_HASH_FILE" \
-		|| ! cat "$ETCD_CERTS_HASH_FILE" >/dev/null 2>&1 \
-		|| ! rm "$ETCD_CERTS_HASH_FILE"; then
-		ocf_exit_reason "cannot read/write to certificate hash file $ETCD_CERTS_HASH_FILE"
-		exit $OCF_ERR_GENERIC
-	fi
-
 	return $OCF_SUCCESS
 }
 
@@ -2687,7 +2602,6 @@ ETCD_MEMBER_DIR="/var/lib/etcd/member"
 ETCD_REVISION_JSON="/var/lib/etcd/revision.json"
 ETCD_REVISION_BUMP_PERCENTAGE=0.2
 ETCD_BUMP_REV_DEFAULT=1000000000
-ETCD_CERTS_HASH_FILE="${OCF_RESKEY_config_location}/certs.hash"
 # State file location: Uses HA_RSCTMP to ensure automatic cleanup on reboot.
 # This is intentional - reboots are controlled stops, not failures requiring detection.
 CONTAINER_HEARTBEAT_FILE=${HA_RSCTMP}/podman-container-last-running


### PR DESCRIPTION
## Summary

etcd 3.6+ hot-reloads TLS certificates on each new TLS handshake via Go's `GetCertificate` callback ([etcd PR #7829](https://github.com/etcd-io/etcd/pull/7829)). The cert hash monitor that runs every 10s monitor cycle is dead code — it cannot trigger a useful action.

This PR removes:
- `etcd_certificates_hash_manager()` function (~53 lines)
- `etcd_certs_dir` OCF parameter (default, assignment, XML metadata)
- `ETCD_CERTS_HASH_FILE` variable and on-disk state file
- All 4 call sites: monitor (check), start (update), validate (write test), archive (debug copy)

**86 lines deleted, 0 added.**

### Relationship to OCPBUGS-86897

This removal also eliminates the root cause of [OCPBUGS-86897](https://issues.redhat.com/browse/OCPBUGS-86897): the cert monitor detected hash changes → returned `OCF_ERR_GENERIC` → Pacemaker stopped etcd → `leave_etcd_member_list()` self-removed the node → rejoined as learner with new member ID. This fired 10× per CI cert rotation run.

PR #2170 addresses the same bug with a minimal 4-line fix (update hash instead of triggering restart). This PR takes the next step: removing the monitoring infrastructure entirely, since etcd hot-reloads certs and the monitor serves no purpose.

### What stays untouched

- TLS cert/key paths in etcd configuration
- Volume mount (`-v .../etcd-certs:/etc/kubernetes/static-pod-certs`)
- All other etcd lifecycle logic

etcd still receives certs via the volume mount and hot-reloads them per-handshake.

### CEO follow-up

`cluster-etcd-operator/bindata/etcd/cluster-restore-tnf.sh` lists `certs.hash` in `PODMAN_ETCD_CONFIGURATION_FILES`. The loop already skips missing files, so this is harmless — will clean up in a separate CEO PR.

## Test plan

- [x] `bash -n heartbeat/podman-etcd` — syntax check passes
- [x] Deploy patched RPM to TNF cluster, trigger cert rotation, confirm no monitor action
- [x] Run full `openshift-tests run openshift/two-node` DualReplica suite (20 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)