### PR TITLE
OCPBUGS-112044: podman-etcd: treat crm_attribute 'not found' exits as empty, not error

### DIFF
--- a/heartbeat/podman-etcd
+++ b/heartbeat/podman-etcd
@@ -1252,7 +1252,7 @@ get_cib_permanent_attribute()
 	local output rc
 	output=$(crm_attribute --query --type nodes --node "$1" --name "$2" 2>/dev/null)
 	rc=$?
-	[ $rc -ne 0 ] && return $rc
+	[ $rc -ne 0 ] && [ $rc -ne 105 ] && [ $rc -ne 6 ] && return $rc
 	echo "$output" | awk -F"value=" '{print $2}'
 }
 
@@ -1262,7 +1262,7 @@ get_cib_transient_attribute()
 	local output rc
 	output=$(crm_attribute --query --lifetime reboot --node "$1" --name "$2" 2>/dev/null)
 	rc=$?
-	[ $rc -ne 0 ] && return $rc
+	[ $rc -ne 0 ] && [ $rc -ne 105 ] && [ $rc -ne 6 ] && return $rc
 	echo "$output" | awk -F"value=" '{print $2}' | tr -d "'"
 }
 


### PR DESCRIPTION
crm_attribute --query returns exit code 105 (CRM_EX_NOSUCH) on Pacemaker 2.1.x+ and exit code 6 (ENODATA) on older versions whenan attribute does not exist.

The previous code treated any non-zero exit as a hard failure, causing false errors in get_cib_permanent_attribute
and get_cib_transient_attribute when querying attributes that have not been set yet (e.g. force_new_cluster, restart_no_leave, revision).

All callers already handle empty output gracefully, so let these two exit codes fall through to produce an empty string instead of aborting.
