### PR TITLE
podman-etcd: scope sync to etcd filesystem to avoid CephFS hang

### DIFF
--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -705,7 +705,7 @@ wipe_data_folder_for_learner()
 		ocf_log err "could not delete etcd member directory ($ETCD_MEMBER_DIR), error code: $?"
 		return $OCF_ERR_GENERIC
 	fi
-	sync
+	sync -f "$OCF_RESKEY_config_location"
 	return $OCF_SUCCESS
 }
 


### PR DESCRIPTION
## Problem

Bare `sync` in `wipe_data_folder_for_learner()` (heartbeat/podman-etcd, line 708) issues `sync(2)`, which flushes dirty buffers for **every** mounted filesystem. When ODF (OpenShift Data Foundation) is installed, CephFS kernel mounts block indefinitely if Ceph is unreachable — the typical case during an upgrade reboot when the node running Ceph OSDs is being drained. This causes Pacemaker's 10-minute start timeout to expire, etcd never starts, and the cluster loops.

## Fix

Replace `sync` with `sync -f "$OCF_RESKEY_config_location"`, which uses `syncfs(2)` scoped to the filesystem containing the etcd data directory (`/var/lib/etcd`). No other filesystem is touched.

## Testing

- Samsung customer hit this in production with ODF on TNF. The `sync -f` workaround was applied and confirmed across 3 consecutive reboots with no hangs.
- Validated on a 4.22.4 aarch64 TNF cluster with ODF installed.

## References

- [OCPBUGS-104449](https://redhat.atlassian.net/browse/OCPBUGS-104449)