### PR TITLE
High: storage-mon: Delete a timer that has not stopped.

### DIFF
--- a/tools/storage_mon.c
+++ b/tools/storage_mon.c
@@ -314,6 +314,11 @@ static int32_t sigchld_handler(int32_t sig, void *data)
 							if (!daemon_check_first_all_devices) {
 								daemon_check_first_all_devices = TRUE;
 							}
+							/* To prevent the timer from triggering when the timeout is set to a value greater */ 
+							/* than the interval, the io_timeout timer is stopped once the check of all devices is complete. */
+							if (qb_loop_timer_is_running(storage_mon_poll_handle, expire_handle)) { 
+								qb_loop_timer_del(storage_mon_poll_handle, expire_handle);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Hi Oyvind,
Hi All,

An issue was identified when using storage-mon in daemon mode.

No problems occur when using the default values ​​for `check_interval` (default: 30) and `io_timeout` (default: 10), or when `io_timeout` is set to a value smaller than `check_interval`. 
However, if `io_timeout` is set to a value larger than `check_interval`, an unexpected  io_timeout occurs.
This happens because the timer configured for `io_timeout` is not stopped.

This fix stops the `io_timeout` timer once all monitoring tasks are complete, thereby preventing unexpected timeouts.

Best Regards,
Hideo Yamauchi.
