### PR TITLE
nvmet-*: When the nvmet kernel module is not detected, attempt to load it to avoid manual execution.

### DIFF
--- a/heartbeat/nvmet-namespace
+++ b/heartbeat/nvmet-namespace
@@ -164,8 +164,15 @@ nvmet_namespace_monitor() {
 
 nvmet_namespace_validate() {
 	if [ ! -d /sys/kernel/config/nvmet ]; then
-		ocf_log err "/sys/kernel/config/nvmet does not exist -- Load the nvmet.ko linux kernel module."
-		exit $OCF_ERR_INSTALLED
+	    ocf_log info "nvmet kernel module not loaded, attempting to load it..."
+	    modprobe nvmet 2>/dev/null
+		
+		if [ ! -d /sys/kernel/config/nvmet ]; then
+		    ocf_log err "Failed to load nvmet.ko kernel module. Please check if the module exists and is compatible with your kernel."
+		    exit $OCF_ERR_INSTALLED
+		else
+		    ocf_log info "nvmet kernel module loaded successfully."
+		fi
 	fi
 	subsys=/sys/kernel/config/nvmet/subsystems/${OCF_RESKEY_nqn}
 	namespace=${subsys}/namespaces/${OCF_RESKEY_namespace_id}

--- a/heartbeat/nvmet-port
+++ b/heartbeat/nvmet-port
@@ -198,8 +198,15 @@ nvmet_port_validate() {
 	fi
 
 	if [ ! -d /sys/kernel/config/nvmet ]; then
-		ocf_log err "/sys/kernel/config/nvmet does not exist -- Load the nvmet.ko linux kernel module."
-		exit $OCF_ERR_INSTALLED
+	    ocf_log info "nvmet kernel module not loaded, attempting to load it..."
+	    modprobe nvmet 2>/dev/null
+		
+		if [ ! -d /sys/kernel/config/nvmet ]; then
+		    ocf_log err "Failed to load nvmet.ko kernel module. Please check if the module exists and is compatible with your kernel."
+		    exit $OCF_ERR_INSTALLED
+		else
+		    ocf_log info "nvmet kernel module loaded successfully."
+		fi
 	fi
 	portdir=/sys/kernel/config/nvmet/ports/${OCF_RESKEY_port_id}
 

--- a/heartbeat/nvmet-subsystem
+++ b/heartbeat/nvmet-subsystem
@@ -150,8 +150,15 @@ nvmet_subsystem_monitor() {
 
 nvmet_subsystem_validate() {
 	if [ ! -d /sys/kernel/config/nvmet ]; then
-		ocf_log err "/sys/kernel/config/nvmet does not exist -- Load the nvmet.ko linux kernel module."
-		exit $OCF_ERR_INSTALLED
+	    ocf_log info "nvmet kernel module not loaded, attempting to load it..."
+	    modprobe nvmet 2>/dev/null
+        
+		if [ ! -d /sys/kernel/config/nvmet ]; then
+		    ocf_log err "Failed to load nvmet.ko kernel module. Please check if the module exists and is compatible with your kernel."
+		    exit $OCF_ERR_INSTALLED
+		else
+		    ocf_log info "nvmet kernel module loaded successfully."
+		fi
 	fi
 	return $OCF_SUCCESS
 }


### PR DESCRIPTION
When the nvmet kernel module is not detected, attempt to load it to avoid manual execution.