### PR TITLE
portblock: fix incorrect parameters for NftDelete() when using reset_local_on_unblock_stop

### DIFF
--- a/heartbeat/portblock
+++ b/heartbeat/portblock
@@ -630,7 +630,7 @@ PortBLOCK()
         fi
         rc_in=$?
         if $try_reset ; then
-          NftDelete "OUTPUT" "$1" "s" "$ports"
+          NftDelete "OUTPUT" "$1" "s" "$3" "$2"
         fi
       else
         if $try_reset ; then


### PR DESCRIPTION
Fixes https://github.com/ClusterLabs/resource-agents/issues/2202.