### PR TITLE
oralsnr: enable support for multiple listeners per SID

### DIFF
--- a/heartbeat/oralsnr
+++ b/heartbeat/oralsnr
@@ -25,6 +25,7 @@
 #	OCF_RESKEY_home (optional; else read it from /etc/oratab)
 #	OCF_RESKEY_user (optional; user to run the listener)
 #	OCF_RESKEY_listener (optional; defaults to LISTENER)
+#	OCF_RESKEY_tns_svc_name (optional; defaults to Oracle SID)
 #
 # Initialization:
 
@@ -43,6 +44,9 @@ OCF_RESKEY_listener_default="LISTENER"
 : ${OCF_RESKEY_home=${OCF_RESKEY_home_default}}
 : ${OCF_RESKEY_user=${OCF_RESKEY_user_default}}
 : ${OCF_RESKEY_listener=${OCF_RESKEY_listener_default}}
+
+OCF_RESKEY_tns_svc_name_default="${OCF_RESKEY_sid}"
+: ${OCF_RESKEY_tns_svc_name=${OCF_RESKEY_tns_svc_name_default}}
 
 #######################################################################
 
@@ -81,10 +85,10 @@ Oracle Listener instance as an HA resource.
 
 <parameters>
 
-<parameter name="sid" unique="1" required="1">
+<parameter name="sid" unique="0" required="1">
 <longdesc lang="en">
-The Oracle SID (aka ORACLE_SID). Necessary for the monitor op,
-i.e. to do tnsping SID.
+The Oracle SID (aka ORACLE_SID). Used for the monitor op, when
+alias is undefined i.e. to do tnsping SID.
 </longdesc>
 <shortdesc lang="en">sid</shortdesc>
 <content type="string" default="${OCF_RESKEY_sid_default}" />
@@ -118,14 +122,25 @@ Defaults to LISTENER.
 
 <parameter name="tns_admin" required="0" unique="0">
 <longdesc lang="en">
-	Full path to the directory that contains the Oracle
-	listener tnsnames.ora configuration file.  The shell
-	variable TNS_ADMIN is set to the value provided.
+Full path to the directory that contains the Oracle
+listener tnsnames.ora configuration file.  The shell
+variable TNS_ADMIN is set to the value provided.
 </longdesc>
 <shortdesc lang="en">
-	Full path to the directory containing tnsnames.ora
+Full path to the directory containing tnsnames.ora
 </shortdesc>
 <content type="string"/>
+</parameter>
+
+<parameter name="tns_svc_name" unique="1" required="0">
+<longdesc lang="en">
+The TNS alias (aka net_service_name) to ping during the 
+monitor operation. Defaults to the Oracle SID.
+</longdesc>
+<shortdesc lang="en">
+TNS alias to ping
+</shortdesc>
+<content type="string" />
 </parameter>
 
 </parameters>
@@ -237,11 +252,11 @@ test_listener() {
 # and does it work?
 test_tnsping() {
 	local output
-	output=`tnsping $ORACLE_SID`
+	output=`tnsping ${OCF_RESKEY_tns_svc_name}`
 	if echo "$output" | tail -1 | grep -qs '^OK'; then
 		return $OCF_SUCCESS
 	else
-		ocf_exit_reason "tnsping $ORACLE_SID failed: $output"
+		ocf_exit_reason "tnsping ${OCF_RESKEY_tns_svc_name} failed: $output"
 		return $OCF_ERR_GENERIC
 	fi
 }


### PR DESCRIPTION
Previously, configuring multiple listeners for the same SID caused validation warnings and false positive monitor operations.

One can configure several listeners per instance, one for front-end applications, another for backup etc. To properly support this architecture, this commit introduces the following changes:

* Removed the `unique` constraint on the `sid` parameter, as the `listener` parameter is the true unique identifier for the OS-level process.

* Added a new resource option `tns_svc_name` to allow cluster administrators to specify a custom TNS alias (e.g. pointing to a specific port) for the monitor operation.

* Updated `test_tnsping()` to use the new `tns_svc_name` parameter instead of hardcoded `$ORACLE_SID`. This parameter dynamically defaults to the database SID, ensuring complete backward compatibility for existing single-listener setups.