### PR TITLE
IPaddr2: fix loop variable

### DIFF
--- a/heartbeat/IPaddr2
+++ b/heartbeat/IPaddr2
@@ -1228,7 +1228,7 @@ ip_served() {
 	if [ -z "$IP_CIP" ]; then
 		for i in $cur_nic; do
 			# check address label
-			if [ -n "$IFLABEL" ] && [ -z "`$IP2UTIL -o -f $FAMILY addr show $nic label $IFLABEL`" ]; then
+			if [ -n "$IFLABEL" ] && [ -z "`$IP2UTIL -o -f $FAMILY addr show dev $i label $IFLABEL`" ]; then
 				echo partial3
 				return 0
 			fi


### PR DESCRIPTION
$nic variable is not defined anywhere in the file so the command
would list any interface with a matching label.
